### PR TITLE
Grid equality bugfix (storage) and print improvement

### DIFF
--- a/powersimdata/input/grid.py
+++ b/powersimdata/input/grid.py
@@ -100,35 +100,26 @@ class Grid(object):
         _univ_eq(self.gencost["before"], other.gencost["before"], "gencost")
 
         # compare storage
-        self_storage_num = len(self.storage["gencost"])
-        other_storage_num = len(other.storage["gencost"])
-        if self_storage_num == 0:
-            _univ_eq(other_storage_num, 0, "storage")
-        else:
-            # These are dicts, so we need to go one level deeper
-            self_keys = self.storage.keys()
-            other_keys = other.storage.keys()
-            _univ_eq(self_keys, other_keys, "storage")
-            ignored_subkeys = {
-                "duration",
-                "min_stor",
-                "max_stor",
-                "InEff",
-                "OutEff",
-                "energy_price",
-            }
-            for subkey in self_keys:
-                if subkey in ignored_subkeys:
-                    continue
-                # REISE will modify gencost and some gen columns
-                if subkey != "gencost":
-                    self_data = self.storage[subkey]
-                    other_data = other.storage[subkey]
-                    if subkey == "gen":
-                        excluded_cols = ["ramp_10", "ramp_30"]
-                        self_data = self_data.drop(excluded_cols, axis=1)
-                        other_data = other_data.drop(excluded_cols, axis=1)
-                    _univ_eq(self_data, other_data, "storage")
+        _univ_eq(len(self.storage["gen"]), len(other.storage["gen"]), "storage")
+        _univ_eq(self.storage.keys(), other.storage.keys(), "storage")
+        ignored_subkeys = {
+            "duration",
+            "min_stor",
+            "max_stor",
+            "InEff",
+            "OutEff",
+            "energy_price",
+            "gencost",
+        }
+        for subkey in set(self.storage.keys()) - ignored_subkeys:
+            # REISE will modify some gen columns
+            self_data = self.storage[subkey]
+            other_data = other.storage[subkey]
+            if subkey == "gen":
+                excluded_cols = ["ramp_10", "ramp_30"]
+                self_data = self_data.drop(excluded_cols, axis=1)
+                other_data = other_data.drop(excluded_cols, axis=1)
+            _univ_eq(self_data, other_data, "storage")
 
         # compare bus
         # MOST changes BUS_TYPE for buses with DC Lines attached


### PR DESCRIPTION
### Purpose
- Ensure that grid equality works when comparing a `TAMU` grid with storage and a `MATReader` grid with storage.
- Stop printing that the grids can't be compared when really they've been found to be unequal (see https://github.com/Breakthrough-Energy/RenewableEnergyProject/issues/325#issuecomment-747871206)

### What the code is doing
- The `ignored_subkeys` are defined as a part of an `AbstractGrid`, and given default values in a `TAMU` grid. The values are used when producing storage table entries, but are not used after that. When we load a `MATReader` grid, we load the storage table entries, but we don't load these default values; and we shouldn't load from `usa_tamu_model.py`, because a `MATReader` is not necessarily a `TAMU` grid. So, when we compare Grids, we want to ignore these, since the real data to compare is in the tables, which are compared.
- We remove the print, and use `except Exception:` rather than `except:` on the advice of https://www.flake8rules.com/rules/E722.html (which is the complaint that pops up on a bare `except:`).

### Testing
To be added.

### Time estimate
2 minutes.