### PR TITLE
Grid Scaling: hierarchical grid field class

### DIFF
--- a/powersimdata/input/tests/test_grid_field.py
+++ b/powersimdata/input/tests/test_grid_field.py
@@ -5,49 +5,95 @@ import unittest
 from pandas.testing import assert_frame_equal
 
 
-def test_change_table_parsing():
+def test_change_table_parsing_2levels():
     input_ct = {'wind': {301: 3}, 'coal': {302: 5, 304: 6, 305: 10}}
-    change_table_hierarchy = ['type', 'zoneid']
-    result = HierarchicalGridField.ct_hierarchy_iterator(input_ct, change_table_hierarchy)
+    change_table_hierarchy = ['type', 'zone_id']
+    result = HierarchicalGridField.ct_hierarchy_generator(
+            input_ct, change_table_hierarchy)
 
     # Answer should be:
-    # [{'ct_hierarchy': ['type', 'zoneid'], 'index': ('wind', 301), 'scaling_value': 3},
-    #  {'ct_hierarchy': ['type', 'zoneid'], 'index': ('coal', 302), 'scaling_value': 5},
-    #  {'ct_hierarchy': ['type', 'zoneid'], 'index': ('coal', 304), 'scaling_value': 6},
-    #  {'ct_hierarchy': ['type', 'zoneid'], 'index': ('coal', 305), 'scaling_value': 10}]
+    # [{'ct_hierarchy':
+    #       ['type', 'zoneid'], 'index': ('wind', 301), 'scaling_value': 3},
+    #  {'ct_hierarchy':
+    #       ['type', 'zoneid'], 'index': ('coal', 302), 'scaling_value': 5},
+    #  {'ct_hierarchy':
+    #       ['type', 'zoneid'], 'index': ('coal', 304), 'scaling_value': 6},
+    #  {'ct_hierarchy':
+    #       ['type', 'zoneid'], 'index': ('coal', 305), 'scaling_value': 10}]
 
     for change in result:
-        change['ct_hierarchy'] == change_table_hierarchy
-        len(change['ct_hierarchy']) == len(change['index']) == 2
-        assert input_ct[change['index'][0]][change['index'][1]] == change['scaling_value']
+        assert(change['ct_hierarchy'] == change_table_hierarchy)
+        assert (len(change['ct_hierarchy']) == len(change['index']) == 2)
+        index = change['index']
+        assert input_ct[index[0]][index[1]] == change['scaling_value']
+
+
+def test_change_table_parsing_3levels():
+    input_ct = {'wind': {301: {1002: 3}}, 'coal': {302: {1001: 5, 1003: 2}}}
+
+    change_table_hierarchy = ['type', 'zone_id', 'bus_id']
+    result = HierarchicalGridField.ct_hierarchy_generator(
+            input_ct, change_table_hierarchy)
+
+    # Answer should be:
+    # [{'ct_hierarchy':
+    #       ['type', 'zoneid','bus_id'], 'index': ('wind', 301, 1002),
+    #       'scaling_value': 3},
+    #  {'ct_hierarchy':
+    #       ['type', 'zoneid', 'bus_id'], 'index': ('coal', 302, 1001),
+    #       'scaling_value': 5},
+    #  {'ct_hierarchy':
+    #       ['type', 'zoneid', 'bus_id'], 'index': ('coal', 304, 1003),
+    #       'scaling_value': 2},
+
+    for change in result:
+        assert(change['ct_hierarchy'] == change_table_hierarchy)
+        assert(len(change['ct_hierarchy']) == len(change['index']) == 3)
+        index = change['index']
+        assert input_ct[index[0]][index[1]][index[2]] == \
+            change['scaling_value']
 
 
 def test_change_table_error():
     input_ct = {'wind': {301: 3}, 'coal': {302: [5], 304: 6, 305: 10}}
-    change_table_hierarchy = ['type', 'zoneid']
-    with pytest.raises(KeyError):
-        list(HierarchicalGridField.ct_hierarchy_iterator(input_ct, change_table_hierarchy))
+    change_table_hierarchy = ['type', 'zone_id']
+    with pytest.raises(TypeError):
+        list(HierarchicalGridField.ct_hierarchy_generator(
+                input_ct, change_table_hierarchy))
 
 
 def test_change_table_depth_mixed_type():
     input_ct = {'wind': {3}, 'coal': {302: [5], 304: 6, 305: 10}}
-    change_table_hierarchy = ['type', 'zoneid']
-    with pytest.raises(KeyError):
-        list(HierarchicalGridField.ct_hierarchy_iterator(input_ct, change_table_hierarchy))
+    change_table_hierarchy = ['type', 'zone_id']
+    with pytest.raises(TypeError):
+        list(HierarchicalGridField.ct_hierarchy_generator(
+                input_ct, change_table_hierarchy))
 
 
 def test_change_table_depth_too_shallow():
     input_ct = {'wind': 3, 'coal': {302: 5, 304: 6, 305: 10}}
-    change_table_hierarchy = ['type', 'zoneid']
-    with pytest.raises(AssertionError):
-        list(HierarchicalGridField.ct_hierarchy_iterator(input_ct, change_table_hierarchy))
+    change_table_hierarchy = ['type', 'zone_id']
+    with pytest.raises(ValueError):
+        list(HierarchicalGridField.ct_hierarchy_generator(
+                input_ct, change_table_hierarchy))
 
 
 def test_change_table_depth_too_deep():
     input_ct = {'wind': {301: {301: 3}}, 'coal': {302: 5, 304: 6, 305: 10}}
+    change_table_hierarchy = ['type', 'zone_id']
+    with pytest.raises(ValueError):
+        list(HierarchicalGridField.ct_hierarchy_generator(
+                input_ct, change_table_hierarchy))
+
+
+def test_ct_hierarchy_validation():
+    plant = _create_grid_plant_dataframe()
+    input_ct = {'wind': {301: {301: 3}}, 'coal': {302: 5, 304: 6, 305: 10}}
     change_table_hierarchy = ['type', 'zoneid']
+    plant_field = HierarchicalGridField(plant, 'plant', {})
     with pytest.raises(AssertionError):
-        list(HierarchicalGridField.ct_hierarchy_iterator(input_ct, change_table_hierarchy))
+        list(plant_field.ct_hierarchy_iterator(input_ct,
+                                               change_table_hierarchy))
 
 
 # For these tests, the grouping are as follows:
@@ -60,19 +106,6 @@ def test_change_table_depth_too_deep():
 #        Pacific      105
 # wind   Atlantic     102
 # Name: plant_id, dtype: int64
-
-
-def test_single_group_index():
-    plant = _create_grid_plant_dataframe()
-    plant_field = HierarchicalGridField(plant, 'plant', {})
-
-    type_zone_index = plant_field.get_hierarchical_grouping(['type', 'zone_name'])
-    idx = type_zone_index.get_idx(('solar', 'Pacific'))
-
-    tc = unittest.TestCase('__init__')
-    tc.assertEqual(idx, [101, 104, 105])
-
-    assert_frame_equal(plant.loc[idx], plant.loc[[101, 104, 105]])
 
 
 def test_single_hierarchical_index():
@@ -104,7 +137,7 @@ def test_multiple_hierarchical_index():
 def _create_grid_plant_dataframe():
     mock_plant = {
         'plant_id': [101, 102, 103, 104, 105, 106],
-        'bus_id': [1001, 1002, 1003, 1004, 1005, 1006],
+        'bus_id': [1001, 1002, 1003, 1004, 1005, 1001],
         'type': ['solar', 'wind', 'hydro', 'solar', 'solar', 'hydro'],
         'zone_name': ['Pacific', 'Atlantic', 'Atlantic', 'Pacific',
                       'Pacific', 'Pacific'],


### PR DESCRIPTION
## Purpose

This PR implements hierarchical indexing using pandas in two different formulations using Pandas `groupby` and `set_index`. This allows us to scale appropriate rows within a particular GridField dataframe. A grouped/hierarchical index is extracted and the GridField dataframe isn't modified during the indexing process.

## What is the code doing?

The goal of the `HierarchicalGridField` class is to:
1. enable parsing of a hierarchical change table format
2. export an independent hierarchical or grouping index

This allows us to more loosely couple the scaling of `plant` and `gencost` fields. It also gives us the flexibility to merge/join dataframes (such as `bus` and `plant`) and extract a hierarchical index using their combined columns.

I've implemented the indexing using both `groupby` and `set_index`. One advantage of `groupby` is shortening of code to generate the index. However, this formulation is limited by the command `get_group` which only extracts one group at time:
https://github.com/pandas-dev/pandas/issues/28298
giving up the ability to use lists within the tuple indices (as you can natively with `df.loc[["categoryA", "categoryB"]])`. The following command to get solar and wind row indices for both Atlantic and Pacific within a single line breaks using the `groupby` formulation:
`type_zone_index.get_idx((['solar', 'wind'], ['Atlantic', 'Pacific']))`
We would also need to deal with `KeyError` exceptions, and concatenate the individual group indices. This issues are dealt with automatically using `.loc`. 

With the `set_index` formulation, I can scale more succinctly  as follows:
```
thermal_gen_types = ['coal', 'dfo', 'geothermal', 'ng', 'nuclear']
atlantic_thermal_idx = type_zone_index.get_idx((thermal_gen_types, 'Atlantic'))

plant_data.loc[atlantic_thermal_idx,['Pmax','Pmin']] *= scaling_value
```
without `KeyError` exceptions, group index concatenation, or loops. We can decide which of these formulations we want within this PR or keep them both for a bit longer before deciding...

Next PR will integrate transform functions into the specific grid fields similar to the earlier prototype notebook:
https://github.com/intvenlab/PowerSimData/blob/multilevel_scaling_demo/powersimdata/scaling/MultiLevel_Index_Scaling_Demo.ipynb

## Where to look

 powersimdata/input/grid_fields.py
 powersimdata/input/tests/test_grid_field.py

## Time estimate

30 - 60 min