### PR TITLE
pandas deprecation warning

### DIFF
--- a/powersimdata/scenario/scenario.py
+++ b/powersimdata/scenario/scenario.py
@@ -12,7 +12,7 @@ from collections import OrderedDict
 
 import pandas as pd
 
-pd.set_option("display.max_colwidth", -1)
+pd.set_option("display.max_colwidth", None)
 
 
 class Scenario(object):


### PR DESCRIPTION
## Purpose
Update pandas `set_option` to avoid deprecation warning message

## What is the code doing?
There is no code. I got the following message when running the test:
```
======================================================================= warnings summary =======================================================================
powersimdata/scenario/scenario.py:15
  /Users/brdo/CEM/PowerSimData/powersimdata/scenario/scenario.py:15: FutureWarning: Passing a negative integer is deprecated in version 1.0 and will not be supported in future version. Instead, use None to not limit the column width.
    pd.set_option("display.max_colwidth", -1)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
======================================================== 185 passed, 10 deselected, 1 warning in 25.28s ========================================================
```
I have hence replaced the value of the second argument as suggested in the message above.

## Where to look
The option is set in the `powersimdata.scenario.scenario` module

## Time estimate
5 min. Run the test using `purest . -m "not integration"` in the `develop` branch first, checkout the `ben/pandas` branch and run the test again 