### PR TITLE
Append new branches to branch data frame of Grid object

### DIFF
--- a/powersimdata/input/scaler.py
+++ b/powersimdata/input/scaler.py
@@ -265,6 +265,7 @@ class Scaler(object):
                     new_branch.loc[i, 'to_lon'] = to_lon
                     new_branch.loc[i, 'to_lat'] = to_lat
                     new_branch.loc[i, 'x'] = x
+                self._grid.branch = self._grid.branch.append(new_branch)
         return self._grid
 
     def get_power_output(self, resource):


### PR DESCRIPTION
## Purpose
Fix bug when adding AC lines through change table (issue #176).

## What is the code doing?
It appends the data frame enclosing the new branches to the existing one.

## Where to look
in `powersimdata/input/scaler.py`, a single line of code is added

## Ime estimate
2min