### PR TITLE
feat: let user specify more parameters for storage

### DIFF
--- a/powersimdata/input/abstract_grid.py
+++ b/powersimdata/input/abstract_grid.py
@@ -82,6 +82,9 @@ def storage_template():
         "max_stor": None,  # ratio
         "InEff": None,
         "OutEff": None,
+        "LossFactor": None,  # stored energy fraction / hour
         "energy_price": None,  # $/MWh
+        "terminal_min": None,
+        "terminal_max": None,
     }
     return storage

--- a/powersimdata/input/grid.py
+++ b/powersimdata/input/grid.py
@@ -1,6 +1,7 @@
 import os
 
 from powersimdata.input.scenario_grid import FromREISE, FromREISEjl
+from powersimdata.network.usa_tamu.constants import storage as tamu_storage
 from powersimdata.network.usa_tamu.usa_tamu_model import TAMU
 from powersimdata.utility.helpers import MemoryCache, cache_key
 
@@ -102,15 +103,7 @@ class Grid(object):
         # compare storage
         _univ_eq(len(self.storage["gen"]), len(other.storage["gen"]), "storage")
         _univ_eq(self.storage.keys(), other.storage.keys(), "storage")
-        ignored_subkeys = {
-            "duration",
-            "min_stor",
-            "max_stor",
-            "InEff",
-            "OutEff",
-            "energy_price",
-            "gencost",
-        }
+        ignored_subkeys = {"gencost"} | set(tamu_storage.defaults.keys())
         for subkey in set(self.storage.keys()) - ignored_subkeys:
             # REISE will modify some gen columns
             self_data = self.storage[subkey]

--- a/powersimdata/input/tests/test_change_table.py
+++ b/powersimdata/input/tests/test_change_table.py
@@ -422,7 +422,7 @@ def test_add_bus_bad_type(ct):
 
 
 def test_add_new_elements_at_new_buses(ct):
-    max_existing_index = grid.bus.index.max()
+    max_existing_index = int(grid.bus.index.max())
     new_buses = [
         {"lat": 40, "lon": 50.5, "zone_id": 2, "baseKV": 69},
         {"lat": -40.5, "lon": -50, "zone_name": "Massachusetts", "Pd": 10},
@@ -430,7 +430,7 @@ def test_add_new_elements_at_new_buses(ct):
     ct.add_bus(new_buses)
     new_bus1 = max_existing_index + 1
     new_bus2 = max_existing_index + 2
-    ct.add_storage_capacity(bus_id={new_bus1: 100})
+    ct.add_storage_capacity([{"bus_id": new_bus1, "capacity": 100}])
     ct.add_dcline([{"from_bus_id": new_bus1, "to_bus_id": new_bus2, "capacity": 200}])
     ct.add_branch([{"from_bus_id": new_bus1, "to_bus_id": new_bus2, "capacity": 300}])
     ct.add_plant([{"type": "wind", "bus_id": new_bus2, "Pmax": 400}])

--- a/powersimdata/input/tests/test_transform_grid.py
+++ b/powersimdata/input/tests/test_transform_grid.py
@@ -489,7 +489,11 @@ def test_add_gen_add_entries_in_gencost_data_frame(ct):
 
 
 def test_add_storage(ct):
-    storage = {2021005: 116.0, 2028827: 82.5, 2028060: 82.5}
+    storage = [
+        {"bus_id": 2021005, "capacity": 116.0},
+        {"bus_id": 2028827, "capacity": 82.5},
+        {"bus_id": 2028060, "capacity": 82.5},
+    ]
     ct.add_storage_capacity(storage)
     new_grid = TransformGrid(grid, ct.ct).get_grid()
 
@@ -497,8 +501,8 @@ def test_add_storage(ct):
     pmax = new_grid.storage["gen"].Pmax.values
 
     assert new_grid.storage["gen"].shape[0] != grid.storage["gen"].shape[0]
-    assert np.array_equal(pmin, -1 * np.array(list(storage.values())))
-    assert np.array_equal(pmax, np.array(list(storage.values())))
+    assert np.array_equal(pmin, -1 * np.array([d["capacity"] for d in storage]))
+    assert np.array_equal(pmax, np.array([d["capacity"] for d in storage]))
 
 
 def test_add_bus(ct):

--- a/powersimdata/input/transform_grid.py
+++ b/powersimdata/input/transform_grid.py
@@ -356,7 +356,7 @@ class TransformGrid(object):
 
     def _add_storage(self):
         """Adds storage to the grid."""
-        first_storage_id = self.grid.plant.shape[0] + 1
+        first_storage_id = self.grid.plant.index.max() + 1
         for i, entry in enumerate(self.ct["storage"]):
             storage_id = first_storage_id + i
             self._add_storage_unit(entry)

--- a/powersimdata/input/transform_grid.py
+++ b/powersimdata/input/transform_grid.py
@@ -370,7 +370,8 @@ class TransformGrid(object):
         :param int bus_id: bus identification number.
         :param dict entry: storage details, containing at least "bus_id" and "capacity".
         """
-        gen = {g: 0 for g in self.grid.storage["gen"].columns}
+        storage = self.grid.storage
+        gen = {g: 0 for g in storage["gen"].columns}
         gen["bus_id"] = entry["bus_id"]
         gen["Vg"] = 1
         gen["mBase"] = 100
@@ -379,9 +380,9 @@ class TransformGrid(object):
         gen["Pmin"] = -1 * entry["capacity"]
         gen["ramp_10"] = entry["capacity"]
         gen["ramp_30"] = entry["capacity"]
-        self.grid.storage["gen"] = self.grid.storage["gen"].append(
-            gen, ignore_index=True, sort=False
-        )
+        storage["gen"] = storage["gen"].append(gen, ignore_index=True, sort=False)
+        # Maintain int columns after the append converts them to float
+        storage["gen"] = storage["gen"].astype({"bus_id": "int", "status": "int"})
 
     def _add_storage_gencost(self):
         """Sets generation cost of storage unit."""
@@ -403,7 +404,8 @@ class TransformGrid(object):
         :param dict entry: storage details, containing at least:
             "bus_id", "capacity".
         """
-        data = {g: 0 for g in self.grid.storage["StorageData"].columns}
+        storage = self.grid.storage
+        data = {g: 0 for g in storage["StorageData"].columns}
 
         capacity = entry["capacity"]
         duration = entry["duration"]
@@ -427,9 +429,11 @@ class TransformGrid(object):
         data["InEff"] = entry["InEff"]
         data["LossFactor"] = entry["LossFactor"]
         data["rho"] = 1
-        self.grid.storage["StorageData"] = self.grid.storage["StorageData"].append(
+        storage["StorageData"] = storage["StorageData"].append(
             data, ignore_index=True, sort=False
         )
+        # Maintain int columns after the append converts them to float
+        storage["StorageData"] = storage["StorageData"].astype({"UnitIdx": "int"})
 
 
 def voltage_to_x_per_distance(grid):

--- a/powersimdata/input/transform_grid.py
+++ b/powersimdata/input/transform_grid.py
@@ -356,29 +356,29 @@ class TransformGrid(object):
 
     def _add_storage(self):
         """Adds storage to the grid."""
-        storage_id = self.grid.plant.shape[0]
-        for bus_id, value in self.ct["storage"]["bus_id"].items():
-            storage_id += 1
-            self._add_storage_unit(bus_id, value)
+        first_storage_id = self.grid.plant.shape[0] + 1
+        for i, entry in enumerate(self.ct["storage"]):
+            storage_id = first_storage_id + i
+            self._add_storage_unit(entry)
             self._add_storage_gencost()
             self._add_storage_genfuel()
-            self._add_storage_data(storage_id, value)
+            self._add_storage_data(storage_id, entry)
 
-    def _add_storage_unit(self, bus_id, value):
+    def _add_storage_unit(self, entry):
         """Add storage unit.
 
         :param int bus_id: bus identification number.
-        :param float value: storage capacity.
+        :param dict entry: storage details, containing at least "bus_id" and "capacity".
         """
         gen = {g: 0 for g in self.grid.storage["gen"].columns}
-        gen["bus_id"] = bus_id
+        gen["bus_id"] = entry["bus_id"]
         gen["Vg"] = 1
         gen["mBase"] = 100
         gen["status"] = 1
-        gen["Pmax"] = value
-        gen["Pmin"] = -1 * value
-        gen["ramp_10"] = value
-        gen["ramp_30"] = value
+        gen["Pmax"] = entry["capacity"]
+        gen["Pmin"] = -1 * entry["capacity"]
+        gen["ramp_10"] = entry["capacity"]
+        gen["ramp_30"] = entry["capacity"]
         self.grid.storage["gen"] = self.grid.storage["gen"].append(
             gen, ignore_index=True, sort=False
         )
@@ -396,35 +396,38 @@ class TransformGrid(object):
         """Sets fuel type of storage unit."""
         self.grid.storage["genfuel"].append("ess")
 
-    def _add_storage_data(self, storage_id, value):
+    def _add_storage_data(self, storage_id, entry):
         """Sets storage data.
 
         :param int storage_id: storage identification number.
-        :param float value: storage capacity.
+        :param dict entry: storage details, containing at least:
+            "bus_id", "capacity".
         """
         data = {g: 0 for g in self.grid.storage["StorageData"].columns}
 
-        duration = self.grid.storage["duration"]
-        min_stor = self.grid.storage["min_stor"]
-        max_stor = self.grid.storage["max_stor"]
-        energy_price = self.grid.storage["energy_price"]
+        capacity = entry["capacity"]
+        duration = entry["duration"]
+        min_stor = entry["min_stor"]
+        max_stor = entry["max_stor"]
+        energy_value = entry["energy_value"]
+        terminal_min = entry["terminal_min"]
+        terminal_max = entry["terminal_max"]
 
         data["UnitIdx"] = storage_id
-        data["ExpectedTerminalStorageMax"] = value * duration * max_stor
-        data["ExpectedTerminalStorageMin"] = value * duration / 2
-        data["InitialStorage"] = value * duration / 2
-        data["InitialStorageLowerBound"] = value * duration / 2
-        data["InitialStorageUpperBound"] = value * duration / 2
-        data["InitialStorageCost"] = energy_price
-        data["TerminalStoragePrice"] = energy_price
-        data["MinStorageLevel"] = value * duration * min_stor
-        data["MaxStorageLevel"] = value * duration * max_stor
-        data["OutEff"] = self.grid.storage["OutEff"]
-        data["InEff"] = self.grid.storage["InEff"]
-        data["LossFactor"] = 0
+        data["ExpectedTerminalStorageMax"] = capacity * duration * terminal_max
+        data["ExpectedTerminalStorageMin"] = capacity * duration * terminal_min
+        data["InitialStorage"] = capacity * duration / 2  # Start with half
+        data["InitialStorageLowerBound"] = capacity * duration / 2  # Start with half
+        data["InitialStorageUpperBound"] = capacity * duration / 2  # Start with half
+        data["InitialStorageCost"] = energy_value
+        data["TerminalStoragePrice"] = energy_value
+        data["MinStorageLevel"] = capacity * duration * min_stor
+        data["MaxStorageLevel"] = capacity * duration * max_stor
+        data["OutEff"] = entry["OutEff"]
+        data["InEff"] = entry["InEff"]
+        data["LossFactor"] = entry["LossFactor"]
         data["rho"] = 1
-        prev_storage_data = self.grid.storage["StorageData"]
-        self.grid.storage["StorageData"] = prev_storage_data.append(
+        self.grid.storage["StorageData"] = self.grid.storage["StorageData"].append(
             data, ignore_index=True, sort=False
         )
 

--- a/powersimdata/network/usa_tamu/constants/__init__.py
+++ b/powersimdata/network/usa_tamu/constants/__init__.py
@@ -1,1 +1,0 @@
-__all__ = ["plants", "zones"]

--- a/powersimdata/network/usa_tamu/constants/storage.py
+++ b/powersimdata/network/usa_tamu/constants/storage.py
@@ -1,0 +1,11 @@
+defaults = {
+    "duration": 4,
+    "min_stor": 0.05,
+    "max_stor": 0.95,
+    "InEff": 0.9,
+    "OutEff": 0.9,
+    "energy_value": 20,
+    "LossFactor": 0,
+    "terminal_min": 0,
+    "terminal_max": 1,
+}

--- a/powersimdata/network/usa_tamu/usa_tamu_model.py
+++ b/powersimdata/network/usa_tamu/usa_tamu_model.py
@@ -7,6 +7,7 @@ from powersimdata.input.helpers import (
     csv_to_data_frame,
 )
 from powersimdata.network.csv_reader import CSVReader
+from powersimdata.network.usa_tamu.constants.storage import defaults
 from powersimdata.network.usa_tamu.constants.zones import (
     abv2state,
     interconnect2loadzone,
@@ -41,15 +42,6 @@ class TAMU(AbstractGrid):
         else:
             self.data_loc = data_loc
 
-    def _set_storage(self):
-        """Sets storage properties."""
-        self.storage["duration"] = 4
-        self.storage["min_stor"] = 0.05
-        self.storage["max_stor"] = 0.95
-        self.storage["InEff"] = 0.9
-        self.storage["OutEff"] = 0.9
-        self.storage["energy_price"] = 20
-
     def _build_network(self):
         """Build network."""
         reader = CSVReader(self.data_loc)
@@ -59,7 +51,7 @@ class TAMU(AbstractGrid):
         self.dcline = reader.dcline
         self.gencost["after"] = self.gencost["before"] = reader.gencost
 
-        self._set_storage()
+        self.storage.update(defaults)
 
         add_information_to_model(self)
 


### PR DESCRIPTION
### Purpose
Let user specify more parameters for storage. Closes #380.

### What the code is doing
- In **abstract_grid.py**: we add parameters `LossFactor`, `terminal_min`, and `terminal_max`.
- In **change_table.py**: we refactor `add_storage_capacity` to follow the pattern set in `add_plant` etc.
- In **grid.py**: ~we add the `Lossfactor` parameter to the ignored keys for `grid.storage` in the grid equality check.~ we automatically populate the ignored keys for grid.storage in the grid equality check from the new **storage.py**.
- In **transform_grid.py**: we interpret the new change table schema.
- We add a new file **storage.py** to handle `usa_tamu` storage constants.
- In **usa_tamu_model.py**: we get our storage default values from the new **storage.py** file.
- We update **test_change_table.py** and **test_transform_grid.py** accordingly

### Testing
Unit tests are updated to the new format and now pass.

### Time estimate
15-30 minutes. New tests to ensure that the new parameters are set properly are still incoming, but review can get started on everything else.