### PR TITLE
refactor: remove unused id2type and type2id

### DIFF
--- a/powersimdata/network/usa_tamu/constants/plants.py
+++ b/powersimdata/network/usa_tamu/constants/plants.py
@@ -1,20 +1,3 @@
-id2type = {
-    0: "wind",
-    1: "solar",
-    2: "hydro",
-    3: "ng",
-    4: "nuclear",
-    5: "coal",
-    6: "geothermal",
-    7: "dfo",
-    8: "biomass",
-    9: "other",
-    10: "storage",
-    11: "wind_offshore",
-}
-
-type2id = {value: key for key, value in id2type.items()}
-
 type2color = {
     "wind": "xkcd:green",
     "solar": "xkcd:amber",

--- a/powersimdata/tests/mock_grid.py
+++ b/powersimdata/tests/mock_grid.py
@@ -182,8 +182,6 @@ class MockGrid(object):
         self.interconnect = None
         self.zone2id = {"zone1": 1, "zone2": 2}
         self.id2zone = {1: "zone1", 2: "zone2"}
-        self.type2id = {}
-        self.id2type = {}
         self.type2color = {}
 
         # Loop through names for grid data frames, add (maybe empty) data


### PR DESCRIPTION
### Purpose

Remove a dictionary that adds no information, so it can be deleted. See Breakthrough-Energy/PowerSimData#288 and https://github.com/Breakthrough-Energy/PostREISE/pull/163.

### Time to review

2 minutes.