### PR TITLE
refactor: reduce memory requirements for mesh branch scaling

### DIFF
--- a/powersimdata/input/design_transmission.py
+++ b/powersimdata/input/design_transmission.py
@@ -183,15 +183,9 @@ def _identify_mesh_branch_upgrades(ref_scenario, upgrade_n=100, quantile=0.95,
     # If we rank by MW-miles, what 'length' do we give to zero-length branches?
     zero_length_value = 1       # miles
     
-    # Get raw congestion dual values
-    ref_congu = ref_scenario.state.get_congu()
-    ref_congl = ref_scenario.state.get_congl()
-    ref_cong_abs = pd.DataFrame(
-        np.maximum(ref_congu.to_numpy(), ref_congl.to_numpy()),
-        index=ref_congu.index,
-        columns=ref_congu.columns)
-    # Free up some memory, since we don't need two directional arrays anymore
-    del ref_congu, ref_congl
+    # Get raw congestion dual values, add them
+    rss = ref_scenario.state
+    ref_cong_abs = rss.get_congu() + rss.get_congl()
     
     # Parse 2-D array to vector of quantile values, filter out non-significant
     quantile_cong_abs = ref_cong_abs.quantile(quantile)


### PR DESCRIPTION
### Purpose

Reduce memory requirements for using the `design_transmission` module, and as a side-benefit simplify the code.

### What is the code doing

Previously, we needed enough memory to store a congestion dataframe five times: we loaded CONGU, we loaded CONGL, we created numpy array versions of both, and we created a new dataframe of the same size to hold the element-wise maximization of these two dataframes. We did a 'clean-up' of CONGU and CONGL afterwards, but that doesn't help us if we don't have enough peak memory.

Instead, we can make use of the fact that element-wise, only one of CONGU and CONGL will be non-zero: we can simply add them instead of performing a type conversion, performing a numpy element-wise maximization, and then storing that result into a new dataframe. I think this new format only requires enough memory to store a congestion dataframe two or three times, depending on the internals of pandas DataFrame addition.

Perhaps most importantly, this function makes use of sparse dataframes as introduced in https://github.com/intvenlab/PostREISE/pull/96: we no longer expand the sparse dataframes into non-sparse numpy arrays. Even when starting with sparse dataframes, trying to run the previous code created a MemoryError on our laptops, while the new code runs without a problem.

### Time Estimate

Half an hour or less.

