### PR TITLE
Add constants to plant module

### DIFF
--- a/powersimdata/network/usa_tamu/constants/plants.py
+++ b/powersimdata/network/usa_tamu/constants/plants.py
@@ -46,3 +46,28 @@ type2label = {
 }
 
 label2type = {value: key for key, value in type2label.items()}
+
+renewable_resources = {"solar", "wind", "wind_offshore"}
+carbon_resources = {"coal", "ng", "dfo"}
+clean_resources = renewable_resources | {"geothermal", "hydro", "nuclear"}
+all_resources = carbon_resources | {"other"} | clean_resources
+
+
+# MWh to metric tons of CO2
+# Source: IPCC Special Report on Renewable Energy Sources and Climate Change
+# Mitigation (2011), Annex II: Methodology, Table A.II.4, 50th percentile
+# http://www.ipcc-wg3.de/report/IPCC_SRREN_Annex_II.pdf
+carbon_per_mwh = {
+    "coal": 1001,
+    "dfo": 840,
+    "ng": 469,
+}
+
+# MMBTu of fuel per hour to metric tons of CO2 per hour
+# Source: https://www.epa.gov/energy/greenhouse-gases-equivalencies-calculator-calculations-and-references
+# = (Heat rate MMBTu/h) * (kg C/mmbtu) * (mass ratio CO2/C) / (kg to tonnes)
+carbon_per_mmbtu = {
+    "coal": 26.05,
+    "dfo": 20.31,
+    "ng": 14.46,
+}


### PR DESCRIPTION
## Purpose
Add constants for generators. This will be used in ***PostREISE***.

## What is the code doing?
There is no code

## Where to look
I added some `list` of resources in the *powersimdata/network/usa_tamu/constants/plants.py* module. I am open to suggestions if names/location/definition is inappropriate

## Time estimate
2 min