### PR TITLE
refactor: remove seaborn as a dependency

### DIFF
--- a/powersimdata/input/grid.py
+++ b/powersimdata/input/grid.py
@@ -1,5 +1,4 @@
 import os
-import seaborn as sns
 import warnings
 
 from powersimdata.input.usa_tamu_model import TAMU
@@ -114,17 +113,17 @@ def get_type2color():
     :return: (*dict*) -- generator type to color mapping.
     """
     type2color = {
-        'wind': sns.xkcd_rgb["green"],
-        'solar': sns.xkcd_rgb["amber"],
-        'hydro': sns.xkcd_rgb["light blue"],
-        'ng': sns.xkcd_rgb["orchid"],
-        'nuclear': sns.xkcd_rgb["silver"],
-        'coal': sns.xkcd_rgb["light brown"],
-        'geothermal': sns.xkcd_rgb["hot pink"],
-        'dfo': sns.xkcd_rgb["royal blue"],
-        'biomass': sns.xkcd_rgb["dark green"],
-        'other': sns.xkcd_rgb["melon"],
-        'storage': sns.xkcd_rgb["orange"]}
+        'wind': "xkcd:green",
+        'solar': "xkcd:amber",
+        'hydro': "xkcd:light blue",
+        'ng': "xkcd:orchid",
+        'nuclear': "xkcd:silver",
+        'coal': "xkcd:light brown",
+        'geothermal': "xkcd:hot pink",
+        'dfo': "xkcd:royal blue",
+        'biomass': "xkcd:dark green",
+        'other': "xkcd:melon",
+        'storage': "xkcd:orange"}
     return type2color
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,4 @@ pandas==0.25.3
 paramiko==2.4.2
 pytest==4.5.0
 scipy==1.2.0
-seaborn==0.9.0
 tqdm==4.29.1


### PR DESCRIPTION
### Purpose

Avoid requiring us to load plotting libraries (seaborn and matplotlib) when all we really need is a string that specifies a color for matplotlib in PostREISE.
Closes #87.

### What is the code doing

Specifying our xkcd colors in an equivalent way, without needing to import seaborn to do it.

Removing seaborn from our requirements list.

### Time to review

Extremely quick, it's less than 15 lines of changes and most of them are doing the same thing.