### PR TITLE
fix loadzone2state, add loadzone2interconnect

### DIFF
--- a/powersimdata/utility/constants.py
+++ b/powersimdata/utility/constants.py
@@ -291,6 +291,11 @@ interconnect2loadzone = {
     },
 }
 
+# Map loadzone to interconnect
+loadzone2interconnect = {}
+for interconnect, zone_set in interconnect2loadzone.items():
+    loadzone2interconnect.update({zone: interconnect for zone in zone_set})
+
 interconnect2loadzone["USA"] = (
     interconnect2loadzone["Eastern"]
     | interconnect2loadzone["Western"]


### PR DESCRIPTION
### Purpose

Closes https://github.com/Breakthrough-Energy/PowerSimData/issues/225

### What is the code doing

- Removing hard-coded partial dict for `loadzone2state`, adding an auto-generated version.
- Also adding `loadzone2interconnect` (to be used later in PostREISE)

### Time to review

5 minutes.