### PR TITLE
Extend mappings to include usa and texas western

### DIFF
--- a/powersimdata/utility/constants.py
+++ b/powersimdata/utility/constants.py
@@ -316,6 +316,12 @@ interconnect2loadzone = {
     },
 }
 
+interconnect2loadzone["USA"] = (
+    interconnect2loadzone["Eastern"]
+    | interconnect2loadzone["Western"]
+    | interconnect2loadzone["Texas"]
+)
+
 interconnect2state = {
     "Eastern": [
         "ME",
@@ -358,8 +364,18 @@ interconnect2state = {
     "Texas": ["TX"],
     "Western": ["WA", "OR", "CA", "NV", "AZ", "UT", "NM", "CO", "WY", "ID", "MT"],
 }
+interconnect2state["USA"] = (
+    interconnect2state["Eastern"]
+    + interconnect2state["Western"]
+    + interconnect2state["Texas"]
+)
+interconnect2state["Texas_Western"] = (
+    interconnect2state["Texas"] + interconnect2state["Western"]
+)
 
 state2interconnect = {}
 for k, v in interconnect2state.items():
+    if k in ("USA", "Texas_Western"):
+        continue
     for s in v:
         state2interconnect[s] = k


### PR DESCRIPTION
**Purpose** - move logic from spot check notebook into git
**What it does** - extend `interconnect2loadzone` and `interconnect2state` to include USA, and Texas_Western for the latter. These are ignored when computing state2interconnect for compatibility, and since the primary usage of that is likely the specific interconnect (e.g. we don't need to include USA since it's obvious). 
**Time to review** - 5-10 mins. Integration tests still pass locally, and I searched for usages of these but didn't find any places where it looked like this would break something. 