### PR TITLE
Set collab solar fraction

### DIFF
--- a/powersimdata/design/clean_capacity_scaling.py
+++ b/powersimdata/design/clean_capacity_scaling.py
@@ -6,6 +6,21 @@ import os
 import pickle
 
 
+def _check_solar_fraction(solar_fraction):
+    """Checks that the solar_fraction is between 0 and 1, or is None.
+
+    :raises TypeError: if type is not int, float, or None.
+    :raises ValueError: if value is not between 0 and 1.
+    """
+    if solar_fraction is None:
+        pass
+    elif isinstance(solar_fraction, (int, float)):
+        if not (0 <= solar_fraction <= 1):
+            raise ValueError("solar_fraction must be between 0 and 1")
+    else:
+        raise TypeError("solar_fraction must be int/float or None")
+
+
 class AbstractStrategyManager:
     """
     Base class for strategy objects, contains common functions
@@ -220,16 +235,10 @@ class CollaborativeStrategyManager(AbstractStrategyManager):
     def set_solar_fraction(self, solar_fraction):
         """Sets desired solar fraction, to be used in subsequent calculations.
 
-        :param [float/NoneType] solar_fraction: solar fraction to be used in
+        :param [float/int/None] solar_fraction: solar fraction to be used in
             calculating added capacity. *None* will maintain previous ratio.
         """
-        if solar_fraction is None:
-            pass
-        elif isinstance(solar_fraction, float):
-            if not (0 <= solar_fraction <= 1):
-                raise ValueError("solar fraction must be between 0 and 1")
-        else:
-            raise TypeError("solar_fraction must be float or None")
+        _check_solar_fraction(solar_fraction)
         self.solar_fraction = solar_fraction
 
     def calculate_total_shortfall(self):
@@ -411,13 +420,6 @@ class TargetManager:
         assert (external_ce_historical_amount >= 0), "external_ce_historical" \
                                                      "_amount must be greater"\
                                                      " than zero"
-        assert (type(solar_percentage) == float or
-                type(solar_percentage) == int or
-                solar_percentage is None), "solar_percentage must be" \
-                                           " a number or None"
-        if type(solar_percentage) == float:
-            assert (0 <= solar_percentage <= 1), "solar_percentage must be " \
-                                               "between 0 and 1"
         self.region_name = region_name
         self.ce_category = ce_category
 
@@ -425,6 +427,7 @@ class TargetManager:
         self.ce_target_fraction = ce_target_fraction
         self.ce_target = self.total_demand * self.ce_target_fraction
         self.external_ce_historical_amount = external_ce_historical_amount
+        _check_solar_fraction(solar_percentage)
         self.solar_percentage = solar_percentage
 
         self.allowed_resources = []


### PR DESCRIPTION
### Purpose

Simplify the getting of collaborative scaling next capacities. Once targets & resources are defined, `collaborative_strategy_manager.data_frame_of_next_capacities()` seems to be the top-level user-facing function, but there's no input for `solar_fraction` there. We _could_ add an input here, pass that input to `calculate_capacity_scaling()`, and then pass that input to `calculate_total_added_capacity()`, or we could add one call to `collaborative_strategy_manager.set_solar_fraction()` before calling `data_frame_of_next_capacities()` and then we don't have to worry about propagating an input three levels deep.

### What is the code doing

- We add a `solar_fraction` attribute to `__init__()`, defaulting to `None`.
- We add a new function `_check_solar_capacity()` to check inputs.
- We add a new method `set_solar_fraction()` which assigns values to the instance attribute.
- We modify `calculate_total_added_capacity()` to not take an input for `solar_fraction`, but to get it from the instance attribute instead.
- We re-use `_check_solar_capacity()` to replace functionality in `TargetManager.__init__()`

### Validation

The code has been tested, and using the setter results in changes to the output capacities. The setter complains on bad inputs. All existing unit tests still pass.

### Time to review

Five to fifteen minutes. This feature is not urgent, since I've already used the code for what I need it for right now, and I can always rebase and re-use it in the meantime. It would be nice to have in the codebase eventually though.