### PR TITLE
update color and label dictionaries to include default values for curtailments

### DIFF
--- a/powersimdata/network/usa_tamu/constants/plants.py
+++ b/powersimdata/network/usa_tamu/constants/plants.py
@@ -31,12 +31,13 @@ type2label = {
     "storage": "Storage",
     "solar_curtailment": "Solar Curtailment",
     "wind_curtailment": "Wind Curtailment",
-    "wind_offshore_curtailment": "Wind Offshore Curtailment",
+    "wind_offshore_curtailment": "Offshore Wind Curtailment",
 }
 
 type2hatchcolor = {
     "solar_curtailment": "xkcd:grey",
     "wind_curtailment": "xkcd:grey",
+    "wind_offshore_curtailment": "xkcd:grey",
 }
 
 label2type = {value: key for key, value in type2label.items()}


### PR DESCRIPTION
[Pull Request Etiquette doc](https://github.com/Breakthrough-Energy/REISE/wiki/Pull-Request-Etiquette)

### Purpose
This change mainly serves `analyze_pg` refactor in PostREISE. Specifically for time series generation stack plot, previously we import `type2label` and `type2color` dicts and add these missing entries with hardcoded values in the plot function. After the refactor, the plot function generates the figure with default values in these updated dicts and provides optional parameters for the user to overwrite colors and/or labels for a subset of entires in the dicts. The new plot function should work properly with default values without user specified parameters.

### What the code is doing
Add a few new entries to the existing static dictionaries.

### Where to look
/powersimdata/network/usa_tamu/constants/plants.py

### Time estimate
2min