### PR TITLE
create schema in container automatically

### DIFF
--- a/powersimdata/data_access/README.md
+++ b/powersimdata/data_access/README.md
@@ -8,8 +8,9 @@ Currently, there are csv and sql implementations for the scenario list and
 execute list.
 
 ## Usage
-To try this out, use the `stack.yml` provided in the tests directory to run a
-local instance of postgres, plus an admin ui. The integration tests for the db layer are run against this instance, and you can also connect to it with `psql`, the standard cli tool for interacting with postgres.
+To try this out, use the `stack.yml` to run a local instance of postgres, plus an admin ui. 
+The integration tests for the db layer are run against this instance, and you can also connect to it with `psql`, 
+the standard cli tool for interacting with postgres.
 
 Start the container using the following command, taken from the postgres
 [docs](https://github.com/docker-library/docs/blob/master/postgres/README.md).
@@ -17,18 +18,25 @@ Start the container using the following command, taken from the postgres
 docker-compose -f stack.yml up
 ```
 
-Note - the schema are not automatically created (or part of source control) at this point, so to run the tests you'll need to do this manually. Improvements on this are forthcoming. 
 
 ## Schema creation
-To get a working local database, run the container then do the following:
+When the container starts, it will run the `.sql` files in the mounted volume
+to initialize the database.
+
+To do this manually, run the container then do the following:
 
 ```
 # connect to container, use password from stack.yml
  psql -U postgres -h localhost
 ```
 
-Once in the `psql` shell, you can create the database using `CREATE DATABASE
-psd;` then connect to it with `\c psd`. Make sure there is a file called
-`schema.sql` in your current directory then run `\i schema.sql`. Now if you run
-`\dt` you should see the tables have been created, and should be able to run
-the integration tests. 
+In the psql shell, run `\i sql/schema.sql` (make sure to `cd` to this directory first)
+to create the necessary objects. After this, you should be connected to the `psd` database, 
+and running `\dt` should confirm the tables have been created.
+
+
+## Database management
+At the moment this is kind of a placeholder section. But for anyone interested,
+the stack.yml setup includes a container running an admin ui which can be used to explore the
+containerized db. You can view this at http://localhost:8080 and login using the credentials
+from the file.

--- a/powersimdata/data_access/sql/schema.sql
+++ b/powersimdata/data_access/sql/schema.sql
@@ -1,0 +1,24 @@
+CREATE DATABASE psd;
+\connect psd;
+CREATE TABLE IF NOT EXISTS execute_list(
+  id int primary key not null,
+  status text not null
+);
+CREATE TABLE IF NOT EXISTS scenario_list(
+  id int primary key not null,
+  plan text not null,
+  name text not null,
+  state text not null,
+  interconnect text not null,
+  base_demand text not null,
+  base_hydro text not null,
+  base_solar text not null,
+  base_wind text not null,
+  change_table boolean not null,
+  start_date timestamptz not null,
+  end_date timestamptz not null,
+  interval text not null,
+  engine text not null,
+  runtime text,
+  infeasibilities text
+);

--- a/powersimdata/data_access/stack.yml
+++ b/powersimdata/data_access/stack.yml
@@ -10,6 +10,8 @@ services:
       POSTGRES_PASSWORD: example
     ports:
       - 5432:5432
+    volumes:
+        - ./sql:/docker-entrypoint-initdb.d
 
   adminer:
     image: adminer


### PR DESCRIPTION
### Purpose
Simplify local integration tests by automating schema creation in local db.

### What it does
Add `schema.sql` to git, and mount it in the local db container. Postgres will automatically run the scripts in `/docker-entrypoint-initdb.d` which eliminates the need to any manual db management in this case. 

To test this, I removed the existing containers (`docker-compose -f stack.yml down` and `docker container prune`) then recreated them and logged in using `psql` to verify.

### Time to review
5 min