### PR TITLE
interconnect to time zone

### DIFF
--- a/powersimdata/network/usa_tamu/constants/zones.py
+++ b/powersimdata/network/usa_tamu/constants/zones.py
@@ -370,3 +370,13 @@ for k, v in interconnect2state.items():
         state2interconnect[s] = k
 
 loadzone = set(loadzone2interconnect.keys())
+
+interconnect2timezone = {
+    "USA": "ETC/GMT+6",
+    "Eastern": "ETC/GMT+5",
+    "Texas": "ETC/GMT+6",
+    "Western": "ETC/GMT+8",
+    "Texas_Western": "ETC/GMT+7",
+    "Texas_Eastern": "ETC/GMT+5",
+    "Eastern_Western": "ETC/GMT+6",
+}


### PR DESCRIPTION
## Purpose
Create a dictionary mapping interconnect to a time zone. This will be useful in *PostREISE* when we want to do plots in local time

## What is the code doing?
There is no code, only a dictionary is declared. Time zones from `pytz` are used. Note that time offset with respect to GMT. The reason is that GMT never changes for  Daylight Saving Time and DST creates a mess when resampling time series. Surprisingly, `GMT+X` in `pytz` corresponds to GMT - Xh.
* GMT+5 is EST;
* GMT+6 is CST;
* GMT+7 is MST;
* GMT+8 is PST.

## Time estimate
2 min. We need to agree on the time zone to use for each interconnect and combination of interconnects.