### PR TITLE
Allow user to specify that profiles are the same as a previous scenario

### DIFF
--- a/powersimdata/scenario/execute.py
+++ b/powersimdata/scenario/execute.py
@@ -390,13 +390,13 @@ class SimulationInput(object):
             else:
                 self._create_link_to_base_profile(kind)
         else:
-            copy_from_TMP_DIR = posixpath.join(
+            from_dir = posixpath.join(
                 server_setup.EXECUTE_DIR, f"scenario_{profiles_as}"
             )
-            copy_to_TMP_DIR = posixpath.join(
+            to_dir = posixpath.join(
                 server_setup.EXECUTE_DIR, f"scenario_{self._scenario_info['id']}"
             )
-            command = f"cp {copy_from_TMP_DIR}/{p}.csv {copy_to_TMP_DIR}"
+            command = f"cp {from_dir}/{p}.csv {to_dir}"
             stdin, stdout, stderr = self._ssh.exec_command(command)
             if len(stderr.readlines()) != 0:
                 raise IOError(f"Failed to copy {p}.csv on server")


### PR DESCRIPTION
### Purpose

When we're iterating through scenarios with identical renewable capacity/profiles, most of the scenario setup time is in uploading another identical copy of the same profiles to the server. This allows the user to specify 'don't do that, just directly copy them from a given previous scenario'.

### What is the code doing

- In `Execute`, we add a optional parameter to the `prepare_simulation_input` method to specify e.g. `profiles_as=1464`, and we type-check this input.
- In `SimulationInput`, we add an optional parameter to the `prepare_profile` method. If this is given, then we perform a `cp` via the ssh connection, raising an error if the call does not complete successfully.

### Validation

Testing on my local machine & internet connection, this reduces the scenario setup time from 15-20 minutes to 2 minutes. I've tested with the first commit (logic in Execute), but not with the second (logic in SimulationInput).

### Time to review

15 minutes. This is a relatively low priority to merge, since I can run this branch locally and there shouldn't be any downstream effects.