### PR TITLE
Add dictionaries to zones module

### DIFF
--- a/powersimdata/network/usa_tamu/constants/zones.py
+++ b/powersimdata/network/usa_tamu/constants/zones.py
@@ -368,3 +368,5 @@ for k, v in interconnect2state.items():
         continue
     for s in v:
         state2interconnect[s] = k
+
+loadzone = set(loadzone2interconnect.keys())


### PR DESCRIPTION
## Purpose
Add dictionaries to the zone modules. Those are needed in PostREISE (branch ben/helpers in PostREISE)

## What is the code doing
Very little code. Two dictionaries and one list were created

## Where to look
* `state2abv` dictionary
* `abv2loadzone` dictionary
* `loadzone` set

## Time estimate
2 min