### PR TITLE
feat: add temporal curtailment calculation

### DIFF
--- a/powersimdata/design/generation/curtailment.py
+++ b/powersimdata/design/generation/curtailment.py
@@ -1,0 +1,127 @@
+import pandas as pd
+
+from powersimdata.scenario.scenario import Scenario
+
+default_pmin_dict = {
+    "coal": None,
+    "dfo": 0,
+    "geothermal": 0.95,
+    "hydro": None,
+    "ng": 0,
+    "nuclear": 0.95,
+    "other": 0,
+    "solar": 0,
+    "wind": 0,
+    "wind_offshore": 0,
+}
+profile_methods = {
+    "hydro": "get_hydro",
+    "solar": "get_solar",
+    "wind": "get_wind",
+    "wind_offshore": "get_wind",
+}
+
+
+def temporal_curtailment(
+    scenario, pmin_by_type=None, pmin_by_id=None, curtailable={"solar", "wind"}
+):
+    """Calculate the minimum share of potential renewable energy that will be curtailed
+        due to supply/demand mismatch, assuming no storage is present.
+
+    :param powersimdata.scenario.scenario.Scenario scenario: scenario instance.
+    :param dict/pandas.Series pmin_by_type: Mapping of types to Pmin assumptions. Values
+        between 0 and 1 (inclusive) are treated as shares of Pmax, and None values
+        either maintain given Pmin values (for dispatchable resources) or track profiles
+        (for profile resources, e.g. hydro).
+    :param dict/pandas.Series pmin_by_id: Mapping of IDs to Pmin assumptions, as an
+        override to the default behavior for that plant type. Values between 0 and 1
+        (inclusive) are treated as shares of Pmax, and None values either maintain given
+        Pmin values (for dispatchable resources) or track profiles
+        (for profile resources, e.g. hydro).
+    :param iterable curtailable: resource types which can be curtailed.
+    :return: (*float*) -- share of curtailable resources that will be curtailed.
+    :raises TypeError: if inputs do not mach specified type.
+    :raises ValueError: if any entries in curtailable or keys in pmin_by_type are not
+        types in the grid, any keys in pmin_by_id are not plant IDs in the Grid,
+        or any values in pmin_by_type/pmin_by_id are not in the range [0, 1] or None.
+    """
+    if not isinstance(scenario, Scenario):
+        raise TypeError("scenario must be a Scenario")
+    if pmin_by_type is None:
+        pmin_by_type = {}
+    if pmin_by_id is None:
+        pmin_by_id = {}
+    check_dicts = {"pmin_by_id": pmin_by_id, "pmin_by_type": pmin_by_type}
+    for name, d in check_dicts.items():
+        if not isinstance(d, (dict, pd.Series)):
+            raise TypeError(f"{name} must be a dict or pandas Series")
+        # Access values via appropriate method whether d is a dict or a pandas Series
+        values = d.values() if isinstance(d, dict) else d.values
+        if not all([v is None or 0 <= v <= 1 for v in values]):
+            err_msg = f"all entries in {name} must be None or in the range [0, 1]"
+            raise ValueError(err_msg)
+    plant = scenario.state.get_grid().plant
+    valid_types = plant["type"].unique()
+    if not set(pmin_by_type.keys()) <= set(valid_types):
+        raise ValueError("Got invalid plant type as a key to pmin_by_type")
+    if not set(pmin_by_id.keys()) <= set(plant.index):
+        raise ValueError("Got invalid plant id as a key to pmin_by_id")
+    try:
+        if not set(curtailable) <= set(valid_types):
+            raise ValueError("Got invalid plant type within curtailable")
+    except TypeError:
+        raise TypeError("curtailable must be an iterable")
+
+    # Get profiles, filter out plant-level overrides, then sum
+    all_profiles = pd.concat(
+        [getattr(scenario.state, m)() for m in set(profile_methods.values())], axis=1
+    )
+    plant_id_mask = ~plant.index.isin(pmin_by_id.keys())
+    base_plant_ids_by_type = plant.loc[plant_id_mask].groupby("type").groups
+    valid_profile_types = set(base_plant_ids_by_type) & set(profile_methods)
+    plant_ids_for_summed_profiles = set().union(
+        *[set(base_plant_ids_by_type[g]) for g in valid_profile_types]
+    )
+    summed_profiles = (
+        all_profiles[plant_ids_for_summed_profiles].groupby(plant["type"], axis=1).sum()
+    )
+
+    # Build up a series of firm generation
+    summed_demand = scenario.state.get_demand().sum(axis=1)
+    firm_generation = pd.Series(0, index=summed_demand.index)
+    # Add plants without plant-level overrides ('base' plants)
+    pmin_dict = {**default_pmin_dict, **pmin_by_type}
+    # Don't iterate over plant types not present in this grid
+    pmin_dict = {k: pmin_dict[k] for k in base_plant_ids_by_type}
+    for resource, pmin in pmin_dict.items():
+        if (resource in curtailable) or (pmin == 0):
+            continue
+        if pmin is None:
+            if resource in profile_methods:
+                firm_generation += summed_profiles[resource]
+            else:
+                summed_pmin = plant.Pmin.loc[base_plant_ids_by_type[resource]].sum()
+                firm_generation += pd.Series(summed_pmin, index=summed_demand.index)
+        else:
+            summed_pmin = pmin * plant.Pmax.loc[base_plant_ids_by_type[resource]].sum()
+            firm_generation += pd.Series(summed_pmin, index=summed_demand.index)
+    # Add plants with plant-level overrides
+    for plant_id, pmin in pmin_by_id.items():
+        if pmin == 0:
+            continue
+        if pmin is None:
+            if plant.loc[plant_id, "type"] in profile_methods:
+                firm_generation += all_profiles[plant_id]
+            else:
+                plant_pmin = plant.loc[plant_id, "Pmin"]
+                firm_generation += pd.Series(plant_pmin, index=summed_demand.index)
+        else:
+            plant_pmin = plant.loc[plant_id, "Pmax"] * pmin
+            firm_generation += pd.Series(plant_pmin, index=summed_demand.index)
+
+    # Finally, compare this summed firm generation against summed curtailable generation
+    total_curtailable = summed_profiles[curtailable].sum(axis=1)
+    net_demand = summed_demand - firm_generation
+    curtailable_max_gen = pd.concat([net_demand, total_curtailable], axis=1).min(axis=1)
+    curtailment_fraction = 1 - curtailable_max_gen.sum() / total_curtailable.sum()
+    return curtailment_fraction

--- a/powersimdata/design/generation/tests/test_curtailment.py
+++ b/powersimdata/design/generation/tests/test_curtailment.py
@@ -1,0 +1,89 @@
+import pandas as pd
+import pytest
+
+from powersimdata.design.generation.curtailment import temporal_curtailment
+from powersimdata.tests.mock_scenario import MockScenario
+
+mock_plant = {
+    "plant_id": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
+    "type": ["coal", "wind", "solar", "hydro", "ng", "nuclear"] * 2,
+    "Pmax": [50, 50, 50, 50, 20, 60, 100, 50, 50, 50, 40, 120],
+    "Pmin": [20, 0, 0, 0, 0, 30, 30, 0, 0, 0, 10, 75],
+}
+
+mock_demand = pd.DataFrame(
+    {1: [350, 350, 325, 400, 500]},
+)
+
+mock_hydro = pd.DataFrame(
+    {
+        3: [25, 40, 50, 30, 0],
+        9: [25, 40, 50, 30, 0],
+    }
+)
+
+mock_solar = pd.DataFrame(
+    {
+        2: [20, 20, 20, 20, 20],
+        8: [10, 20, 30, 40, 50],
+    }
+)
+
+mock_wind = pd.DataFrame(
+    {
+        1: [0, 50, 0, 50, 0],
+        7: [20, 30, 20, 30, 20],
+    }
+)
+
+
+@pytest.fixture
+def mock_scenario():
+    return MockScenario(
+        grid_attrs={"plant": mock_plant},
+        demand=mock_demand,
+        hydro=mock_hydro,
+        solar=mock_solar,
+        wind=mock_wind,
+    )
+
+
+def test_temporal_curtailment(mock_scenario):
+    assert temporal_curtailment(mock_scenario) == pytest.approx(0.3361702)
+
+    # Testing that "None" overrides the default simulation Pmin with the data Pmin
+    curtailment = temporal_curtailment(mock_scenario, pmin_by_type={"ng": None})
+    assert curtailment == pytest.approx(0.4)
+    curtailment = temporal_curtailment(mock_scenario, pmin_by_id={10: None})
+    assert curtailment == pytest.approx(0.4)
+
+    # Testing that we can change replace the Pmin with relative-to-Pmax values
+    curtailment = temporal_curtailment(mock_scenario, pmin_by_id={5: 1})
+    assert curtailment == pytest.approx(0.35531915)
+    curtailment = temporal_curtailment(mock_scenario, pmin_by_id={11: 1})
+    assert curtailment == pytest.approx(0.37446809)
+    curtailment = temporal_curtailment(mock_scenario, pmin_by_id={5: 1, 11: 1})
+    assert curtailment == pytest.approx(0.39361702)
+    curtailment = temporal_curtailment(mock_scenario, pmin_by_type={"nuclear": 1})
+    assert curtailment == pytest.approx(0.39361702)
+    curtailment = temporal_curtailment(mock_scenario, pmin_by_id={5: 1, 11: 0.99})
+    assert curtailment == pytest.approx(0.38595744)
+    curtailment = temporal_curtailment(mock_scenario, pmin_by_type={"nuclear": 0.98})
+    assert curtailment == pytest.approx(0.37063830)
+    # Testing that we can override by-type with by-id
+    curtailment = temporal_curtailment(
+        mock_scenario, pmin_by_type={"nuclear": 1}, pmin_by_id={11: 0.99}
+    )
+    assert curtailment == pytest.approx(0.38595744)
+
+    # Testing that we can relax the Pmin of a profile resource by type
+    assert temporal_curtailment(mock_scenario, pmin_by_type={"hydro": 0}) == 0
+    # Testing that we can relax the Pmin of a profile resource by id
+    assert temporal_curtailment(mock_scenario, pmin_by_id={3: 0}) == pytest.approx(0.1)
+    curtailment = temporal_curtailment(mock_scenario, pmin_by_id={3: 0, 9: 0})
+    assert curtailment == 0
+    # Testing that we can override by-type with by-id
+    curtailment = temporal_curtailment(
+        mock_scenario, pmin_by_type={"hydro": 0}, pmin_by_id={9: None}
+    )
+    assert curtailment == pytest.approx(0.1)


### PR DESCRIPTION
### Purpose
Add functionality to pre-calculate curtailment caused by temporal mismatch between demand, inflexible generation, and curtailable profile resources.

### What the code is doing

First, profiles for hydro, solar, and wind are summed by type, with the exclusion of any plant IDs which the user specifies do not behave like all the rest (e.g., maybe some solar plants are behind-the-meter and are not curtailable, and we would want to see how this impact the rest of the wind plants).

Then, a time-series of inflexible generation is built-up, first based on on per-generator-type logic for plants without plant-level overrides (default values mimic what REISE.jl does currently), then based on the behavior of plant-level overrides.

Finally, the summed profile of curtailable resources is compared against the demand minus firm generation to get a time-series of the maximum possible use of these curtailable resources (assuming no energy storage) and this is normalized based on the total available energy from the curtailable resources.

### Testing
Unit tests still need to be added, but integration tests behave as expected (matching previously-done manual calculations). 

### Usage Example/Visuals
First, let's see the minimum solar/wind curtailment with default values:
```python
>>> from powersimdata.design.generation.curtailment import temporal_curtailment
>>> from powersimdata.scenario.scenario import Scenario
>>> scenario = Scenario(2505)
[...truncated...]
>>> temporal_curtailment(scenario)
[...truncated...]
0.25601475590030276
```

What if the nuclear and geothermal plants are running at 100%? This sort of calculation is useful when calculating total potential clean energy.
```python
>>> temporal_curtailment(scenario, pmin_by_type={'nuclear': 1, 'geothermal': 1})
[...truncated...]
0.2594608282619938
```
As expected, this would lead to higher curtailment of wind and solar. What if most nuclear and geothermal plants are running at 100%, but there are a few nuclear plants with integrated storage, so we assume that these plants can go down to 0 when necessary?
```python
>>> temporal_curtailment(scenario, pmin_by_type={'nuclear': 1, 'geothermal': 1}, pmin_by_id={p: 0 for p in range(14026, 14032)})
[...truncated...]
0.24669058923694587
```
As expected, this would lead to lower curtailment.

### Time estimate
15 minutes.