### PR TITLE
feat: redirect output stream to os.devnull via parameters of Popen

### DIFF
--- a/powersimdata/scenario/execute.py
+++ b/powersimdata/scenario/execute.py
@@ -14,7 +14,7 @@ import numpy as np
 import os
 import posixpath
 from scipy.io import savemat
-from subprocess import Popen, PIPE
+from subprocess import Popen
 
 
 class Execute(State):
@@ -118,10 +118,12 @@ class Execute(State):
         cmd = [
             'ssh', username+'@'+const.SERVER_ADDRESS,
             'export PYTHONPATH="%s:$PYTHONPATH";' % path_to_package,
-            'python3',
+            'nohup', 'python3', '-u',
             '%s' % path_to_script,
-            self._scenario_info['id']]
-        process = Popen(cmd, stdin=PIPE, stdout=PIPE, stderr=PIPE)
+            self._scenario_info['id'],
+            '</dev/null >/dev/null 2>&1 &'
+        ]
+        process = Popen(cmd)
         print("PID: %s" % process.pid)
         return process
 


### PR DESCRIPTION
### Purpose

This branch is a clean-up version of the recent working branch `nohup_execute` regarding the disconnected issue we encountered during scenario runs. 

We conducted a series of test runs to explore the possible solutions to get rid of the requirement of active SSH connection between local client and our remote server (Zeus). The following two approaches that redirect output stream to `os.devnull` are proved to work:
a)
```
cmd = [
    'ssh', username+'@'+const.SERVER_ADDRESS,
    'export PYTHONPATH="%s:$PYTHONPATH";' % path_to_package,
    'nohup', 'python3', '-u',
    '%s' % path_to_script,
    self._scenario_info['id'],
    '</dev/null >/dev/null 2>&1 &'
]
```
b)
```
cmd = [
    'ssh', username+'@'+const.SERVER_ADDRESS,
    'export PYTHONPATH="%s:$PYTHONPATH";' % path_to_package,
    'python3',
    '%s' % path_to_script,
    self._scenario_info['id']
]
process = Popen(cmd, stdin=DEVNULL, stdout=DEVNULL, stderr=DEVNULL)
```
After reading through the documentation of `subprocess.popen`, the parameters of function `Popen` does following:

> stdin, stdout and stderr specify the executed program’s standard input, standard output and standard error file handles, respectively. Valid values are PIPE, DEVNULL, an existing file descriptor (a positive integer), an existing file object, and None. PIPE indicates that a new pipe to the child should be created. DEVNULL indicates that the special file os.devnull will be used. With the default settings of None, no redirection will occur; the child’s file handles will be inherited from the parent. Additionally, stderr can be STDOUT, which indicates that the stderr data from the applications should be captured into the same file handle as for stdout.

Literally, there is no difference between a) and b). In both cases, we create a child process with output stream being redirect to `os.devnull` and any lower level process (Julia script) will inherit this property and suppress the communication with the local client who starts the process. 

Closes [#278](https://app.zenhub.com/workspaces/renewable-energy-integration-5bfdd1184b5806bc2bf88976/issues/intvenlab/renewableenergyproject/278).

### What is the code doing

Implement approach b) above.

### Validation

This branch has been tested via Scenario 746 and 747. Both of them are created locally on a Mac laptop with VPN on. Then they went into the queue on Gurobi Cloud. Right after they were submitted, the local VPN was cut off. Both of the two scenarios were successfully finished and extracted.  

### Time to review
5 min to 30 min depends on how much one would like to dive into the documentations of the `subprocess` module.