### PR TITLE
Get averaged congestion via the Scenario object

### DIFF
--- a/powersimdata/output/profiles.py
+++ b/powersimdata/output/profiles.py
@@ -24,7 +24,7 @@ class OutputData(object):
 
         :param str scenario_id: scenario id.
         :param str field_name: *'PG'*, *'PF'*, *'LMP'*, *'CONGU'*, *'CONGL'*,
-            *STORAGE_PG* or *STORAGE_E*.
+            *'AVERAGED_CONG'*, *'STORAGE_PG'* or *'STORAGE_E'*.
         :return: (*pandas.DataFrame*) -- specified field as a data frame.
         :raises FileNotFoundError: if file not found on local machine.
         :raises ValueError: if second argument is not an allowable field.
@@ -64,11 +64,12 @@ def _check_field(field_name):
     """Checks field name.
 
     :param str field_name: *'PG'*, *'PF'*, *'PF_DCLINE'*, *'LMP'*, *'CONGU'*,
-        or *'CONGL'*, *'STORAGE_PG'* or *'STORAGE_E'*.
+        or *'CONGL'*, '*'AVERAGED_CONG'*', *'STORAGE_PG'* or *'STORAGE_E'*.
     :raises ValueError: if not *'PG'*, *'PF'*, *'PF_DCLINE'*, *'LMP'*,
-        *'CONGU'*, or *'CONGL'*, *'STORAGE_PG'* or *'STORAGE_E'*.
+        *'CONGU'*, or *'CONGL'*, *'AVERAGED_CONG'*, *'STORAGE_PG'* or
+        *'STORAGE_E'*.
     """
-    possible = ['PG', 'PF', 'PF_DCLINE', 'LMP', 'CONGU', 'CONGL', 'STORAGE_PG',
-                'STORAGE_E']
+    possible = ['PG', 'PF', 'PF_DCLINE', 'LMP', 'CONGU', 'CONGL',
+                'AVERAGED_CONG', 'STORAGE_PG', 'STORAGE_E']
     if field_name not in possible:
         raise ValueError('Only %s data can be loaded' % " | ".join(possible))

--- a/powersimdata/scenario/analyze.py
+++ b/powersimdata/scenario/analyze.py
@@ -133,6 +133,17 @@ class Analyze(State):
 
         return congl
 
+    def get_averaged_cong(self):
+        """Returns averaged CONGL and CONGU.
+
+        :return: (*pandas.DataFrame*) -- data frame of averaged congestion with
+            the branch id as indices an the averaged CONGL and CONGU as columns.
+        """
+        od = OutputData(self._ssh)
+        mean_cong = od.get_data(self._scenario_info['id'], 'AVERAGED_CONG')
+
+        return mean_cong
+
     def get_storage_pg(self):
         """Returns STORAGE_PG data frame.
 


### PR DESCRIPTION
## Purpose
Download/load the averaged congestion data frame.

## What is the code doing
Download the averaged congestion pickle file from the server if not already on the local machine and return a data frame with the branch id as indices and the averaged CONGL and CONGU as columns.

## Where to look
Two objects have been modified:
* the `get_averaged_cong` method in the `Analyze` object has been implemented.
* the list of possible output files that can be downloaded/loaded has been updated in the `OutputData` object.

## Time estimate
Should be very quick