### PR TITLE
Specify grid model when creating scenario

### DIFF
--- a/powersimdata/input/grid.py
+++ b/powersimdata/input/grid.py
@@ -11,7 +11,9 @@ class Grid(object):
     """Grid
 
     :param str/list interconnect: interconnect name(s).
-    :param str source: model used to build the network.
+    :param str source: should be either the name of a grid model within the
+        '*powersimdata/network*' directory or a filename for a '*.mat*' file, which
+        will be interpreted based on the engine which created it.
     :param str engine: engine used to run scenario, if using ScenarioGrid.
     :raises TypeError: if source and engine are not both strings.
     :raises ValueError: if model or engine does not exist.

--- a/powersimdata/scenario/execute.py
+++ b/powersimdata/scenario/execute.py
@@ -40,7 +40,10 @@ class Execute(State):
 
     def _set_ct_and_grid(self):
         """Sets change table and grid."""
-        base_grid = Grid(self._scenario_info["interconnect"].split("_"))
+        base_grid = Grid(
+            self._scenario_info["interconnect"].split("_"),
+            source=self._scenario_info["grid_model"],
+        )
         if self._scenario_info["change_table"] == "Yes":
             input_data = InputData()
             self.ct = input_data.get_data(self._scenario_info, "ct")
@@ -162,8 +165,8 @@ class Execute(State):
     def launch_simulation(self, threads=None, extract_data=True):
         """Launches simulation on server.
 
-        :param int/None threads: the number of threads to be used. This defaults to None,
-            where None means auto.
+        :param int/None threads: the number of threads to be used. This defaults to
+            None, where None means auto.
         :param bool extract_data: whether the results of the simulation engine should
             automatically extracted after the simulation has run. This defaults to True.
         :raises TypeError: if threads is not an int or if extract_data is not a boolean


### PR DESCRIPTION
### Purpose
Set grid model during the building phase of a scenario (#84)

### What the code is doing
A `set_grid_model` method in the `Create` class allows to set the grid model. If not called the `grid_model` key of the `scenario_info` dictionary is set to `usa_tamu`. When the `create scenario` method of the `Create` class is called the `grid_model` field (located between `engine` and `runtime`) in the ***ScenarioList** file will be set.

### Testing
We will create/launch/extract a dummy scenario

### Where to look
* The `powersimdata.scenario.create` module where the `set_grid_model` method can be called and the `scenario_info` dictionary is filled.
* The `powersimdata.scenario.execute` module where the `Grid` class is instantiated using the `grid_model` key of the `scenario_info` dictionary.

### Time estimate
15min. It mirrors what we did to set the engine

### Note
We will have before testing to add a new `grid_model` column to the ***ScenarioList** file and set `usa_tamu` as value for all existing scenario