### PR TITLE
Specify installation dependencies for consumers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,16 @@
 from setuptools import setup, find_packages
 
+install_requires = [
+    "cryptography",
+    "geopy",
+    "jsonpickle",
+    "numpy",
+    "pandas",
+    "paramiko",
+    "scipy",
+    "tqdm",
+]
+
 setup(
     name="powersimdata",
     version="0.3",
@@ -10,4 +21,5 @@ setup(
     packages=find_packages(),
     package_data={"powersimdata": ["input/data/*/*"]},
     zip_safe=False,
+    install_requires=install_requires,
 )


### PR DESCRIPTION
**Purpose** - enable a user of this package to have necessary packages resolved by pip automatically
**What it does** - When a powersimdata (or any package) is installed as a library, it has a different set of requirements compared to deploying the package on its own or in a local dev environment. For example - things like pytest are not required, and versions should be more permissive (to the extent that functionality still works) since the consuming package/application may share some of these. Here, we list these separately from requirements.txt, including everything except pytest and omitting versions.

I tested this by installing into PreREISE, referencing this branch, using the environment variables for authentication: 
```
pipenv install -e git+https://{$GIT_USER}:{$GIT_PASS}@github.com/intvenlab/PowerSimData.git@2fbee73033c389fc2becef6cf9ca2a2c4f249e97#egg=powersimdata
```

This resulted in only the powersimdata reference added to Pipfile, but the specified packages installed. See example partial output from `pipenv graph`:

<img width="248" alt="depgraph" src="https://user-images.githubusercontent.com/66005238/85788252-87c5b780-b6e1-11ea-8bcd-eeabc91eba6a.PNG">

**Time to review** - 5 mins. Tests still pass and this won't affect anything since we're not using it yet.
