### PR TITLE
feat: set REISE.jl as default engine (#226)

### DIFF
--- a/powersimdata/scenario/create.py
+++ b/powersimdata/scenario/create.py
@@ -281,7 +281,7 @@ class _Builder(object):
     hydro = ""
     solar = ""
     wind = ""
-    engine = "REISE"
+    engine = "REISE.jl"
     name = "builder"
 
     def set_name(self, plan_name, scenario_name):


### PR DESCRIPTION
## Purpose
Set REISE.jl as the default simulation engine since REISE is no longer used.

## What is the code doing?
Use REISE.jl inplace of REISE as the default value of the engine when building a scenario.

## Where to look
In the constructor of the `_Builder` class where the `engine` attribute is defined.

## Time estimate
2 min