### PR TITLE
refactor: remove redundant function for getting bus demand

### DIFF
--- a/powersimdata/input/input_data.py
+++ b/powersimdata/input/input_data.py
@@ -102,14 +102,14 @@ def _read_data(filepath):
     return data
 
 
-def get_bus_demand(scenario_id, grid):
+def get_bus_demand(scenario_info, grid):
     """Returns demand profiles by bus.
 
-    :param str scenario_id: scenario id.
+    :param dict scenario_info: scenario information.
     :param powersimdata.input.grid.Grid grid: grid to construct bus demand for.
     :return: (*pandas.DataFrame*) -- data frame of demand.
     """
-    demand = InputData().get_data(scenario_id, "demand")
+    demand = InputData().get_data(scenario_info, "demand")
     bus = grid.bus
     bus["zone_Pd"] = bus.groupby("zone_id")["Pd"].transform("sum")
     bus["zone_share"] = bus["Pd"] / bus["zone_Pd"]

--- a/powersimdata/output/output_data.py
+++ b/powersimdata/output/output_data.py
@@ -95,7 +95,7 @@ def construct_load_shed(scenario_info, grid, infeasibilities=None):
         load_shed = pd.DataFrame.sparse.from_spmatrix(load_shed_data)
     else:
         print("Infeasibilities, constructing DataFrame")
-        bus_demand = get_bus_demand(scenario_info["id"], grid)
+        bus_demand = get_bus_demand(scenario_info, grid)
         load_shed = np.zeros((len(hours), len(buses)))
         # Convert '24H' to 24
         interval = int(scenario_info["interval"][:-1])

--- a/powersimdata/scenario/analyze.py
+++ b/powersimdata/scenario/analyze.py
@@ -5,10 +5,9 @@ import pickle
 import pandas as pd
 
 from powersimdata.input.grid import Grid
-from powersimdata.input.input_data import InputData
+from powersimdata.input.input_data import InputData, get_bus_demand
 from powersimdata.input.transform_profile import TransformProfile
 from powersimdata.output.output_data import OutputData, construct_load_shed
-from powersimdata.scenario.helpers import calculate_bus_demand
 from powersimdata.scenario.state import State
 from powersimdata.utility import server_setup
 
@@ -275,10 +274,8 @@ class Analyze(State):
 
         :return: (*pandas.DataFrame*) -- data frame of demand (hour, bus).
         """
-        profile = TransformProfile(self._scenario_info, self.get_grid(), self.get_ct())
-        demand = profile.get_profile("demand")
         grid = self.get_grid()
-        return calculate_bus_demand(grid.bus, demand)
+        return get_bus_demand(self._scenario_info, grid)
 
     def get_hydro(self):
         """Returns hydro profile

--- a/powersimdata/scenario/create.py
+++ b/powersimdata/scenario/create.py
@@ -10,14 +10,11 @@ import pandas as pd
 from powersimdata.data_access.scenario_list import ScenarioListManager
 from powersimdata.input.change_table import ChangeTable
 from powersimdata.input.grid import Grid
+from powersimdata.input.input_data import get_bus_demand
 from powersimdata.input.transform_grid import TransformGrid
 from powersimdata.input.transform_profile import TransformProfile
 from powersimdata.scenario.execute import Execute
-from powersimdata.scenario.helpers import (
-    calculate_bus_demand,
-    check_interconnect,
-    interconnect2name,
-)
+from powersimdata.scenario.helpers import check_interconnect, interconnect2name
 from powersimdata.scenario.state import State
 from powersimdata.utility import server_setup
 
@@ -153,9 +150,8 @@ class Create(State):
 
         :return: (*pandas.DataFrame*) -- data frame of demand (hour, bus).
         """
-        demand = self.get_profile("demand")
         grid = self.get_grid()
-        return calculate_bus_demand(grid.bus, demand)
+        return get_bus_demand(self._scenario_info, grid)
 
     def get_hydro(self):
         """Returns hydro profile.

--- a/powersimdata/scenario/helpers.py
+++ b/powersimdata/scenario/helpers.py
@@ -1,7 +1,3 @@
-import numpy as np
-import pandas as pd
-
-
 def check_interconnect(interconnect):
     """Sets interconnect.
 
@@ -46,25 +42,3 @@ def interconnect2name(interconnect):
                 return "easternwestern"
     else:
         return "usa"
-
-
-def calculate_bus_demand(bus, demand):
-    """Calculates bus-level demand from zone-level demand.
-
-    :param pandas.DataFrame bus: bus data frame.
-    :param pandas.DataFrame demand: demand data frame.
-    :return: (*pandas.DataFrame*) -- dataframe of (hour, bus) demand.
-    """
-    zone_demand = bus.groupby("zone_id").sum().Pd
-    bus_zone_share = bus.apply(lambda x: x.Pd / zone_demand.loc[x.zone_id], axis=1)
-    bus_to_zone = np.zeros((len(zone_demand), len(bus)))
-    bus_idx_lookup = {b: i for i, b in enumerate(bus.index)}
-    zone_idx_lookup = {z: i for i, z in enumerate(zone_demand.index)}
-    for b in bus.index:
-        bus_idx = bus_idx_lookup[b]
-        zone_idx = zone_idx_lookup[bus.loc[b, "zone_id"]]
-        bus_to_zone[zone_idx, bus_idx] = bus_zone_share.loc[b]
-    bus_demand = pd.DataFrame(
-        (demand.to_numpy() @ bus_to_zone), index=demand.index, columns=bus.index
-    )
-    return bus_demand


### PR DESCRIPTION
### Purpose
Per discussion in https://github.com/Breakthrough-Energy/PowerSimData/pull/375, remove a redundant function. `get_bus_demand` is the fastest of the three identical functions:
```python
>>> import timeit
>>> from postreise.analyze.transmission.congestion import map_demand_to_buses
>>> from powersimdata.input.input_data import get_bus_demand
>>> from powersimdata.scenario.helpers import calculate_bus_demand
>>> from powersimdata.scenario.scenario import Scenario
>>> scenario = Scenario(824)
>>> demand = scenario.state.get_demand()
>>> grid = scenario.state.get_grid()
>>> bus = grid.bus
>>> timeit.timeit(lambda: map_demand_to_buses(grid, demand), number=10)
75.39155149999999
>>> timeit.timeit(lambda: calculate_bus_demand(bus, demand), number=10)
45.56884489999993
>>> timeit.timeit(lambda: get_bus_demand(scenario.info, grid), number=10)
30.71693670000002
```

### What the code is doing
- The docstring and parameter names of `get_bus_demand` are updated to reflect reality (I think the way we called `InputData` changed but we didn't update all the references to it).
- `calculate_bus_demand` is removed from **helpers.py**.
- `Analyze` and `Create` are refactored to use `get_bus_demand` instead of `calculate_bus_demand`.
- The `construct_load_shed` method of `OutputData` is updated to reflect the updated `InputData` init (can be tested before & after using scenario 398, which has old-style infeasibilities and triggers this code path).

### Testing
All unit tests still pass.

### Time estimate
10 minutes.