### PR TITLE
fix: allow small tolerance on capacity factors

### DIFF
--- a/powersimdata/design/clean_capacity_scaling.py
+++ b/powersimdata/design/clean_capacity_scaling.py
@@ -751,6 +751,7 @@ class Resource:
             congestion.
         :param float prev_capacity: capacity from scenario run.
         :param float prev_cap_factor: capacity factor from scenario run.
+        :param float tolerance: tolerance for values outside expected range.
 
         .. todo:: calculate directly from scenario results
         """


### PR DESCRIPTION
### Purpose

Similarly to https://github.com/intvenlab/PowerSimData/pull/128, we want to avoid an AssertionError that happens if the total generation is slightly above a capacity factor of 1. This can be seen when loading Scenario 519 and calling `CollaborativeStrategyManager.populate_targets_with_resources()`, there is one region for which 'other' type generators have a calculated capacity factor of 100.01%, and this halts the method.

### What is the code doing

Adding a small tolerance (1e-3 by default) to the `0 < x < 1` check.

### Time to review

5 minutes.