### PR TITLE
Fix bugs in TransformProfile class

### DIFF
--- a/powersimdata/input/transform_profile.py
+++ b/powersimdata/input/transform_profile.py
@@ -94,13 +94,13 @@ class TransformProfile(object):
         """
         for r in self.scale_keys[resource]:
             if r in self.ct.keys() and "zone_id" in self.ct[r].keys():
-                type_in_zone = self.base_grid.plant.groupby(["zone_id", "type"])
+                type_in_zone = self.base_plant.groupby(["zone_id", "type"])
                 for z, f in self.ct[r]["zone_id"].items():
                     plant_id = type_in_zone.get_group((z, r)).index.tolist()
                     profile.loc[:, plant_id] *= f
-                if r in self.ct.keys() and "plant_id" in self.ct[r].keys():
-                    for i, f in self.ct[r]["plant_id"].items():
-                        profile.loc[:, i] *= f
+            if r in self.ct.keys() and "plant_id" in self.ct[r].keys():
+                for i, f in self.ct[r]["plant_id"].items():
+                    profile.loc[:, i] *= f
 
         return profile
 


### PR DESCRIPTION
### Purpose

Fix a couple bugs in new plant scaling:
- When calculating the scaling factor relative to the neighbor plant, use the unscaled neighbor plant Pmax as the denominator.
- When adding a new plant, do not scale the new plant's profile by the zone scaling factor.
- Allow plants to be scaled by plant_id, even without a zone_id scaling.

### Validation

Using `develop`:
```python
>>> from powersimdata.scenario.scenario import Scenario
>>> scenario = Scenario('708')
[truncated]
>>> scenario.state.get_wind().sum().sum()
--> Loading wind
433748151.2792061
>>> scenario.state.get_solar().sum().sum()
--> Loading solar
240551657.10216737
```

 Using the fix:
```python
>>> from powersimdata.scenario.scenario import Scenario
>>> scenario = Scenario('708')
[truncated]
>>> scenario.state.get_wind().sum().sum()
--> Loading wind
[truncated]
430668463.9902249
>>> scenario.state.get_solar().sum().sum()
--> Loading solar
[truncated]
239461752.33742672
```

### Time to review

15 minutes. We have no tests of the new profile values yet, but we are currently running RenewablesAtRetirements scenarios which need this branch, so I think this is a relatively high priority to fix.