### PR TITLE
fix: avoid error when scaling from scenario with slightly negative generation

### DIFF
--- a/powersimdata/scaling/clean_capacity_scaling/auto_capacity_scaling.py
+++ b/powersimdata/scaling/clean_capacity_scaling/auto_capacity_scaling.py
@@ -761,13 +761,16 @@ class Resource:
         self.prev_cap_factor = prev_cap_factor
 
     # todo: calculate directly from scenario results
-    def set_generation(self, prev_generation):
+    def set_generation(self, prev_generation, tolerance=1e-3):
         """
         Set generation from scenario run
         :param prev_generation: generation from scenario run
+        :param {float, int} tolerance: tolerance for ignored negative values
         """
+        if ((-1 * tolerance) <= prev_generation < 0):
+            prev_generation = 0
         assert (prev_generation >= 0), \
-            "prev_generation must be greater than zero"
+            f"prev_generation must be greater than zero. Got {prev_generation}"
         self.prev_generation = prev_generation
 
     def set_curtailment(self, prev_curtailment):


### PR DESCRIPTION
### Purpose

Avoid an `AssertionError` when calling `AbstractStrategyManager.populate_targets_with_resources()` using a `ScenarioInfo` object based on a `Scenario` where `prev_generation` for a state/gentype evaluates to a slightly negative number. This can be seen when trying this on Scenario 409.

### What is the code doing

Adding a small tolerance range to the negativity check in `set_generation()`, where if the value being passed is negative but within this tolerance, it is set to 0. Also adding more description to the error message on the assert.

### Time to review

Extremely short, it's 5 lines of changes. It can be tested using Scenario 409: it should fail using develop but pass using this branch.