### PR TITLE
Update scenario status

### DIFF
--- a/powersimdata/scenario/execute.py
+++ b/powersimdata/scenario/execute.py
@@ -169,6 +169,7 @@ class Execute(State):
 
         :raises ValueError: if status is invalid
         """
+        self._update_scenario_status()
         valid_status = ["prepared", "failed", "finished"]
         if self._scenario_status not in valid_status:
             raise ValueError(


### PR DESCRIPTION
### Purpose
Update scenario status before launching a simulation.

### What the code is doing
Update the `_scenario_status` attribute of the `Execute`.

### Where to look
The `_update_scenario_status` method is invoked in the `_check_if_ready` method which, in turn, is invoked in the `launch_simulation` method

### Time estimate
2 min