### PR TITLE
fix: change caught Exception for get_load_shed

### DIFF
--- a/powersimdata/scenario/analyze.py
+++ b/powersimdata/scenario/analyze.py
@@ -216,7 +216,8 @@ class Analyze(State):
             load_shed = construct_load_shed(self._scenario_info, grid, infeasibilities)
 
             filename = scenario_id + "_LOAD_SHED.pkl"
-            filepath = os.path.join(server_setup.LOCAL_DIR, filename)
+            output_dir = server_setup.OUTPUT_DIR
+            filepath = os.path.join(server_setup.LOCAL_DIR, output_dir, filename)
             with open(filepath, "wb") as f:
                 pickle.dump(load_shed, f)
 

--- a/powersimdata/scenario/analyze.py
+++ b/powersimdata/scenario/analyze.py
@@ -209,7 +209,7 @@ class Analyze(State):
             # It's either on the server or in our local ScenarioData folder
             output_data = OutputData(data_loc=self.data_loc)
             load_shed = output_data.get_data(scenario_id, "LOAD_SHED")
-        except FileNotFoundError:
+        except OSError:
             # The scenario was run without load_shed, and we must construct it
             grid = self.get_grid()
             infeasibilities = self._parse_infeasibilities()


### PR DESCRIPTION
### Purpose
Restore previous functionality when calling `scenario.state.get_load_shed()` on a scenario with no load shed.

### What the code is doing
Change which Exception triggers the construction of an empty load_shed data frame.

### Testing
Can be verified by calling `Scenario(1861).state.get_load_shed()` before and after.

### Time estimate
2 minutes.