### PR TITLE
feat: specify number of threads to use to run simulation

### DIFF
--- a/powersimdata/scenario/execute.py
+++ b/powersimdata/scenario/execute.py
@@ -119,7 +119,7 @@ class Execute(State):
         if extra_args is None:
             extra_args = []
 
-        path_to_package = posixpath.join(const.HOME_DIR, self._scenario_info["engine"])
+        path_to_package = posixpath.join(const.MODEL_DIR, self._scenario_info["engine"])
         if self._scenario_info["engine"] == "REISE":
             folder = "pyreise"
         else:
@@ -187,13 +187,15 @@ class Execute(State):
             print("Current status: %s" % self._scenario_status)
             return
 
-    def launch_simulation(self):
+    def launch_simulation(self, threads=None):
         """Launches simulation on server.
 
+        :param int/None threads: the number of threads to be used (None -> auto).
         :return: (*subprocess.Popen*) -- new process used to launch simulation.
         """
         print("--> Launching simulation on server")
-        return self._run_script("call.py")
+        extra_args = None if threads is None else [threads]
+        return self._run_script("call.py", extra_args=extra_args)
 
     def extract_simulation_output(self):
         """Extracts simulation outputs {PG, PF, LMP, CONGU, CONGL} on server.


### PR DESCRIPTION
### Purpose

Allow a user to specify the number of threads to use to run a simulation via the Scenario object framework. This is a follow-on to specifying the number of threads in REISE.jl's Julia side (https://github.com/Breakthrough-Energy/REISE.jl/pull/66), and specifying the number of threads in REISE.jl's Python side (https://github.com/Breakthrough-Energy/REISE.jl/pull/67); I believe this PR completes this feature.

### What is the code doing

In `_run_script()`, we add an optional argument `extra_args`, which is either a list of arguments to append after the python call, or `None`. We also break the construction of the long `cmd` list into a few sub-lists so that it's easier to insert the `extra_args`, if they are defined (otherwise we insert `[]`, so no effect when adding lists).

In `launch_simulation()`, we add an optional argument for the number of `threads` to run with. If this argument is supplied, we pass `[threads]` as `extra_args` to `_run_script()`, otherwise we pass `None`.

### Time to review

30 minutes. The code itself is fairly simple, but since this is integral to our scenario run process we want to be sure we think through any unintended side-effects.