### PR TITLE
feat: enable get_load_shed from Analyze

### DIFF
--- a/powersimdata/output/profiles.py
+++ b/powersimdata/output/profiles.py
@@ -1,8 +1,11 @@
+from powersimdata.input.profiles import get_bus_demand
 from powersimdata.utility.transfer_data import download
 from powersimdata.utility import const
 
+import numpy as np
 import os
 import pandas as pd
+from scipy.sparse import coo_matrix
 
 
 class OutputData(object):
@@ -74,3 +77,42 @@ def _check_field(field_name):
                 'AVERAGED_CONG', 'STORAGE_PG', 'STORAGE_E', 'LOAD_SHED']
     if field_name not in possible:
         raise ValueError('Only %s data can be loaded' % " | ".join(possible))
+
+
+def construct_load_shed(ssh_client, scenario_info, grid, infeasibilities=None):
+    """Constructs load_shed dataframe from relevant scenario/grid data.
+
+    :param paramiko.client.SSHClient ssh_client: session with an SSH server.
+    :param dict scenario_info: info attribute of Scenario object.
+    :param powersimdata.input.grid.Grid grid: grid to construct load_shed for.
+    :param dict/None infeasibilities: dictionary of
+        {interval (int): load shed percentage (int)}, or None.
+    :return: (*pandas.DataFrame*) -- data frame of load_shed.
+    """
+    hours = pd.date_range(start=scenario_info['start_date'],
+                          end=scenario_info['end_date'],
+                          freq='1H').tolist()
+    buses = grid.bus.index
+    if infeasibilities is None:
+        print('No infeasibilities, constructing DataFrame')
+        load_shed_data = coo_matrix((len(hours), len(buses)))
+        load_shed = pd.DataFrame.sparse.from_spmatrix(load_shed_data)
+    else:
+        print('Infeasibilities, constructing DataFrame')
+        bus_demand = get_bus_demand(ssh_client, scenario_info['id'], grid)
+        load_shed = np.zeros((len(hours), len(buses)))
+        # Convert '24H' to 24
+        interval = int(scenario_info['interval'][:-1])
+        for i, v in infeasibilities.items():
+            start = i * interval
+            end = (i+1) * interval
+            base_demand = bus_demand.iloc[start:end, :].to_numpy()
+            shed_demand = base_demand * (v / 100)
+            load_shed[start:end, :] = shed_demand
+        load_shed = pd.DataFrame(load_shed, columns=buses, index=hours)
+        load_shed = load_shed.astype(pd.SparseDtype("float", 0))
+    load_shed.index = hours
+    load_shed.index.name = 'UTC'
+    load_shed.columns = buses
+
+    return load_shed

--- a/powersimdata/scenario/analyze.py
+++ b/powersimdata/scenario/analyze.py
@@ -2,15 +2,13 @@ from powersimdata.utility import const
 from powersimdata.input.grid import Grid
 from powersimdata.input.scaler import ScaleProfile
 from powersimdata.input.profiles import InputData
-from powersimdata.output.profiles import OutputData
+from powersimdata.output.profiles import OutputData, construct_load_shed
 from powersimdata.scenario.state import State
 
 import copy
 import os
-import numpy as np
 import pandas as pd
 import pickle
-from scipy.sparse import coo_matrix
 
 
 class Analyze(State):
@@ -203,38 +201,16 @@ class Analyze(State):
         :return: (*pandas.DataFrame*) -- data frame of load shed (hour x bus).
         """
         scenario_id = self._scenario_info['id']
-        output_data = OutputData(self._ssh)
         try:
             # It's either on the server or in our local ScenarioData folder
+            output_data = OutputData(self._ssh)
             load_shed = output_data.get_data(scenario_id, 'LOAD_SHED')
         except FileNotFoundError:
             # The scenario was run without load_shed, and we must construct it
+            grid = self.get_grid()
             infeasibilities = self._parse_infeasibilities()
-            hours = pd.date_range(start=self._scenario_info['start_date'],
-                                  end=self._scenario_info['end_date'],
-                                  freq='1H').tolist()
-            buses = self.get_grid().bus.index
-            if infeasibilities is None:
-                print('No infeasibilities, constructing DataFrame')
-                load_shed_data = coo_matrix((len(hours), len(buses)))
-                load_shed = pd.DataFrame.sparse.from_spmatrix(load_shed_data)
-            else:
-                print('Infeasibilities, constructing DataFrame')
-                bus_demand = self.get_bus_demand()
-                load_shed = np.zeros((len(hours), len(buses)))
-                # Convert '24H' to 24
-                interval = int(self._scenario_info['interval'][:-1])
-                for i, v in infeasibilities.items():
-                    start = i * interval
-                    end = (i+1) * interval
-                    base_demand = bus_demand.iloc[start:end, :].to_numpy()
-                    shed_demand = base_demand * (v / 100)
-                    load_shed[start:end, :] = shed_demand
-                load_shed = pd.DataFrame(load_shed, columns=buses, index=hours)
-                load_shed = load_shed.astype(pd.SparseDtype("float", 0))
-            load_shed.index = hours
-            load_shed.index.name = 'UTC'
-            load_shed.columns = buses
+            load_shed = construct_load_shed(
+                self._ssh, self._scenario_info, grid, infeasibilities)
 
             filename = scenario_id + '_LOAD_SHED.pkl'
             filepath = os.path.join(const.LOCAL_DIR, filename)
@@ -285,23 +261,6 @@ class Analyze(State):
                         self._scenario_info['interval']) - pd.Timedelta('1H')
                     demand[start:end] *= 1. - value / 100.
                 return demand
-
-    def get_bus_demand(self):
-        """Returns demand profiles by bus.
-
-        :return: (*pandas.DataFrame*) -- data frame of demand.
-        """
-        profile = ScaleProfile(self._ssh, self._scenario_info['id'],
-                               self.get_grid(), self.get_ct())
-        demand = profile.get_demand()
-        bus = self.get_grid().bus
-        bus['zone_Pd'] = bus.groupby('zone_id')['Pd'].transform('sum')
-        bus['zone_share'] = bus['Pd'] / bus['zone_Pd']
-        zone_bus_shares = pd.DataFrame({
-            z: bus.groupby('zone_id').get_group(z).zone_share
-            for z in demand.columns}).fillna(0)
-        bus_demand = demand.dot(zone_bus_shares.T)
-        return bus_demand
 
     def get_hydro(self):
         """Returns hydro profile


### PR DESCRIPTION
### Purpose

Now that we save the `load_shed` results from REISE.jl scenarios, it would be nice to be able to access them via the Scenario object. This enables that, and also returns equivalent values for scenarios which have been run with REISE. Closes #175.

### What is the code doing

In `profiles.py`: adding `LOAD_SHED` as a valid key to use when getting files.

In `analyze.py`:
- adding a new method `get_bus_demand` that calculates demand by (hour, bus) as MATPOWER/REISE.jl do.
- adding a new method `get_load_shed` that gets load shed either from the server, from the local folder, or by constructing it via the `demand` and infeasibilities (for scenarios run with 5% load shedding instead of targeted). If constructing it, we build a sparse dataframe and then save that as a pickle in the local folder, so that it is available for next time without re-calculation.

### Demonstration

We use three representative scenarios:
- Scenario 87 (no load shed pickle, some infeasibilities)
- Scenario 151 (no load shed pickle, no infeasibilities)
- Scenario 585 (load shed pickle on server)

```
>>> from powersimdata.scenario.scenario import Scenario
>>> scenario = Scenario('87')
SCENARIO: base | WesternBase_2016_noHVDC_Final_2019Sep
[---truncated output---]
>>> load_shed = scenario.state.get_load_shed()
--> Loading LOAD_SHED
87_LOAD_SHED.pkl not found in C:\Users\dolsen\ScenarioData\ on local machine
Infeasibilities, constructing DataFrame
--> Loading demand
>>> load_shed = scenario.state.get_load_shed()
--> Loading LOAD_SHED
>>> load_shed.sum().sum()
1474991.0250000004
>>> scenario.state.get_demand().iloc[(34*144):(36*144), :].sum().sum() * 0.05
--> Loading demand
1474991.025
>>> load_shed.sum(axis=1)[load_shed.sum(axis=1) > 0]
UTC
2016-07-23 00:00:00    6371.45
2016-07-23 01:00:00    6340.85
2016-07-23 02:00:00    6238.20
2016-07-23 03:00:00    6047.75
2016-07-23 04:00:00    5857.35
                        ...
2016-08-03 19:00:00    5290.65
2016-08-03 20:00:00    5493.15
2016-08-03 21:00:00    5668.60
2016-08-03 22:00:00    5810.50
2016-08-03 23:00:00    5919.40
Length: 288, dtype: float64
```
On first load, we create the dataframe and save it. On subsequent loads, we load from what's already saved. The `load_shed` that we calculate is identical (same totals, same timing) to what the infeasibilities represent (5% load shedding in 2x 144H intervals, 34 and 35), the only difference is floating point precision.
```
>>> scenario = Scenario('151')
SCENARIO: base | WACA_Anchor_AllMatchCA_2030_SpurUpgrade_Mesh100x3_fix
[---truncated output---]
>>> load_shed = scenario.state.get_load_shed()
--> Loading LOAD_SHED
151_LOAD_SHED.pkl not found in C:\Users\dolsen\ScenarioData\ on local machine
No infeasibilities, constructing DataFrame
>>> load_shed = scenario.state.get_load_shed()
--> Loading LOAD_SHED
>>> load_shed.sum().sum()
0.0
```
On first load, we create the dataframe and save it. On subsequent loads, we load from what's already saved. `load_shed` is an empty sparse dataframe.
```
>>> scenario = Scenario('585')
SCENARIO: Julia | Eastern2030CollaborativeOffshore_Mandate_OB2_Mesh200x2
[---truncated output---]
>>> load_shed = scenario.state.get_load_shed()
--> Loading LOAD_SHED
585_LOAD_SHED.pkl not found in C:\Users\dolsen\ScenarioData\ on local machine
Transferring 585_LOAD_SHED.pkl from server
100%|#####################################| 14.1M/14.1M [00:01<00:00, 10.4Mb/s]
>>> load_shed = scenario.state.get_load_shed()
--> Loading LOAD_SHED
>>> load_shed.sum().sum()
45832.31829716498
```
On first load, we get the pickle file from the server. On subsequent loads, we load from what's already saved. `load_shed` is non-empty sparse dataframe.

### Time to review

Half an hour to an hour. I think the logic is straightforward, but maybe we want to relocate some of the code? `get_load_shed` is the longest function in Analyze now, even after we re-locate `get_bus_demand` out. Low urgency for now, since we can play around with this locally.