### PR TITLE
feat: add with syntax to PrintManager

### DIFF
--- a/powersimdata/utility/helpers.py
+++ b/powersimdata/utility/helpers.py
@@ -130,6 +130,12 @@ class PrintManager(object):
         """Constructor"""
         self.stdout = sys.stdout
 
+    def __enter__(self):
+        self.block_print()
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.enable_print()
+
     @staticmethod
     def block_print():
         """Suppresses print"""


### PR DESCRIPTION
### Purpose
Allow the use of the `with` statement with the `PrintManager`.

### What the code is doing
`__enter__` and `__exit__` functions are added, as documented in https://docs.python.org/3/reference/compound_stmts.html#the-with-statement.

### Usage Example/Visuals
Previously, if we wanted to block print for a block of code, we needed to do something like:
```python
>>> pm = PrintManager()
>>> pm.block_print()
>>> demand = scenario.state.get_demand()
>>> pm.enable_print()
```

Now, the same commands can be accomplished via a shorter syntax:
```python
>>> with PrintManager():
...     demand = scenario.state.get_demand()
```

### Time estimate
5 minutes.