### PR TITLE
test: remove index column from test assertion

### DIFF
--- a/powersimdata/data_access/tests/test_execute_csv.py
+++ b/powersimdata/data_access/tests/test_execute_csv.py
@@ -37,5 +37,5 @@ def test_get_execute_file_from_server_type(execute_table):
 @pytest.mark.integration
 @pytest.mark.ssh
 def test_get_execute_file_from_server_header(execute_table):
-    header = ["id", "status"]
+    header = ["status"]
     assert_array_equal(execute_table.columns, header)

--- a/powersimdata/data_access/tests/test_execute_csv.py
+++ b/powersimdata/data_access/tests/test_execute_csv.py
@@ -39,3 +39,4 @@ def test_get_execute_file_from_server_type(execute_table):
 def test_get_execute_file_from_server_header(execute_table):
     header = ["status"]
     assert_array_equal(execute_table.columns, header)
+    assert "id" == execute_table.index.name

--- a/powersimdata/data_access/tests/test_scenario_csv.py
+++ b/powersimdata/data_access/tests/test_scenario_csv.py
@@ -47,6 +47,7 @@ def test_get_scenario_file_from_server_header(data_access, scenario_table):
         "infeasibilities",
     ]
     assert_array_equal(scenario_table.columns, header)
+    assert "id" == scenario_table.index.name
 
 
 @pytest.mark.integration

--- a/powersimdata/data_access/tests/test_scenario_csv.py
+++ b/powersimdata/data_access/tests/test_scenario_csv.py
@@ -30,7 +30,6 @@ def test_get_scenario_file_from_server_type(data_access, scenario_table):
 @pytest.mark.ssh
 def test_get_scenario_file_from_server_header(data_access, scenario_table):
     header = [
-        "id",
         "plan",
         "name",
         "state",


### PR DESCRIPTION
### Purpose
Fix failing integration test - id column is now an index, so isn't in the `.columns` attribute. Code changes were introduced in #365

### What the code is doing
Updated the expected list of column headers

### Testing
Ran `pytest -m "not db"` locally

### Time estimate
2 min