### PR TITLE
fix: get newer pipenv and fix installation in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 FROM python:3.8.3
 
-RUN apt-get update && apt-get install -y pipenv
+RUN apt-get update
 
 WORKDIR /app
 COPY Pipfile .
 COPY Pipfile.lock .
-RUN pipenv install --dev --system; \
-    pip install -U pip ipython; \
+RUN pip install -U pip pipenv ipython; \
+    pipenv sync --dev --system; \
     pip install jedi==0.17.2
 
 COPY . .


### PR DESCRIPTION
### Purpose
Use pip to install pipenv which gets a newer version that has the `--system` option on `pipenv sync`. This is used to install directly from the lock file outside a virtualenv. 

### What the code is doing
Updated docker build steps.

### Testing
Ran the build with `--no-cache`, got some slightly misleading output but upon running a shell in the container I found that the packages are installed correctly. 

### Time estimate
3 min