### PR TITLE
doc: adding datapackage.json for tabular data package

### DIFF
--- a/powersimdata/input/data/usa_tamu/datapackage.json
+++ b/powersimdata/input/data/usa_tamu/datapackage.json
@@ -208,7 +208,7 @@
                     },
                     {
                         "name": "Pd",
-                        "description": "real power demand (MW)",
+                        "description": "real power demand (MW). Zone power demand is disaggregated to buses proportional to Pd.",
                         "type": "float"
                     },
                     {


### PR DESCRIPTION
This PR adds a file `datapackage.json` which describes the schema of our data, to be added to the Zenodo dataset. Describing our input grid data is fairly straightforward (though tedious), describing our profiles is a little less so. I didn't want to write a description of each column in e.g. `hydro.csv` (all 3000 of them) so I wrote a general description of the table instead. I'm not sure how kosher this is, but I didn't see a cleaner way to do so.