### PR TITLE
Load and transform US normalized profiles

### DIFF
--- a/powersimdata/input/input_data.py
+++ b/powersimdata/input/input_data.py
@@ -1,9 +1,9 @@
 import os
+import posixpath
 
 import pandas as pd
 
 from powersimdata.data_access.context import Context
-from powersimdata.scenario.helpers import interconnect2name
 from powersimdata.utility import server_setup
 from powersimdata.utility.helpers import MemoryCache, cache_key
 
@@ -59,10 +59,11 @@ class InputData(object):
         ext = self.file_extension[field_name]
 
         if field_name in ["demand", "hydro", "solar", "wind"]:
-            interconnect = interconnect2name(scenario_info["interconnect"].split("_"))
             version = scenario_info["base_" + field_name]
-            file_name = interconnect + "_" + field_name + "_" + version + "." + ext
-            from_dir = server_setup.BASE_PROFILE_DIR
+            file_name = field_name + "_" + version + "." + ext
+            from_dir = posixpath.join(
+                server_setup.BASE_PROFILE_DIR, scenario_info["grid_model"]
+            )
         else:
             file_name = scenario_info["id"] + "_" + field_name + "." + ext
             from_dir = server_setup.INPUT_DIR

--- a/powersimdata/input/transform_profile.py
+++ b/powersimdata/input/transform_profile.py
@@ -1,111 +1,109 @@
 import copy
 
-from powersimdata.input.grid import Grid
 from powersimdata.input.input_data import InputData
 
 
 class TransformProfile(object):
-    """Transforms profile according to operations listed in change table."""
+    """Transform profile according to operations listed in change table."""
 
     def __init__(self, scenario_info, grid, ct):
-        """Constructor
+        """Constructor.
 
         :param dict scenario_info: scenario information.
-        :param powersimdata.input.grid.Grid grid: a Grid object.
+        :param powersimdata.input.grid.Grid grid: a Grid object previously
+            transformed.
         :param dict ct: change table.
         """
         self._input_data = InputData()
         self.scenario_info = scenario_info
-        self.grid = copy.deepcopy(grid)
+
         self.ct = copy.deepcopy(ct)
+        self.grid = copy.deepcopy(grid)
+
         self.scale_keys = {
             "wind": {"wind", "wind_offshore"},
             "solar": {"solar"},
             "hydro": {"hydro"},
             "demand": {"demand"},
         }
-        self.n_new_plant = (
-            0 if "new_plant" not in self.ct.keys() else len(self.ct["new_plant"])
-        )
-        self.base_plant = Grid(self.grid.interconnect).plant
+        self.n_new_plant, self.n_new_clean_plant = self._get_number_of_new_plant()
+
+    def _get_number_of_new_plant(self):
+        """Return the total number of new plant and new plant with profiles.
+
+        :return: (*tuple*) -- first element is the total number of new plant and second
+            element is the total number of new clean plant (*hydro*, *solar*,
+            *onshore wind* and *offshore wind*).
+        """
+        n_plant = [0, 0]
+        if "new_plant" in self.ct.keys():
+            for p in self.ct["new_plant"]:
+                n_plant[0] += 1
+                if p["type"] in set().union(*self.scale_keys.values()):
+                    n_plant[1] += 1
+        return n_plant
 
     def _get_renewable_profile(self, resource):
-        """Returns the transformed grid.
+        """Return the transformed profile.
 
         :param str resource: *'hydro'*, *'solar'* or *'wind'*.
-        :return: (*pandas.DataFrame*) -- power output for generators of
-            specified type with plant identification number  as columns and
-            UTC timestamp as index.
+        :return: (*pandas.DataFrame*) -- power output for generators of specified type
+            with plant identification number as columns and UTC timestamp as indices.
         """
-        power_output = self._input_data.get_data(self.scenario_info, resource)
-        if not bool(self.ct):
-            return power_output
+        plant_id = (
+            self.grid.plant.iloc[: len(self.grid.plant) - self.n_new_plant]
+            .isin(self.scale_keys[resource])
+            .query("type == True")
+            .index
+        )
+
+        profile = self._input_data.get_data(self.scenario_info, resource)[plant_id]
+        scaled_profile = self._scale_plant_profile(profile)
+
+        if self.n_new_clean_plant > 0:
+            new_profile = self._add_plant_profile(profile, resource)
+            return scaled_profile.join(new_profile)
         else:
-            if self.n_new_plant > 0:
-                power_output = self._add_plant_profile(power_output, resource)
-            if resource in self.ct.keys():
-                power_output = self._scale_plant_profile(power_output, resource)
-            return power_output
+            return scaled_profile
+
+    def _scale_plant_profile(self, profile):
+        """Scale profile.
+
+        :param pandas.DataFrame profile: profile with plant identification number as
+            columns and UTC timestamp as indices. Values are for 1-W generators.
+        :return: (*pandas.DataFrame*) -- scaled power output profile.
+        """
+        plant_id = list(map(int, profile.columns))
+        return profile * self.grid.plant.loc[plant_id, "Pmax"]
 
     def _add_plant_profile(self, profile, resource):
-        """Add power output profile for plants added via the change table.
+        """Add profile for plants added via the change table.
 
-        :param pandas.DataFrame profile: power output profile with plant
-            identification number as columns and UTC timestamp as index.
+        :param pandas.DataFrame profile: profile with plant identification number as
+            columns and UTC timestamp as indices.
         :param resource: fuel type.
-        :return: (*pandas.DataFrame*) -- power output profile with additional
-            columns corresponding to new generators inserted to the grid via
-            the change table.
+        :return: (*pandas.DataFrame*) -- profile with additional columns corresponding
+            to new generators inserted to the grid via the change table.
         """
         new_plant_ids, neighbor_ids, scaling = [], [], []
         for i, entry in enumerate(self.ct["new_plant"]):
             if entry["type"] in self.scale_keys[resource]:
-                new_plant_id = self.grid.plant.index[-self.n_new_plant + i]
-                new_plant_ids.append(new_plant_id)
-                neighbor_id = entry["plant_id_neighbor"]
-                neighbor_ids.append(neighbor_id)
-                scaling.append(entry["Pmax"] / self.base_plant.loc[neighbor_id, "Pmax"])
+                new_plant_ids.append(self.grid.plant.index[-self.n_new_plant + i])
+                neighbor_ids.append(entry["plant_id_neighbor"])
+                scaling.append(entry["Pmax"])
 
-        if len(new_plant_ids) > 0:
-            neighbor_profiles = profile[neighbor_ids]
-            new_profiles = neighbor_profiles.multiply(scaling, axis=1)
-            new_profiles.columns = new_plant_ids
-            joined_profiles = profile.join(new_profiles)
-            return joined_profiles
-        else:
-            return profile
-
-    def _scale_plant_profile(self, profile, resource):
-        """Scales power output according to change table.
-
-        :param pandas.DataFrame profile: power output profile with plant
-            identification number as columns and UTC timestamp as index.
-        :param resource: fuel type.
-        :return: (*pandas.DataFrame*) -- scaled power output profile.
-        """
-        for r in self.scale_keys[resource]:
-            if r in self.ct.keys() and "zone_id" in self.ct[r].keys():
-                if self.n_new_plant > 0:
-                    type_in_zone = self.grid.plant[: -self.n_new_plant].groupby(
-                        ["zone_id", "type"]
-                    )
-                else:
-                    type_in_zone = self.grid.plant.groupby(["zone_id", "type"])
-                for z, f in self.ct[r]["zone_id"].items():
-                    plant_id = type_in_zone.get_group((z, r)).index.tolist()
-                    profile.loc[:, plant_id] *= f
-            if r in self.ct.keys() and "plant_id" in self.ct[r].keys():
-                for i, f in self.ct[r]["plant_id"].items():
-                    profile.loc[:, i] *= f
-
-        return profile
+        neighbor_profile = profile[neighbor_ids]
+        new_profile = neighbor_profile.multiply(scaling, axis=1)
+        new_profile.columns = new_plant_ids
+        return new_profile
 
     def _get_demand_profile(self):
-        """Returns scaled demand profile.
+        """Return scaled demand profile.
 
         :return: (*pandas.DataFrame*) -- data frame of demand.
         """
-        demand = self._input_data.get_data(self.scenario_info, "demand")
+        zone_id = sorted(self.grid.bus.zone_id.unique())
+        demand = self._input_data.get_data(self.scenario_info, "demand")[zone_id]
         if bool(self.ct) and "demand" in list(self.ct.keys()):
             for key, value in self.ct["demand"]["zone_id"].items():
                 print(
@@ -116,7 +114,7 @@ class TransformProfile(object):
         return demand
 
     def get_profile(self, name):
-        """Returns profile.
+        """Return profile.
 
         :param str name: either *'demand'*, *'hydro'*, *'solar'*, *'wind'*.
         :return: (*pandas.DataFrame*) -- profile.

--- a/powersimdata/network/usa_tamu/constants/zones.py
+++ b/powersimdata/network/usa_tamu/constants/zones.py
@@ -85,7 +85,11 @@ interconnect2loadzone["USA"] = (
     | interconnect2loadzone["Western"]
     | interconnect2loadzone["Texas"]
 )
-
+# Map interconnect to load zone id
+interconnect2id = {
+    k: set(zone_df.isin(v).query("zone_name == True").index)
+    for k, v in interconnect2loadzone.items()
+}
 
 # Map load zone id to state abbreviations
 id2abv = {k: state2abv[v] for k, v in zone_df.state.to_dict().items()}


### PR DESCRIPTION
### Purpose
Use the newly constructed profiles:
* ***demand_vJan2021.csv***
* ***hydro_vJan2021.csv***
* ***solar_vJan2021.csv***
* ***wind_vJan2021.csv***
The power output in these profiles are now normalized (independent of the `Pmax` of the generator) and enclose, for each fuel type, all the generator in the US grid.

### What the code is doing
* Modify the `InputData` class to fetch the new profile located in **raw/GRID_MODEL*** where ***GRID_MODEL*** indicates the grid model, e.g., `usa_tamu`.
* Add a new dictionary in the `powersimdata.network.usa_tamu.constants.zones` to map interconnect to load zone id
* Refactor the `TransformProfile` class and the associated tests

### Testing
run `pytest -v powersimdata/input/tests/test_transform_profile.py`. All the new profiles will be downloaded from the server the first time you run the tests. 

### Where to look
The core of the changes is located in `powersimdata/input/transform_profile`

### Time estimate
30min