### PR TITLE
fix: populate optional area_type to all related functions

### DIFF
--- a/powersimdata/design/scenario_info.py
+++ b/powersimdata/design/scenario_info.py
@@ -42,7 +42,7 @@ class ScenarioInfo:
         :param str area: one of: *loadzone*, *state*, *state abbreviation*,
             *interconnect*, *'all'*
         :param str area_type: one of: *'loadzone'*, *'state'*,
-            *'state_abbr'*,*'interconnect'*
+            *'state_abbr'*, *'interconnect'*
         :return: (*set*) -- set of loadzones associated to the query area
         :raise Exception: if area is invalid or the combination of
             area and area_type is invalid or the type of area_type is invalid.
@@ -122,20 +122,22 @@ class ScenarioInfo:
                              'start_time falls behind end_time!')
         return start_i, end_i
 
-    def get_available_resource(self, area):
+    def get_available_resource(self, area, area_type=None):
         """Find the available resources of a specific area in the grid of the
             given scenario
 
         :param str area: one of: *loadzone*, *state*, *state abbreviation*,
             *interconnect*, *'all'*
+        :param str area_type: one of: *'loadzone'*, *'state'*,
+            *'state_abbr'*, *'interconnect'*
         :return: (*list*) -- a list of available resources in the query area
         """
-        loadzone_set = self.area_to_loadzone(area)
+        loadzone_set = self.area_to_loadzone(area, area_type)
         available_resources = self.grid.plant[
             self.grid.plant['zone_name'].isin(loadzone_set)]['type'].unique()
         return available_resources.tolist()
 
-    def get_demand(self, area, start_time, end_time):
+    def get_demand(self, area, start_time, end_time, area_type=None):
         """Calculate the total demand of the query area during the query time
             range of the given scenario
 
@@ -145,10 +147,12 @@ class ScenarioInfo:
             *'YYYY-MM-DD HH:MM:SS'*
         :param str end_time: end timestamp in the format
             *'YYYY-MM-DD HH:MM:SS'*
+        :param str area_type: one of: *'loadzone'*, *'state'*,
+            *'state_abbr'*, *'interconnect'*
         :return: (*float*) -- total demand (in MWh)
             based on the specified parameters
         """
-        loadzone_set = self.area_to_loadzone(area)
+        loadzone_set = self.area_to_loadzone(area, area_type)
         self.check_time_range(start_time, end_time)
         total_demand = self.demand.loc[
             start_time:end_time,
@@ -157,17 +161,19 @@ class ScenarioInfo:
         ].sum().sum()
         return float(total_demand)
 
-    def get_capacity(self, gentype, area):
+    def get_capacity(self, gentype, area, area_type=None):
         """Calculate the total capacity of the query gentype in the query area
             of the given scenario
 
         :param str gentype: type of generator
         :param str area: one of: *loadzone*, *state*, *state abbreviation*,
             *interconnect*, *'all'*
+        :param str area_type: one of: *'loadzone'*, *'state'*,
+            *'state_abbr'*, *'interconnect'*
         :return: (*float*) -- total capacity (in MW) based on the
             specified parameters
         """
-        loadzone_set = self.area_to_loadzone(area)
+        loadzone_set = self.area_to_loadzone(area, area_type)
         total_capacity = self.grid.plant[
             (self.grid.plant['type'] == gentype) &
             (self.grid.plant['zone_name'].isin(loadzone_set))]['Pmax'].sum()
@@ -175,7 +181,8 @@ class ScenarioInfo:
             warnings.warn('No such type of generator in the area specified!')
         return float(total_capacity)
 
-    def get_generation(self, gentype, area, start_time, end_time):
+    def get_generation(self, gentype, area, start_time, end_time,
+                       area_type=None):
         """Calculate the total generation of the query gentype in the query
             area during the query time range of the given scenario
 
@@ -186,10 +193,12 @@ class ScenarioInfo:
             *'YYYY-MM-DD HH:MM:SS'*
         :param str end_time: end timestamp in the format
             *'YYYY-MM-DD HH:MM:SS'*
+        :param str area_type: one of: *'loadzone'*, *'state'*,
+            *'state_abbr'*, *'interconnect'*
         :return: (*float*) -- total generation (in MWh)
             based on the specified parameters
         """
-        loadzone_set = self.area_to_loadzone(area)
+        loadzone_set = self.area_to_loadzone(area, area_type)
         plant_id_list = list(self.grid.plant
                              [(self.grid.plant['type'] == gentype) &
                               (self.grid.plant['zone_name'].
@@ -199,7 +208,8 @@ class ScenarioInfo:
         total_generation = query_pg_df.loc[start_time:end_time].sum().sum()
         return float(total_generation)
 
-    def get_profile_resource(self, gentype, area, start_time, end_time):
+    def get_profile_resource(self, gentype, area, start_time, end_time,
+                             area_type=None):
         """Calculate the total resource from profile of the query gentype in
             the query area during the query time range of the given scenario
 
@@ -210,11 +220,13 @@ class ScenarioInfo:
             *'YYYY-MM-DD HH:MM:SS'*
         :param str end_time: end timestamp in the format
             *'YYYY-MM-DD HH:MM:SS'*
+        :param str area_type: one of: *'loadzone'*, *'state'*,
+            *'state_abbr'*, *'interconnect'*
         :return: (*float*) -- total resource from profile (in MWh)
             based on the specified parameters
         :raise Exception: if the resource type is invalid
         """
-        loadzone_set = self.area_to_loadzone(area)
+        loadzone_set = self.area_to_loadzone(area, area_type)
         plant_id_list = list(self.grid.plant
                              [(self.grid.plant['type'] == gentype) &
                               (self.grid.plant['zone_name'].
@@ -226,7 +238,8 @@ class ScenarioInfo:
         total_resource = query_profile_df.loc[start_time:end_time].sum().sum()
         return float(total_resource)
 
-    def get_curtailment(self, gentype, area, start_time, end_time):
+    def get_curtailment(self, gentype, area, start_time, end_time,
+                        area_type=None):
         """Calculate the curtailment of the query gentype in the query
             area during the query time range of the given scenario
 
@@ -237,20 +250,23 @@ class ScenarioInfo:
             *'YYYY-MM-DD HH:MM:SS'*
         :param str end_time: end timestamp in the format
             *'YYYY-MM-DD HH:MM:SS'*
+        :param str area_type: one of: *'loadzone'*, *'state'*,
+            *'state_abbr'*, *'interconnect'*
         :return: (*float*) -- curtailment percentage (rounded up to
             two decimals) based on the specified parameters
         """
         total_generation = self.get_generation(gentype, area,
-                                               start_time, end_time)
+                                               start_time, end_time, area_type)
         total_profile_resource = self.get_profile_resource(gentype, area,
                                                            start_time,
-                                                           end_time)
+                                                           end_time, area_type)
         if total_profile_resource == 0 and total_generation == 0:
             return 0
         curtailment = round(1 - (total_generation / total_profile_resource), 4)
         return float(curtailment)
 
-    def get_capacity_factor(self, gentype, area, start_time, end_time):
+    def get_capacity_factor(self, gentype, area, start_time, end_time,
+                            area_type=None):
         """Calculate the capacity factor of the query gentype in the
             query area during the query time range of the given scenario
 
@@ -261,21 +277,23 @@ class ScenarioInfo:
             *'YYYY-MM-DD HH:MM:SS'*
         :param str end_time: end timestamp in the format
             *'YYYY-MM-DD HH:MM:SS'*
+        :param str area_type: one of: *'loadzone'*, *'state'*,
+            *'state_abbr'*, *'interconnect'*
         :return: (*float*) -- capacity factor based on the specified parameters
         """
         start_i, end_i = self.check_time_range(start_time, end_time)
         total_hours = end_i - start_i + 1
-        total_capacity = self.get_capacity(gentype, area)
+        total_capacity = self.get_capacity(gentype, area, area_type)
         if total_capacity == 0:
             raise ZeroDivisionError('No such type of generator in the area '
                                     'specified. Division by zero.')
         total_generation = self.get_generation(gentype, area,
-                                               start_time, end_time)
+                                               start_time, end_time, area_type)
         cf = round(total_generation / (total_hours * total_capacity), 4)
         return float(cf)
 
     def get_no_congest_capacity_factor(self, gentype, area,
-                                       start_time, end_time):
+                                       start_time, end_time, area_type=None):
         """Calculate the no congestion capacity factor of the query gentype
             in the query area during the query time range of the given scenario
 
@@ -286,10 +304,14 @@ class ScenarioInfo:
             *'YYYY-MM-DD HH:MM:SS'*
         :param str end_time: end timestamp in the format
             *'YYYY-MM-DD HH:MM:SS'*
+        :param str area_type: one of: *'loadzone'*, *'state'*,
+            *'state_abbr'*, *'interconnect'*
         :return: (*float*) -- no congestion capacity factor based
             on the specified parameters
         """
-        cf = self.get_capacity_factor(gentype, area, start_time, end_time)
-        curtailment = self.get_curtailment(gentype, area, start_time, end_time)
+        cf = self.get_capacity_factor(gentype, area, start_time,
+                                      end_time, area_type)
+        curtailment = self.get_curtailment(gentype, area, start_time,
+                                           end_time, area_type)
         no_congest_cf = round(cf / (1 - curtailment), 4)
         return float(no_congest_cf)


### PR DESCRIPTION
### Purpose

The `area_type` parameter is added to function `area_to_loadzone`, however, it is not populated to the functions that call `area_to_loadzone`.

### What is the code doing

populate optional area_type to all related functions.

### Validation

All tests still passed.

### Time to review

5mins