### PR TITLE
fix: allow small negative value for prev_curtailment

### DIFF
--- a/powersimdata/design/clean_capacity_scaling.py
+++ b/powersimdata/design/clean_capacity_scaling.py
@@ -982,11 +982,13 @@ class Resource:
             f"prev_generation must be greater than zero. Got {prev_generation}"
         self.prev_generation = prev_generation
 
-    def set_curtailment(self, prev_curtailment):
+    def set_curtailment(self, prev_curtailment, tolerance=1e-3):
         """Sets curtailment from scenario run.
 
         :param float prev_curtailment: calculated curtailment from scenario run.
         """
+        if (-1 * tolerance) <= prev_curtailment < 0:
+            prev_curtailment = 0
         assert (prev_curtailment >= 0), \
             "prev_curtailment must be greater than zero"
         self.prev_curtailment = prev_curtailment


### PR DESCRIPTION
### Purpose

Similar to #128 and #181, allow a small negative value (from the Barrier method of Gurobi) instead of complaining that it's less than zero. This is necessary for calling `populate_targets_with_resources` on Scenario 639. I think this is the last of these.

### Time to review

It is three lines.