### PR TITLE
fix: add requests to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ install_requires = [
     "scipy",
     "tqdm",
     "psycopg2",
+    "requests",
 ]
 
 setup(


### PR DESCRIPTION
### Purpose
We need requests to be installed in dependent packages.

### What the code is doing
Package is added to setup.py

### Testing
Regenerated Pipfile.lock in postreise and check that it picks up the new package

### Time estimate
1 min