### PR TITLE
chore: add psycopg2 to setup.py

### DIFF
--- a/powersimdata/data_access/scenario_list.py
+++ b/powersimdata/data_access/scenario_list.py
@@ -2,7 +2,6 @@ from powersimdata.data_access.csv_store import CsvStore
 from powersimdata.data_access.sql_store import SqlStore, to_data_frame
 from powersimdata.utility import server_setup
 
-from psycopg2.sql import SQL, Identifier
 import posixpath
 
 

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ install_requires = [
     "paramiko",
     "scipy",
     "tqdm",
+    "psycopg2"
 ]
 
 setup(


### PR DESCRIPTION
### Purpose
Tests in postreise fail due to import errors on psycopg2. Adding to the setup will cause it to be installed.

### What it does
Remove an unused import and add requirement to setup.py. I ran the tests again locally. 

### Time to review
5 min