### PR TITLE
fix: typo in delete_entry

### DIFF
--- a/powersimdata/data_access/scenario_list.py
+++ b/powersimdata/data_access/scenario_list.py
@@ -139,4 +139,4 @@ class ScenarioListManager(CsvStore):
         err_message = (
             "Failed to delete entry in %s on server" % server_setup.SCENARIO_LIST
         )
-        _ = self._execute_and_check_err(command, err_messsage)
+        _ = self._execute_and_check_err(command, err_message)


### PR DESCRIPTION
### Purpose

Correct typo introduced in https://github.com/Breakthrough-Energy/PowerSimData/pull/245

### Testing
Before:
```python
>>> from powersimdata.scenario.scenario import Scenario
>>> from powersimdata.scenario.delete import Delete
>>> scenario = Scenario("1546")
SCENARIO: test | new_syntax_auto_extract

--> State
analyze
--> Loading grid
1546_grid.mat not found in C:\Users\DanielOlsen\ScenarioData\ on local machine
Transferring 1546_grid.mat from server
100%|#######################################| 191k/191k [00:00<00:00, 1.13Mb/s]
Loading bus
Loading plant
Loading heat_rate_curve
Loading gencost_before
Loading gencost_after
Loading branch
Loading sub
Loading bus2sub
>>> scenario.change(Delete)
State switching: analyze --> delete
>>> scenario.state.delete_scenario()
--> Deleting entry in /mnt/bes/pcm/ScenarioList.csv on server
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\Users\DanielOlsen\repos\bes\PowerSimData\powersimdata\scenario\delete.py", line 35, in delete_scenario
    self._scenario_list_manager.delete_entry(self._scenario_info)
  File "C:\Users\DanielOlsen\repos\bes\PowerSimData\powersimdata\data_access\scenario_list.py", line 142, in delete_entry
    _ = self._execute_and_check_err(command, err_messsage)
NameError: name 'err_messsage' is not defined
>>> scenario.state.delete_scenario()
--> Deleting entry in /mnt/bes/pcm/ScenarioList.csv on server
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\Users\DanielOlsen\repos\bes\PowerSimData\powersimdata\scenario\delete.py", line 35, in delete_scenario
    self._scenario_list_manager.delete_entry(self._scenario_info)
  File "C:\Users\DanielOlsen\repos\bes\PowerSimData\powersimdata\data_access\scenario_list.py", line 142, in delete_entry
    _ = self._execute_and_check_err(command, err_messsage)
NameError: name 'err_messsage' is not defined
```
After:
```python
>>> from powersimdata.scenario.scenario import Scenario
>>> from powersimdata.scenario.delete import Delete
>>> scenario = Scenario("1546")
SCENARIO: test | new_syntax_auto_extract

--> State
analyze
--> Loading grid
Loading bus
Loading plant
Loading heat_rate_curve
Loading gencost_before
Loading gencost_after
Loading branch
Loading sub
Loading bus2sub
>>> scenario.change(Delete)
State switching: analyze --> delete
>>> scenario.state.delete_scenario()
--> Deleting entry in /mnt/bes/pcm/ScenarioList.csv on server
--> Deleting entry in execute table on server
--> Deleting scenario input data on server
--> Deleting scenario output data on server
--> Deleting temporary folder on server
--> Deleting input and output data on local machine
>>> quit()
```

### Time estimate

10 seconds.