### PR TITLE
Set keyword value

### DIFF
--- a/powersimdata/design/investment/investment_costs.py
+++ b/powersimdata/design/investment/investment_costs.py
@@ -368,8 +368,8 @@ def _calculate_gen_inv_costs(grid_new, year, cost_case, sum_results=True):
         cost.drop(cost[cost["value"] == "#REF!"].index, inplace=True)
 
         # get rid of $s, commas
-        cost["value"] = cost["value"].str.replace("$", "")
-        cost["value"] = cost["value"].str.replace(",", "").astype("float64")
+        cost["value"] = cost["value"].str.replace("$", "", regex=True)
+        cost["value"] = cost["value"].str.replace(",", "", regex=True).astype("float64")
         # scale from $/kW to $/MW
         cost["value"] *= 1000
 


### PR DESCRIPTION
### Purpose
A FutureWarning is raised when running the tests:
```
powersimdata/design/investment/tests/test_investment_costs.py::test_calculate_gen_inv_costs_2030
  /Users/brdo/CEM/PowerSimData/powersimdata/design/investment/investment_costs.py:371: FutureWarning: The default value of regex will change from True to False in a future version. In addition, single character regular expressions will*not* be treated as literal strings when regex=True.
    cost["value"] = cost["value"].str.replace("$", "")
```
I have set the `regex` parameter to `True` in the `replace` method (current default value) to avoid any surprise when we update pandas.

### Testing
No more warning when running `pytest`

### Where to look
The optional parameter `regex` is set to `True`, which is the current default value

### Time estimate
2 min