### PR TITLE
Create mapping between load zone IDs and time zones

### DIFF
--- a/powersimdata/network/usa_tamu/constants/zones.py
+++ b/powersimdata/network/usa_tamu/constants/zones.py
@@ -201,77 +201,9 @@ interconnect2timezone = {
 }
 
 
-# Map time zones to load zone IDs
-# Note: load zones in > 1 time zone are put in the one where most load centers reside
-timezone2id = {
-    "ETC/GMT+5": {
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10,
-        11,
-        12,
-        13,
-        14,
-        15,
-        16,
-        17,
-        18,
-        19,
-        20,
-        22,
-        23,
-        27,
-        28,
-        29,
-        30,
-        31,
-        32,
-        33,
-    },
-    "ETC/GMT+6": {
-        21,
-        24,
-        25,
-        26,
-        34,
-        35,
-        36,
-        37,
-        38,
-        39,
-        40,
-        41,
-        42,
-        43,
-        44,
-        45,
-        47,
-        48,
-        49,
-        50,
-        51,
-        301,
-        302,
-        303,
-        304,
-        305,
-        306,
-        307,
-        308,
-    },
-    "ETC/GMT+7": {46, 52, 209, 210, 211, 212, 213, 214, 215, 216},
-    "ETC/GMT+8": {201, 202, 203, 204, 205, 206, 207, 208},
-}
-
 # Map load zone IDs to time zones
-id2timezone = {}
-for x in timezone2id:
-    for y in timezone2id[x]:
-        id2timezone[y] = x
+# Note: load zones in > 1 time zone are put in the one where most load centers reside
+id2timezone = zone_df["time_zone"].to_dict()
+
+# Map time zones to load zone IDs
+timezone2id = {k: set(v) for k, v in zone_df.groupby("time_zone").groups.items()}

--- a/powersimdata/network/usa_tamu/data/zone.csv
+++ b/powersimdata/network/usa_tamu/data/zone.csv
@@ -1,77 +1,77 @@
-zone_id,zone_name,state,interconnect
-1,Maine,Maine,Eastern
-2,New Hampshire,New Hampshire,Eastern
-3,Vermont,Vermont,Eastern
-4,Massachusetts,Massachusetts,Eastern
-5,Rhode Island,Rhode Island,Eastern
-6,Connecticut,Connecticut,Eastern
-7,New York City,New York,Eastern
-8,Upstate New York,New York,Eastern
-9,New Jersey,New Jersey,Eastern
-10,Pennsylvania Eastern,Pennsylvania,Eastern
-11,Pennsylvania Western,Pennsylvania,Eastern
-12,Delaware,Delaware,Eastern
-13,Maryland,Maryland,Eastern
-14,Virginia Mountains,Virginia,Eastern
-15,Virginia Tidewater,Virginia,Eastern
-16,North Carolina,North Carolina,Eastern
-17,Western North Carolina,North Carolina,Eastern
-18,South Carolina,South Carolina,Eastern
-19,Georgia North,Georgia,Eastern
-20,Georgia South,Georgia,Eastern
-21,Florida Panhandle,Florida,Eastern
-22,Florida North,Florida,Eastern
-23,Florida South,Florida,Eastern
-24,Alabama,Alabama,Eastern
-25,Mississippi,Mississippi,Eastern
-26,Tennessee,Tennessee,Eastern
-27,Kentucky,Kentucky,Eastern
-28,West Virginia,West Virginia,Eastern
-29,Ohio River,Ohio,Eastern
-30,Ohio Lake Erie,Ohio,Eastern
-31,Michigan Northern,Michigan,Eastern
-32,Michigan Southern,Michigan,Eastern
-33,Indiana,Indiana,Eastern
-34,Chicago North Illinois,Illinois,Eastern
-35,Illinois Downstate,Illinois,Eastern
-36,Wisconsin,Wisconsin,Eastern
-37,Minnesota Northern,Minnesota,Eastern
-38,Minnesota Southern,Minnesota,Eastern
-39,Iowa,Iowa,Eastern
-40,Missouri East,Missouri,Eastern
-41,Missouri West,Missouri,Eastern
-42,Arkansas,Arkansas,Eastern
-43,Louisiana,Louisiana,Eastern
-44,East Texas,Texas,Eastern
-45,Texas Panhandle,Texas,Eastern
-46,New Mexico Eastern,New Mexico,Eastern
-47,Oklahoma,Oklahoma,Eastern
-48,Kansas,Kansas,Eastern
-49,Nebraska,Nebraska,Eastern
-50,South Dakota,South Dakota,Eastern
-51,North Dakota,North Dakota,Eastern
-52,Montana Eastern,Montana,Eastern
-201,Washington,Washington,Western
-202,Oregon,Oregon,Western
-203,Northern California,California,Western
-204,Bay Area,California,Western
-205,Central California,California,Western
-206,Southwest California,California,Western
-207,Southeast California,California,Western
-208,Nevada,Nevada,Western
-209,Arizona,Arizona,Western
-210,Utah,Utah,Western
-211,New Mexico Western,New Mexico,Western
-212,Colorado,Colorado,Western
-213,Wyoming,Wyoming,Western
-214,Idaho,Idaho,Western
-215,Montana Western,Montana,Western
-216,El Paso,Texas,Western
-301,Far West,Texas,Texas
-302,North,Texas,Texas
-303,West,Texas,Texas
-304,South,Texas,Texas
-305,North Central,Texas,Texas
-306,South Central,Texas,Texas
-307,Coast,Texas,Texas
-308,East,Texas,Texas
+zone_id,zone_name,state,interconnect,time_zone
+1,Maine,Maine,Eastern,ETC/GMT+5
+2,New Hampshire,New Hampshire,Eastern,ETC/GMT+5
+3,Vermont,Vermont,Eastern,ETC/GMT+5
+4,Massachusetts,Massachusetts,Eastern,ETC/GMT+5
+5,Rhode Island,Rhode Island,Eastern,ETC/GMT+5
+6,Connecticut,Connecticut,Eastern,ETC/GMT+5
+7,New York City,New York,Eastern,ETC/GMT+5
+8,Upstate New York,New York,Eastern,ETC/GMT+5
+9,New Jersey,New Jersey,Eastern,ETC/GMT+5
+10,Pennsylvania Eastern,Pennsylvania,Eastern,ETC/GMT+5
+11,Pennsylvania Western,Pennsylvania,Eastern,ETC/GMT+5
+12,Delaware,Delaware,Eastern,ETC/GMT+5
+13,Maryland,Maryland,Eastern,ETC/GMT+5
+14,Virginia Mountains,Virginia,Eastern,ETC/GMT+5
+15,Virginia Tidewater,Virginia,Eastern,ETC/GMT+5
+16,North Carolina,North Carolina,Eastern,ETC/GMT+5
+17,Western North Carolina,North Carolina,Eastern,ETC/GMT+5
+18,South Carolina,South Carolina,Eastern,ETC/GMT+5
+19,Georgia North,Georgia,Eastern,ETC/GMT+5
+20,Georgia South,Georgia,Eastern,ETC/GMT+5
+21,Florida Panhandle,Florida,Eastern,ETC/GMT+6
+22,Florida North,Florida,Eastern,ETC/GMT+5
+23,Florida South,Florida,Eastern,ETC/GMT+5
+24,Alabama,Alabama,Eastern,ETC/GMT+6
+25,Mississippi,Mississippi,Eastern,ETC/GMT+6
+26,Tennessee,Tennessee,Eastern,ETC/GMT+6
+27,Kentucky,Kentucky,Eastern,ETC/GMT+5
+28,West Virginia,West Virginia,Eastern,ETC/GMT+5
+29,Ohio River,Ohio,Eastern,ETC/GMT+5
+30,Ohio Lake Erie,Ohio,Eastern,ETC/GMT+5
+31,Michigan Northern,Michigan,Eastern,ETC/GMT+5
+32,Michigan Southern,Michigan,Eastern,ETC/GMT+5
+33,Indiana,Indiana,Eastern,ETC/GMT+5
+34,Chicago North Illinois,Illinois,Eastern,ETC/GMT+6
+35,Illinois Downstate,Illinois,Eastern,ETC/GMT+6
+36,Wisconsin,Wisconsin,Eastern,ETC/GMT+6
+37,Minnesota Northern,Minnesota,Eastern,ETC/GMT+6
+38,Minnesota Southern,Minnesota,Eastern,ETC/GMT+6
+39,Iowa,Iowa,Eastern,ETC/GMT+6
+40,Missouri East,Missouri,Eastern,ETC/GMT+6
+41,Missouri West,Missouri,Eastern,ETC/GMT+6
+42,Arkansas,Arkansas,Eastern,ETC/GMT+6
+43,Louisiana,Louisiana,Eastern,ETC/GMT+6
+44,East Texas,Texas,Eastern,ETC/GMT+6
+45,Texas Panhandle,Texas,Eastern,ETC/GMT+6
+46,New Mexico Eastern,New Mexico,Eastern,ETC/GMT+7
+47,Oklahoma,Oklahoma,Eastern,ETC/GMT+6
+48,Kansas,Kansas,Eastern,ETC/GMT+6
+49,Nebraska,Nebraska,Eastern,ETC/GMT+6
+50,South Dakota,South Dakota,Eastern,ETC/GMT+6
+51,North Dakota,North Dakota,Eastern,ETC/GMT+6
+52,Montana Eastern,Montana,Eastern,ETC/GMT+7
+201,Washington,Washington,Western,ETC/GMT+8
+202,Oregon,Oregon,Western,ETC/GMT+8
+203,Northern California,California,Western,ETC/GMT+8
+204,Bay Area,California,Western,ETC/GMT+8
+205,Central California,California,Western,ETC/GMT+8
+206,Southwest California,California,Western,ETC/GMT+8
+207,Southeast California,California,Western,ETC/GMT+8
+208,Nevada,Nevada,Western,ETC/GMT+8
+209,Arizona,Arizona,Western,ETC/GMT+7
+210,Utah,Utah,Western,ETC/GMT+7
+211,New Mexico Western,New Mexico,Western,ETC/GMT+7
+212,Colorado,Colorado,Western,ETC/GMT+7
+213,Wyoming,Wyoming,Western,ETC/GMT+7
+214,Idaho,Idaho,Western,ETC/GMT+7
+215,Montana Western,Montana,Western,ETC/GMT+7
+216,El Paso,Texas,Western,ETC/GMT+7
+301,Far West,Texas,Texas,ETC/GMT+6
+302,North,Texas,Texas,ETC/GMT+6
+303,West,Texas,Texas,ETC/GMT+6
+304,South,Texas,Texas,ETC/GMT+6
+305,North Central,Texas,Texas,ETC/GMT+6
+306,South Central,Texas,Texas,ETC/GMT+6
+307,Coast,Texas,Texas,ETC/GMT+6
+308,East,Texas,Texas,ETC/GMT+6


### PR DESCRIPTION
### Purpose
Create a means to map load zone IDs to time zones.

### What the code is doing
Two dictionaries are created: one that maps time zones to load zone IDs and another that maps load zone IDs to time zones. The mappings were created manually. Most of the time zone to load zone ID mappings were simple (i.e., the load zone resided entirely in one time zone). Other mappings were less straightforward, especially for load zones that were in multiple time zones. The most notable of these were NE, SD, TN, and KY. Since each of these states were single load zones, I could only assign them to one time zone. In this case, I assigned the load zones to the time zone in which the majority of their load centers reside. This meant that NE (Omaha and Lincoln), SD (Sioux Falls), and TN (Nashville and Memphis) were placed in the Central time zone and KY (Louisville and Lexington) was placed in the Eastern time zone. States that had more load zones, such as TX and FL, benefitted from the mapping because load zones like El Paso, TX and the Florida Panhandle were able to be correctly attributed to their proper time zones (Mountain Time and Central Time, respectively) rather than the time zones used for the majority of their states.

### Testing
I don't believe any rigorous testing is necessary. I tested the mappings to make sure the code worked as intended.

### Where to look
This new code is in: `PowerSimData/powersimdata/network/usa_tamu/constants/zones.py`

### Usage Example/Visuals
These mappings will be used in the NREL Electrification Futures Study modules I'm working on in `PreREISE`. The state-level data is labeled with local hour IDs (i.e., integers from 1 through 8760), so I need to be able to shift the data according to UTC time.

### Time estimate
I imagine this should be quick. Probably only a couple minutes.