### PR TITLE
feat: calculate change table MW-miles with tests and mocks

### DIFF
--- a/powersimdata/scenario/analyze.py
+++ b/powersimdata/scenario/analyze.py
@@ -1,9 +1,79 @@
+from math import radians, cos, sin, asin, sqrt
+
+import pandas as pd
+
 from powersimdata.input.scaler import Scaler
 from powersimdata.output.profiles import OutputData
 from powersimdata.scenario.state import State
 
-import pandas as pd
+def _haversine(point1, point2):
+    """Given two lat/long pairs, return distance in miles.
+    
+    :param tuple (number, number) point1: first point, (lat, long) in degrees.
+    :param tuple (number, number) point2: second point, (lat, long) in degrees.
+    
+    :return: distance in miles, float
+    
+    """
+    
+    _AVG_EARTH_RADIUS_MILES = 3958.7613
+    
+    # unpack latitude/longitude
+    lat1, lng1 = point1
+    lat2, lng2 = point2
+    
+    # convert all latitudes/longitudes from decimal degrees to radians
+    lat1, lng1, lat2, lng2 = map(radians, (lat1, lng1, lat2, lng2))
+    
+    # calculate haversine
+    lat = lat2 - lat1
+    lng = lng2 - lng1
+    d = 2 * _AVG_EARTH_RADIUS_MILES * asin(sqrt(
+        sin(lat * 0.5) ** 2 + cos(lat1) * cos(lat2) * sin(lng * 0.5) ** 2))
+    
+    return d
 
+def _calculate_mw_miles(original_grid, ct):
+    """Given a change table, calculate the number of upgraded lines and 
+    transformers, and the total upgrade quantity (in MW and MW-miles).
+    Currently only supports change_tables that specify branches, not zone_name.
+    Currently lumps Transformer and TransformerWinding upgrades together.
+    
+    :param powersimdata.input.grid original_grid: grid instance.
+    :param powersimdata.input.change_table ct: change_table instance.
+    
+    :return: a dict of keys (types of upgrades) and values (floats/ints).
+    """
+    
+    upgrade_categories = (
+        'mw_miles', 'transformer_mw','num_lines', 'num_transformers')
+    upgrades = {u: 0 for u in upgrade_categories}
+    
+    base_branch = original_grid.branch
+    upgraded_branches = ct['branch']['branch_id']
+    for b, v in upgraded_branches.items():
+        # 'upgraded' capacity is v-1 because a scale of 1 = an upgrade of 0
+        upgraded_capacity = base_branch.loc[b,'rateA'] * (v-1)
+        device_type = base_branch.loc[b,'branch_device_type']
+        if device_type == 'Line':
+            from_coords = (
+                base_branch.loc[b,'from_lat'], base_branch.loc[b,'from_lon'])
+            to_coords = (
+                base_branch.loc[b,'to_lat'], base_branch.loc[b,'to_lon'])
+            addtl_mw_miles = (
+                upgraded_capacity * _haversine(from_coords, to_coords))
+            upgrades['mw_miles'] += addtl_mw_miles
+            upgrades['num_lines'] += 1
+        elif device_type == 'Transformer':
+            upgrades['transformer_mw'] += upgraded_capacity
+            upgrades['num_transformers'] += 1
+        elif device_type == 'TransformerWinding':
+            upgrades['transformer_mw'] += upgraded_capacity
+            upgrades['num_transformers'] += 1
+        else:
+            raise Exception('Unknown branch: ' + str(b))
+    
+    return upgrades
 
 class Analyze(State):
     """Scenario is in a state of being analyzed.
@@ -72,6 +142,11 @@ class Analyze(State):
                        dates[key]+pd.Timedelta(self._scenario_info['interval']),
                        value))
 
+    def calculate_mw_miles(self):
+        mw_miles = _calculate_mw_miles(
+            original_grid=self.scaler._original_grid,
+            ct=self.ct)
+    
     def get_pg(self):
         """Returns PG data frame.
 

--- a/tests/context.py
+++ b/tests/context.py
@@ -1,0 +1,8 @@
+import os
+import sys
+
+# This ensures that we can always test, no matter the installation method.
+sys.path.insert(
+    0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import powersimdata

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -1,0 +1,94 @@
+import pandas as pd
+
+# The index name of each dataframe attribute
+indices = {
+    'branch': 'branch_id',
+    'bus': 'bus_id',
+    'dcline': 'dcline_id',
+    'gencost': 'plant_id',
+    'plant': 'plant_id',
+    }
+
+# The column names of each dataframe attribute
+branch_columns = [
+    'from_bus_id', 'to_bus_id', 'r', 'x', 'b', 'rateA', 'rateB', 'rateC',
+    'ratio', 'angle', 'status', 'angmin', 'angmax', 'Pf', 'Qf', 'Pt', 'Qt',
+    'mu_Sf', 'mu_St', 'mu_angmin', 'mu_angmax', 'branch_device_type',
+    'interconnect', 'from_lat', 'from_lon', 'to_lat', 'to_lon',
+    'from_zone_id', 'to_zone_id', 'from_zone_name', 'to_zone_name']
+
+bus_columns = [
+    'type', 'Pd', 'Qd', 'Gs', 'Bs', 'zone_id', 'Vm', 'Va', 'baseKV', 'Vmax',
+    'Vmin', 'lam_P', 'lam_Q', 'mu_Vmax', 'mu_Vmin', 'interconnect', 'lat',
+    'lon']
+
+dcline_columns = [
+    'from_bus_id', 'to_bus_id', 'status', 'Pf', 'Pt', 'Qf', 'Qt', 'Vf', 'Vt',
+    'Pmin', 'Pmax', 'QminF', 'QmaxF', 'QminT', 'QmaxT', 'loss0', 'loss1',
+    'muPmin', 'muPmax', 'muQminF', 'muQmaxF', 'muQminT', 'muQmaxT',
+    'from_interconnect', 'to_interconnect']
+
+gencost_columns = [
+    'type', 'startup', 'shutdown', 'n', 'c2', 'c1', 'c0', 'interconnect']
+
+plant_columns = [
+    'bus_id', 'Pg', 'Qg', 'Qmax', 'Qmin', 'Vg', 'mBase', 'status', 'Pmax', 
+    'Pmin', 'Pc1', 'Pc2', 'Qc1min', 'Qc1max', 'Qc2min', 'Qc2max', 'ramp_agc',
+    'ramp_10', 'ramp_30', 'ramp_q', 'apf', 'mu_Pmax', 'mu_Pmin', 'mu_Qmax',
+    'mu_Qmin', 'GenMWMax', 'GenMWMin', 'GenFuelCost', 'GenIOB', 'GenIOC',
+    'GenIOD', 'type', 'interconnect', 'lat', 'lon', 'zone_id', 'zone_name']
+
+class MockGrid:
+    def __init__(self, grid_attrs):
+        """ Constructor.
+
+        :param list grid_attrs: dict of {fieldname, data_dict} pairs.
+        """
+
+        if not isinstance(grid_attrs, dict):
+            raise TypeError('grid_attrs must be a dict')
+
+        for key in grid_attrs.keys():
+            if not isinstance(key, str):
+                raise TypeError('grid_attrs keys must all be str')
+
+        extra_keys = set(grid_attrs.keys()) - set(indices.keys())
+        if len(extra_keys) > 0:
+            raise ValueError('Got unknown key(s):' + str(extra_keys))
+
+        cols = {
+            'branch': branch_columns,
+            'bus': bus_columns,
+            'dcline': dcline_columns,
+            'gencost': gencost_columns,
+            'plant': plant_columns,
+            }
+
+        # Loop through names for grid dataframes, add (maybe empty) dataframes.
+        for df_name in indices:
+            if df_name in grid_attrs:
+                df = pd.DataFrame(grid_attrs[df_name])
+            else:
+                df = pd.DataFrame(columns=([indices[df_name]]+cols[df_name]))
+            df.set_index(indices[df_name], inplace=True)
+            setattr(self, df_name, df)
+
+class MockScenario:
+    def __init__(self, grid_attrs, pg):
+        """ Constructor.
+
+        :param list grid_attrs: fields to be added to grid.
+        :param pandas.DataFrame pg: dummy pg
+        """
+        self.grid_attrs = grid_attrs
+        self.pg = pg
+
+    def get_grid(self):
+        """Get grid
+
+        :return: (GridMock) -- mock grid
+        """
+        return MockGrid(self.grid_attrs)
+
+    def get_pg(self):
+        return self.pg

--- a/tests/test_calculate_mw_miles.py
+++ b/tests/test_calculate_mw_miles.py
@@ -1,0 +1,93 @@
+import unittest
+
+# context.py ensures that we always import from current powersimdata folder.
+from context import powersimdata
+from mocks import MockGrid
+from powersimdata.scenario.analyze import _calculate_mw_miles
+
+# branch 11 from Seattle to San Francisco (~679 miles)
+# branch 12 from Seattle to Spokane (~229 miles)
+# branch 13-15 are transformers (0 miles)
+mock_branch = {
+    'branch_id': [11, 12, 13, 14, 15],
+    'rateA': [10, 20, 30, 40, 50],
+    'from_lat': [47.61, 47.61, 47.61, 47.61, 47.61,],
+    'from_lon': [-122.33, -122.33, -122.33, -122.33, -122.33,],
+    'to_lat': [37.78, 47.66, 47.61, 47.61, 47.61],
+    'to_lon': [-122.42, -117.43, -122.33, -122.33, -122.33],
+    'branch_device_type': 2 * ['Line'] + 3 * ['Transformer'],
+    }
+
+expected_keys = set((
+    'mw_miles', 'transformer_mw', 'num_lines', 'num_transformers'))
+
+class TestCalculateMWMiles(unittest.TestCase):
+    def setUp(self):
+        self.grid = MockGrid(grid_attrs={'branch': mock_branch})
+    
+    def _check_return_structure(self, mw_miles):
+        """Check for a dict with proper keys and floats for values.
+        
+        :param dict mw_miles: dict of upgrade metrics.
+        
+        """
+        self.assertIsInstance(mw_miles, dict, 'dict not returned')
+        self.assertEqual(expected_keys, mw_miles.keys(),
+            msg='Dict keys not as expected')
+        for v in mw_miles.values():
+            self.assertIsInstance(v, (float, int))
+    
+    def test_calculate_mw_miles_no_scale(self):
+        mock_ct = {'branch': {'branch_id': {}}}
+        expected_mw_miles = {k: 0 for k in expected_keys}
+        mw_miles = _calculate_mw_miles(self.grid, mock_ct)
+        self._check_return_structure(mw_miles)
+        for k in expected_mw_miles.keys():
+            self.assertAlmostEqual(mw_miles[k], expected_mw_miles[k],
+                msg=('Did not get expected value for ' + str(k)))
+    
+    def test_calculate_mw_miles_one_line_scaled(self):
+        mock_ct = {'branch': {'branch_id': {11: 2}}}
+        expected_mw_miles = {
+            'mw_miles': 6792.03551523,
+            'transformer_mw': 0,
+            'num_lines': 1,
+            'num_transformers': 0,
+            }
+        mw_miles = _calculate_mw_miles(self.grid, mock_ct)
+        self._check_return_structure(mw_miles)
+        for k in expected_mw_miles.keys():
+            self.assertAlmostEqual(mw_miles[k], expected_mw_miles[k],
+                msg=('Did not get expected value for ' + str(k)))
+    
+    def test_calculate_mw_miles_one_transformer_scaled(self):
+        mock_ct = {'branch': {'branch_id': {13: 2.5}}}
+        expected_mw_miles = {
+            'mw_miles': 0,
+            'transformer_mw': 45,
+            'num_lines': 0,
+            'num_transformers': 1,
+            }
+        mw_miles = _calculate_mw_miles(self.grid, mock_ct)
+        self._check_return_structure(mw_miles)
+        for k in expected_mw_miles.keys():
+            self.assertAlmostEqual(mw_miles[k], expected_mw_miles[k],
+                msg=('Did not get expected value for ' + str(k)))
+    
+    def test_calculate_mw_miles_many_scaled(self):
+        mock_ct = {'branch': {'branch_id': {
+            11: 2, 12: 3, 13: 1.5, 14: 1.2, 15: 3}}}
+        expected_mw_miles = {
+            'mw_miles': 15917.06341095,
+            'transformer_mw': 123,
+            'num_lines': 2,
+            'num_transformers': 3,
+            }
+        mw_miles = _calculate_mw_miles(self.grid, mock_ct)
+        self._check_return_structure(mw_miles)
+        for k in expected_mw_miles.keys():
+            self.assertAlmostEqual(mw_miles[k], expected_mw_miles[k],
+                msg=('Did not get expected value for ' + str(k)))
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This branch adds a method to the Analyze object to calculate the aggregate MW-miles of upgrades from a given change_table. A new folder `tests/` is created with a new file `mocks.py` for common testing (copied from PostREISE) and a test script `test_calculate_mw_miles.py` to test returns from the new function for data structure and proper values.