### PR TITLE
switch to relative path

### DIFF
--- a/powersimdata/scenario/execute.py
+++ b/powersimdata/scenario/execute.py
@@ -407,7 +407,7 @@ class SimulationInput(object):
         target = kind + ".csv"
 
         command = "ln -s %s %s" % (
-            posixpath.join(const.BASE_PROFILE_DIR, source),
+            posixpath.join("../../raw", source),
             posixpath.join(self.TMP_DIR, target),
         )
         stdin, stdout, stderr = self._ssh.exec_command(command)


### PR DESCRIPTION
## Purpose
Use relative path in place of absolute path when creating a symbolic link to a base profile in the temporary folder of a scenario. That way, the link won'th break if we change the root of the file system (e.g. `/home/EGM/v2` is renamed `/home/BES`) or when we move a scenario to a backup disk.

## What is the code doing?
There is no code. 

## Where to look
In the `_create_link_to_base_profile` method of the `Simulation Input` class. I use the `cd` command to move into the temporary folder of the scenario and then create a symbolic link to the base profile using a relative path.

## Time estimate
2min. This can be tested on creating, running, extracting a dummy scenario and then moving it to RE-Storage.