### PR TITLE
Trigger docs build

### DIFF
--- a/.github/workflows/ci-docs-trigger.yml
+++ b/.github/workflows/ci-docs-trigger.yml
@@ -1,0 +1,19 @@
+name: Update docs
+
+on:
+  push:
+    branches:
+      - develop
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    env:
+      DISPATCH_API: https://api.github.com/repos/Breakthrough-Energy/docs/actions/workflows/2386877/dispatches
+    steps:
+      - name: Trigger docs build
+        run: |
+          curl -XPOST -H "Authorization: token ${{ secrets.CI_TOKEN_CLONE_REPO }}" \
+          -H "Accept: application/vnd.github.v3+json" \
+          -H "Content-Type: application/json" ${{ env.DISPATCH_API }} \
+          --data '{"ref": "refs/heads/master"}'

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -19,7 +19,6 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip tox
-          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
       - name: Start postgres container
         if: ${{ matrix.toxenv == 'pytest-ci' }}
         run: |

--- a/tox.ini
+++ b/tox.ini
@@ -3,9 +3,9 @@ envlist = pytest-local, format
 skipdist = true
 
 [testenv]
-setenv = 
-    CPPFLAGS=-I/usr/local/opt/openssl/include
-    LDFLAGS=-L/usr/local/opt/openssl/lib
+passenv = 
+    CPPFLAGS
+    LDFLAGS
 deps = 
     pytest: pipenv
     {format,checkformatting}: black


### PR DESCRIPTION
### Purpose
Rebuild the docs when we merge to develop. Once we enable publishing in the docs repo, this will also propagate changes to the github pages site. 

### What it does
Call the github api to create a [workflow dispatch](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#workflow_dispatch) event when we merge to develop. Also removed unused line in the action yml, and pass through the env variables in tox.ini to eliminate platform specific values (it's up to users to set these if needed). 

### Time to review
5 min - I tested this by commenting out the branch filter and checking that the workflow was run