### PR TITLE
refactor: historical clean energy is additional, not reference

### DIFF
--- a/powersimdata/design/tests/test_resource_target_manager.py
+++ b/powersimdata/design/tests/test_resource_target_manager.py
@@ -42,7 +42,7 @@ def test_calculate_ce_shortfall_prev_gt_external(test_method):
 @patch.object(TargetManager, 'calculate_prev_ce_generation',
               return_value=28774.16)
 def test_calculate_ce_shortfall_external_gt_prev(test_method):
-    target = TargetManager('Pacific', 0.25, 'renewables', 200000, 40000)
+    target = TargetManager('Pacific', 0.25, 'renewables', 200000, 11225.84)
     result = target.calculate_ce_shortfall()
     assert result == 10000
 
@@ -74,13 +74,13 @@ def test_calculate_ce_overgeneration_prev_gt_external(test_method):
 @patch.object(TargetManager, 'calculate_prev_ce_generation',
               return_value=28774.16)
 def test_calculate_ce_overgeneration_external_gt_prev(test_method):
-    target = TargetManager('Pacific', 0.25, 'renewables', 200000, 40000)
+    target = TargetManager('Pacific', 0.25, 'renewables', 200000, 11225.84)
     result = target.calculate_ce_overgeneration()
     assert result == 0
 
 
 @patch.object(TargetManager, 'calculate_prev_ce_generation',
-              return_value=68774.16)
+              return_value=12774.16)
 def test_calculate_ce_no_overgeneration_prev_gt_external(test_method):
     target = TargetManager('Pacific', 0.25, 'renewables', 200000, 56000)
     result = target.calculate_ce_overgeneration()
@@ -90,7 +90,7 @@ def test_calculate_ce_no_overgeneration_prev_gt_external(test_method):
 @patch.object(TargetManager, 'calculate_prev_ce_generation',
               return_value=68774.16)
 def test_calculate_ce_no_overgeneration_external_gt_prev(test_method):
-    target = TargetManager('Pacific', 0.25, 'renewables', 200000, 70000)
+    target = TargetManager('Pacific', 0.25, 'renewables', 200000, 1225.84)
     result = target.calculate_ce_overgeneration()
     assert result == 20000
 

--- a/powersimdata/design/tests/test_strategies.py
+++ b/powersimdata/design/tests/test_strategies.py
@@ -225,7 +225,7 @@ def test_independent_capacity_strategy_pacific_external_6():
     nuclear.set_addl_curtailment(0)
 
     target = TargetManager('Pacific', 0.25, 'renewables', 200000*1000,
-                           40000*1000)
+                           14000*1000)
     target.set_allowed_resources(['solar', 'wind', 'geo'])
     target.add_resource(solar)
     target.add_resource(wind)

--- a/powersimdata/design/tests/test_target_manager_input.py
+++ b/powersimdata/design/tests/test_target_manager_input.py
@@ -13,7 +13,7 @@ def test_create_targets_from_dataframe():
                      'ce_category': ['Renewables', 'Clean'],
                      'ce_target_fraction': [.25, .4],
                      'total_demand': [200000, 300000],
-                     'external_ce_historical_amount': [0, 0],
+                     'external_ce_addl_historical_amount': [0, 0],
                      'solar_percentage': [.3, .6],
                      'allowed_resources': ['solar', 'wind']}
 
@@ -29,7 +29,7 @@ def test_create_targets_from_dataframe():
             row.ce_target_fraction,
             row.ce_category,
             row.total_demand,
-            row.external_ce_historical_amount,
+            row.external_ce_addl_historical_amount,
             row.solar_percentage)
 
     assert targets['Pacific'].ce_category == planning_data['ce_category'][0]
@@ -41,7 +41,7 @@ def test_populate_strategy_from_dataframe():
                      'ce_category': ['Renewables', 'Clean'],
                      'ce_target_fraction': [.25, .4],
                      'total_demand': [200000, 300000],
-                     'external_ce_historical_amount': [0, 0],
+                     'external_ce_addl_historical_amount': [0, 0],
                      'solar_percentage': [.3, .6],
                      'allowed_resources': ['solar', 'wind']}
     planning_dataframe = pd.DataFrame.from_dict(planning_data)


### PR DESCRIPTION
### Purpose

Based on conversations with @danlivengood, we want to modify how external clean energy references are incorporated in calculations. The biggest example of this is California: they calculate a 'clean energy total' vastly in excess of our calculated numbers, since they count things like small hydro, rooftop PV, etc. that are not counted by our framework.

Previously, we had been inputting a constant value as the 'historical clean energy reference' (e.g. from California's reported total in 2016). This change instead uses a 'historical additional clean energy' value (which we will calculate once outside of this framework). This has the benefit of allowing accurate calculation of shortfall in scaled-up 2030 scenarios, where previously the over-generation was clipped at this historical reference value, even for future scenarios.

### What is the code doing

In `clean_capacity_scaling.py`: we rename 'external_ce_historical_amount' to 'external_ce_addl_historical_amount'. This offset is added to `prev_ce_generation` (generated energy from 'qualifying' resources in our framework) when calculating total shortfall or overgeneration for each target area.

In `test_resource_target_manager.py`: we modify the test input values to reflect that the final argument to `TargetManager` is an offset, not a reference.

In `test_strategies.py`: we modify the test input values to reflect that the final argument to `TargetManager` is an offset, not a reference.

In `test_target_manager_input.py`: we modify the column naming.

### Time to review

Half an hour. This change is necessary to begin our revised Western 2030 runs, which are a blocker for our USA 2030 runs.