### PR TITLE
ci: use black profile for isort

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN ln -s /mnt/bes/pcm $HOME/ScenarioData
 
 COPY powersimdata/utility/templates /mnt/bes/pcm/
 
-WORKDIR /app
+WORKDIR /PowerSimData
 COPY Pipfile .
 COPY Pipfile.lock .
 RUN pip install -U pip pipenv ipython; \

--- a/powersimdata/data_access/context.py
+++ b/powersimdata/data_access/context.py
@@ -1,9 +1,6 @@
 from powersimdata.data_access.data_access import LocalDataAccess, SSHDataAccess
 from powersimdata.utility import server_setup
-from powersimdata.utility.server_setup import (
-    DeploymentMode,
-    get_deployment_mode,
-)
+from powersimdata.utility.server_setup import DeploymentMode, get_deployment_mode
 
 
 class Context:

--- a/powersimdata/design/transmission/tests/test_statelines.py
+++ b/powersimdata/design/transmission/tests/test_statelines.py
@@ -1,8 +1,6 @@
 import unittest
 
-from powersimdata.design.transmission.statelines import (
-    _classify_interstate_intrastate,
-)
+from powersimdata.design.transmission.statelines import _classify_interstate_intrastate
 from powersimdata.tests.mock_grid import MockGrid
 
 # branch_id is the index

--- a/powersimdata/input/tests/test_grid.py
+++ b/powersimdata/input/tests/test_grid.py
@@ -7,10 +7,7 @@ import pytest
 from powersimdata.input.grid import Grid
 from powersimdata.input.helpers import add_column_to_data_frame
 from powersimdata.input.scenario_grid import format_gencost, link
-from powersimdata.network.usa_tamu.usa_tamu_model import (
-    TAMU,
-    check_interconnect,
-)
+from powersimdata.network.usa_tamu.usa_tamu_model import TAMU, check_interconnect
 
 
 def test_interconnect_type():

--- a/powersimdata/scenario/execute.py
+++ b/powersimdata/scenario/execute.py
@@ -13,10 +13,7 @@ from powersimdata.input.transform_profile import TransformProfile
 from powersimdata.scenario.helpers import interconnect2name
 from powersimdata.scenario.state import State
 from powersimdata.utility import server_setup
-from powersimdata.utility.server_setup import (
-    DeploymentMode,
-    get_deployment_mode,
-)
+from powersimdata.utility.server_setup import DeploymentMode, get_deployment_mode
 
 
 class Execute(State):

--- a/powersimdata/utility/tests/test_distance.py
+++ b/powersimdata/utility/tests/test_distance.py
@@ -2,11 +2,7 @@ from math import sqrt
 
 from numpy.testing import assert_almost_equal, assert_array_almost_equal
 
-from powersimdata.utility.distance import (
-    angular_distance,
-    find_closest_neighbor,
-    ll2uv,
-)
+from powersimdata.utility.distance import angular_distance, find_closest_neighbor, ll2uv
 
 
 def test_ll2uv():

--- a/tox.ini
+++ b/tox.ini
@@ -17,10 +17,13 @@ commands =
     local: pytest -m 'not integration'
     integration: pytest 
     format: black .
-    format: isort -m 3 --tc .
+    format: isort .
     checkformatting: black . --check --diff
-    checkformatting: isort -m 3 --tc --check --diff .
+    checkformatting: isort --check --diff .
     flake8: flake8 powersimdata/
 
 [flake8]
 ignore = E501,W503,E741,E203,W605
+
+[isort]
+profile = black


### PR DESCRIPTION
### Purpose
We can take advantage of isort's built in "profile" for black compatibility. This includes a line length option which we were msising, along with a couple others I'm not sure about. [Source](https://github.com/PyCQA/isort/blob/develop/isort/profiles.py) from their repo is easy to read.

### What the code is doing
Added isort section in tox.ini

### Testing
Ran `tox -e format` locally, and ci passes.

### Time estimate
5 min