### PR TITLE
fix: update area filter in area_to_loadzone function

### DIFF
--- a/powersimdata/scenario/scenario_info.py
+++ b/powersimdata/scenario/scenario_info.py
@@ -50,7 +50,7 @@ class ScenarioInfo:
             area in the order of 'state', 'loadzone', 'state abbreviation',
             'interconnect' and 'all'.
         """
-        if area_type is not None or not isinstance(area_type, str):
+        if area_type is not None and not isinstance(area_type, str):
             raise TypeError("'area_type' should be either None or str.")
         if area_type:
             if area_type == 'loadzone':


### PR DESCRIPTION
There a problem of the function `area_to_loadzone` in `scenario_info.py`: 
Once the loadzone name is the same as state name, previously, the function will consider the `area` as a loadzone by default. This causes the problem when `area` = 'North Carolina' but the query is about NC state instead of loadzone, which should return {'North Carolina', 'Western North Carolina'} instead of {'North Carolina'}.

This fix adds another parameter `area_type` to allow the user to specify which type of `area`. `area_type` should be one of 'loadzone', 'state', 'state_abbr', 'interconnect'. If `area_type` is not specified, the function will match `area` in the order of 'state', 'loadzone', 'state_abbr', 'interconnect', 'all'. If the combination of `area` and `area_type` is invalid, a `ValueError` is raised.