### PR TITLE
fix: Delete correct scenario in ExecuteList file

### DIFF
--- a/powersimdata/scenario/delete.py
+++ b/powersimdata/scenario/delete.py
@@ -42,8 +42,8 @@ class Delete(State):
 
         # Delete entry in execute list
         print("--> Deleting entry in execute table on server")
-        command = "sed -i.bak '/^%s,*/d' %s" % (self._scenario_info['id'],
-                                                const.EXECUTE_LIST)
+        entry = "^%s,extracted" % self._scenario_info['id']
+        command = "sed -i.bak '/%s/d' %s" % (entry, const.EXECUTE_LIST)
         stdin, stdout, stderr = self._ssh.exec_command(command)
         if len(stderr.readlines()) != 0:
             raise IOError("Failed to delete entry in %s on server" %


### PR DESCRIPTION
## Purpose
Fix a bug when deleting a scenario

## What is the code doing
It fixes the `sed` command used to to delete an entry in the *ExecuteList.csv* file.

## Where to look
It is a one line change.

## Time estimate
Very quick.