### PR TITLE
feat: remove potential whitespace in username

### DIFF
--- a/powersimdata/utility/const.py
+++ b/powersimdata/utility/const.py
@@ -23,7 +23,7 @@ def get_server_user():
     dir_path = os.path.dirname(os.path.realpath(__file__))
     try:
         with open(os.path.join(dir_path, ".server_user")) as f:
-            server_user = f.read()
+            server_user = f.read().strip()
     except FileNotFoundError:
         server_user = os.getlogin()
 


### PR DESCRIPTION
**Background** - When I setup the `.server_user` my editor adds a newline which causes ssh auth failure (using "jhagg\n" vs "jhagg"). Calling `.strip()` removes leading and trailing whitespace in case other folks run into this. After the change, I was able to download a scenario. 

**Time to review** - 2 mins 