### PR TITLE
refactor: generalize area to loadzone

### DIFF
--- a/powersimdata/design/generation/clean_capacity_scaling.py
+++ b/powersimdata/design/generation/clean_capacity_scaling.py
@@ -3,7 +3,7 @@ import pandas as pd
 
 from powersimdata.design.mimic_grid import mimic_generation_capacity
 from powersimdata.input.grid import Grid
-from powersimdata.network.usa_tamu.model import area_to_loadzone
+from powersimdata.network.model import area_to_loadzone
 from powersimdata.scenario.scenario import Scenario
 
 
@@ -102,9 +102,11 @@ def _make_zonename2target(grid, targets):
         if a zone is present in more than one target area.
     """
     target_zones = {
-        target_name: area_to_loadzone(target_name)
+        target_name: area_to_loadzone(grid.get_grid_model(), target_name)
         if pd.isnull(targets.loc[target_name, "area_type"])
-        else area_to_loadzone(target_name, targets.loc[target_name, "area_type"])
+        else area_to_loadzone(
+            grid.get_grid_model(), target_name, targets.loc[target_name, "area_type"]
+        )
         for target_name in targets.index.tolist()
     }
     # Check for any collisions

--- a/powersimdata/design/generation/cost_curves.py
+++ b/powersimdata/design/generation/cost_curves.py
@@ -4,7 +4,7 @@ import numpy as np
 import pandas as pd
 
 from powersimdata.input.grid import Grid
-from powersimdata.network.usa_tamu.model import area_to_loadzone
+from powersimdata.network.model import area_to_loadzone
 from powersimdata.utility.helpers import _check_import
 
 
@@ -221,7 +221,7 @@ def build_supply_curve(grid, num_segments, area, gen_type, area_type=None, plot=
         raise ValueError(f"{gen_type} is not a valid generation type.")
 
     # Identify the load zones that correspond to the specified area and area_type
-    returned_zones = area_to_loadzone(area, area_type)
+    returned_zones = area_to_loadzone(grid.get_grid_model(), area, area_type)
 
     # Trim the DataFrame to only be of the desired area and generation type
     data = data.loc[data.zone_name.isin(returned_zones)]

--- a/powersimdata/design/generation/tests/test_cost_curves.py
+++ b/powersimdata/design/generation/tests/test_cost_curves.py
@@ -140,6 +140,7 @@ grid_attrs = {"plant": mock_plant, "gencost_before": mock_gencost}
 grid = MockGrid(grid_attrs)
 grid.interconnect = "Western"
 grid.zone2id = {"Utah": 210, "Colorado": 212, "Washington": 201}
+grid.get_grid_model = lambda: "usa_tamu"
 
 
 def test_get_supply_data():

--- a/powersimdata/design/scenario_info.py
+++ b/powersimdata/design/scenario_info.py
@@ -1,6 +1,6 @@
 import warnings
 
-from powersimdata.network.usa_tamu.model import area_to_loadzone
+from powersimdata.network.model import area_to_loadzone
 
 
 def _check_state(scenario):
@@ -27,15 +27,15 @@ class ScenarioInfo:
         self.pg = scenario.state.get_pg()
         self.grid = scenario.state.get_grid()
         self.demand = scenario.state.get_demand()
+        self.grid_model = self.grid.get_grid_model()
         solar = scenario.state.get_solar()
         wind = scenario.state.get_wind()
         hydro = scenario.state.get_hydro()
         self.profile = {"solar": solar, "wind": wind, "hydro": hydro}
 
-    @staticmethod
-    def area_to_loadzone(area, area_type=None):
+    def area_to_loadzone(self, area, area_type=None):
         """Map the query area to a list of loadzones. For more info, see
-            powersimdata.network.usa_tamu.model.area_to_loadzone().
+            powersimdata.network.model.area_to_loadzone().
 
         :param str area: one of: *loadzone*, *state*, *state abbreviation*,
             *interconnect*, *'all'*
@@ -43,7 +43,7 @@ class ScenarioInfo:
             *'state_abbr'*, *'interconnect'*
         :return: (*set*) -- set of loadzones associated to the query area
         """
-        return area_to_loadzone(area, area_type)
+        return area_to_loadzone(self.grid_model, area, area_type)
 
     def _check_time_range(self, start_time, end_time):
         """Check if the start_time and end_time define a valid time range of

--- a/powersimdata/design/tests/test_scenario_info.py
+++ b/powersimdata/design/tests/test_scenario_info.py
@@ -128,6 +128,7 @@ class TestScenarioInfo(unittest.TestCase):
             wind=mock_wind,
             hydro=mock_hydro,
         )
+        scenario.state.grid.get_grid_model = lambda: "usa_tamu"
         scenario.state.grid.zone2id = {"Oregon": 202, "Arizona": 209}
         self.scenario_info = ScenarioInfo(scenario)
 

--- a/powersimdata/design/transmission/tests/test_upgrade.py
+++ b/powersimdata/design/transmission/tests/test_upgrade.py
@@ -61,6 +61,7 @@ mock_plant = {
 mock_grid = MockGrid(
     grid_attrs={"branch": mock_branch, "bus": mock_bus, "plant": mock_plant}
 )
+mock_grid.get_grid_model = lambda: "usa_tamu"
 
 
 class TestStubTopologyHelpers(unittest.TestCase):

--- a/powersimdata/design/transmission/upgrade.py
+++ b/powersimdata/design/transmission/upgrade.py
@@ -1,7 +1,7 @@
 import pandas as pd
 
 from powersimdata.input.grid import Grid
-from powersimdata.network.usa_tamu.model import area_to_loadzone
+from powersimdata.network.model import area_to_loadzone
 from powersimdata.utility.distance import haversine
 
 
@@ -176,7 +176,7 @@ def get_branches_by_area(grid, area_names, method="either"):
     branch = grid.branch
     selected_branches = set()
     for a in area_names:
-        load_zone_names = area_to_loadzone(a)
+        load_zone_names = area_to_loadzone(grid.get_grid_model(), a)
         to_bus_in_area = branch.to_zone_name.isin(load_zone_names)
         from_bus_in_area = branch.from_zone_name.isin(load_zone_names)
         if method in ("internal", "either"):

--- a/powersimdata/input/grid.py
+++ b/powersimdata/input/grid.py
@@ -1,5 +1,7 @@
 import os
 
+from powersimdata.data_access.context import Context
+from powersimdata.data_access.scenario_list import ScenarioListManager
 from powersimdata.input.scenario_grid import FromREISE, FromREISEjl
 from powersimdata.network.usa_tamu.constants import storage as tamu_storage
 from powersimdata.network.usa_tamu.model import TAMU
@@ -58,6 +60,20 @@ class Grid(object):
         self.storage = data.storage
 
         _cache.put(key, self)
+
+    def get_grid_model(self):
+        """Get the grid model.
+
+        :return: (*str*).
+        """
+        if os.path.isfile(self.data_loc):
+            # For a ScenarioGrid, extract a number from /some/path/number_grid.mat
+            scenario_number = int(os.path.basename(self.data_loc).split("_")[0])
+            slm = ScenarioListManager(Context.get_data_access())
+            return slm.get_scenario_table().loc[scenario_number, "grid_model"]
+        elif os.path.isdir(self.data_loc):
+            # For a data loc directory, extract from /some/path/grid_model/data
+            return self.data_loc.split(os.sep)[-2]
 
     def __eq__(self, other):
         """Used when 'self == other' is evaluated.

--- a/powersimdata/network/model.py
+++ b/powersimdata/network/model.py
@@ -16,7 +16,6 @@ class ModelImmutables:
         self.zones = self._import_constants("zones")
 
         mod = import_module(f"powersimdata.network.{self.model}.model")
-        self.area_to_loadzone = getattr(mod, "area_to_loadzone")
         self.check_interconnect = getattr(mod, "check_interconnect")
         self.interconnect_to_name = getattr(mod, "interconnect_to_name")
 
@@ -39,3 +38,78 @@ class ModelImmutables:
         """
         mod = import_module(f"powersimdata.network.{self.model}.constants.{kind}")
         return {a: getattr(mod, a) for a in dir(mod)}
+
+    def area_to_loadzone(self, *args, **kwargs):
+        """Map the query area to a list of loadzones, using the known grid model."""
+        return area_to_loadzone(
+            self.model, *args, mappings=self.zones["mappings"], **kwargs
+        )
+
+
+def area_to_loadzone(grid_model, area, area_type=None, mappings=None):
+    """Map the query area to a list of loadzones.
+
+    :param str grid_model: the grid model to use to look up constants for mapping.
+    :param str area: one of: *loadzone*, *state*, *state abbreviation*,
+        *interconnect*, *'all'*.
+    :param str area_type: one of: *'loadzone'*, *'state'*, *'state_abbr'*,
+        *'interconnect'*.
+    :param iterable mappings: a set of strings, representing area types to use to map.
+        If None, all mappings are tried.
+    :return: (*set*) -- set of loadzone names associated with the query area.
+    :raises TypeError: if area is not None or str.
+    :raises ValueError: if area is invalid or the combination of area and area_type is
+        invalid.
+    :raises KeyError: if a mapping is provided which isn't present for a grid_model.
+
+    .. note:: if area_type is not specified, the function will check the area in the
+        order of 'state', 'loadzone', 'state abbreviation', 'interconnect' and 'all'.
+    """
+
+    def raise_invalid_area(area_type):
+        raise ValueError("Invalid area for area_type=%s" % area_type)
+
+    zones = ModelImmutables(grid_model).zones
+    mappings = {"loadzone", "state", "state_abbr", "interconnect"}
+
+    if area_type is not None and not isinstance(area_type, str):
+        raise TypeError("'area_type' should be either None or str.")
+    if area_type:
+        if area_type == "loadzone" and "loadzone" in mappings:
+            if area in zones["loadzone"]:
+                loadzone_set = {area}
+            else:
+                raise_invalid_area(area_type)
+        elif area_type == "state" and "state" in mappings:
+            if area in zones["abv2state"].values():
+                loadzone_set = zones["state2loadzone"][area]
+            else:
+                raise_invalid_area(area_type)
+        elif area_type == "state_abbr" and "state_abbr" in mappings:
+            if area in zones.abv2state:
+                loadzone_set = zones["state2loadzone"][zones["abv2state"][area]]
+            else:
+                raise_invalid_area(area_type)
+        elif area_type == "interconnect" and "interconnect" in mappings:
+            if area in zones["interconnect2loadzone"]:
+                loadzone_set = zones["interconnect2loadzone"][area]
+            else:
+                raise_invalid_area(area_type)
+        else:
+            print(f"{area_type} is incorrect. Available area_types are: {mappings}.")
+            raise ValueError("Invalid area_type")
+    else:
+        if "state" in mappings and area in zones["abv2state"].values():
+            loadzone_set = zones["state2loadzone"][area]
+        elif "loadzone" in mappings and area in zones["loadzone"]:
+            loadzone_set = {area}
+        elif "state" in mappings and area in zones["abv2state"]:
+            loadzone_set = zones["state2loadzone"][zones["abv2state"][area]]
+        elif "interconnect" in mappings and area in zones["interconnect2loadzone"]:
+            loadzone_set = zones["interconnect2loadzone"][area]
+        elif area == "all":
+            loadzone_set = zones["loadzone"]
+        else:
+            print("%s is incorrect." % area)
+            raise ValueError("Invalid area")
+    return loadzone_set

--- a/powersimdata/network/usa_tamu/constants/zones.py
+++ b/powersimdata/network/usa_tamu/constants/zones.py
@@ -20,11 +20,14 @@ _exports = [
     "loadzone2id",
     "loadzone2interconnect",
     "loadzone2state",
+    "mappings",
     "state",
     "state2abv",
     "state2loadzone",
     "timezone2id",
 ]
+
+mappings = {"loadzone", "state", "state_abbr", "interconnect"}
 
 # Define combinations of interconnects
 interconnect_combinations = {"USA", "Texas_Western"}

--- a/powersimdata/network/usa_tamu/model.py
+++ b/powersimdata/network/usa_tamu/model.py
@@ -8,12 +8,6 @@ from powersimdata.input.helpers import (
 )
 from powersimdata.network.csv_reader import CSVReader
 from powersimdata.network.usa_tamu.constants.storage import defaults
-from powersimdata.network.usa_tamu.constants.zones import (
-    abv2state,
-    interconnect2loadzone,
-    loadzone,
-    state2loadzone,
-)
 
 
 class TAMU(AbstractGrid):
@@ -131,68 +125,3 @@ def add_information_to_model(model):
 
     add_zone_to_grid_data_frames(model)
     add_coord_to_grid_data_frames(model)
-
-
-def area_to_loadzone(area, area_type=None):
-    """Map the query area to a list of loadzones
-
-    :param str area: one of: *loadzone*, *state*, *state abbreviation*,
-        *interconnect*, *'all'*
-    :param str area_type: one of: *'loadzone'*, *'state'*,
-        *'state_abbr'*, *'interconnect'*
-    :return: (*set*) -- set of loadzone names associated with the query area.
-    :raise TypeError: if area is not None or str
-    :raise ValueError: if area is invalid or the combination of area and area_type is invalid
-
-    .. note:: if area_type is not specified, the function will check the
-        area in the order of 'state', 'loadzone', 'state abbreviation',
-        'interconnect' and 'all'.
-    """
-
-    def raise_invalid_area(area_type):
-        raise ValueError("Invalid area for area_type=%s" % area_type)
-
-    if area_type is not None and not isinstance(area_type, str):
-        raise TypeError("'area_type' should be either None or str.")
-    if area_type:
-        if area_type == "loadzone":
-            if area in loadzone:
-                loadzone_set = {area}
-            else:
-                raise_invalid_area(area_type)
-        elif area_type == "state":
-            if area in list(abv2state.values()):
-                loadzone_set = state2loadzone[area]
-            else:
-                raise_invalid_area(area_type)
-        elif area_type == "state_abbr":
-            if area in abv2state:
-                loadzone_set = state2loadzone[abv2state[area]]
-            else:
-                raise_invalid_area(area_type)
-        elif area_type == "interconnect":
-            if area in {"Texas", "Western", "Eastern"}:
-                loadzone_set = interconnect2loadzone[area]
-            else:
-                raise_invalid_area(area_type)
-        else:
-            print(
-                "%s is incorrect. Available area_types are 'loadzone',"
-                "'state', 'state_abbr', 'interconnect'." % area_type
-            )
-            raise ValueError("Invalid area_type")
-    else:
-        if area in list(abv2state.values()):
-            loadzone_set = state2loadzone[area]
-        elif area in loadzone:
-            loadzone_set = {area}
-        elif area in abv2state:
-            loadzone_set = state2loadzone[abv2state[area]]
-        elif area in {"Texas", "Western", "Eastern"}:
-            loadzone_set = interconnect2loadzone[area]
-        elif area == "all":
-            loadzone_set = loadzone
-        else:
-            print("%s is incorrect." % area)
-            raise ValueError("Invalid area")
-    return loadzone_set

--- a/powersimdata/tests/mock_scenario_info.py
+++ b/powersimdata/tests/mock_scenario_info.py
@@ -5,7 +5,8 @@ from powersimdata.tests.mock_scenario import MockScenario
 class MockScenarioInfo(ScenarioInfo):
     def __init__(self, scenario=None):
         self._DEFAULT_FLOAT = 42
-        scenario = scenario if scenario is not None else MockScenario()
+        scenario = MockScenario() if scenario is None else scenario
+        scenario.state.grid.get_grid_model = lambda: "mock_grid"
         super().__init__(scenario)
 
     def area_to_loadzone(self, area, area_type=None):


### PR DESCRIPTION
### Purpose
- Generalize `area_to_loadzone` to be independent of any given grid model, and create model-specific helper functions which wrap around this generalized function.
- To accomplish this, add a `get_grid_model` function to the Grid object, which can work for a fresh `Grid` or for a `ScenarioGrid`. 

### What the code is doing
- `area_to_loadzone` is removed from `powersimdata.network.usa_tamu.model`.
- A generalized `area_to_loadzone` is added to `powersimdata.network.model`. We add `grid_model` and `mappings` as inputs, used to look up the constants from the appropriate grid model and to control which entries from `[grid_model].constants.zones` we try to access, so that we can avoid trying to access e.g. `zones["state2loadzone"` for a Europe grid.
- We pre-code the set of mapping methods within `usa_tamu.constants.zones`.
- We add a convenienct method `area_to_loadzone` to `ModelImmutables`, which uses the information from the looked-up model to pre-populate some of the entries in the generalized `area_to_loadzone` function.
- We add a new method to the Grid object, `get_grid_model`, which uses the `data_loc` attribute to determine the grid model
  - For a fresh grid, we have the path to the data folder and we can extract the name that way
  - For a previously-run grid, we add a lookup using the ScenarioList (doesn't work now, will work once there's a `grid_model` column).
- We update uses of the `area_to_loadzone` function to use the `get_grid_model` method of a given grid, and pass that to `area_to_loadzone`. For MockGrids, we add a simple `lambda` function to achieve the same result as the previous hard-coding within `area_to_loadzone`.

### Testing
All unit tests still pass.

### Usage Example/Visuals
We can get the grid model easily for a `Grid`:
```python
>>> from powersimdata.input.grid import Grid
>>> Grid("Western").get_grid_model()
Reading bus.csv
Reading plant.csv
Reading gencost.csv
Reading branch.csv
Reading dcline.csv
Reading sub.csv
Reading bus2sub.csv
Reading zone.csv
'usa_tamu'
```
We can't yet get the grid model for a `ScenarioGrid`, because this column is not present in the ScenarioList:
```
>>> from powersimdata.scenario.scenario import Scenario
>>> Scenario(2497).state.get_grid().get_grid_model()
Transferring ScenarioList.csv from server
100%|#######################################| 445k/445k [00:00<00:00, 3.17Mb/s]
Transferring ExecuteList.csv from server
100%|######################################| 39.3k/39.3k [00:00<00:00, 782kb/s]
SCENARIO: Terrapower | Western_90pctclean_10pctnuclear_0pctflex_OB1

--> State
analyze
--> Loading grid
Loading bus
Loading plant
Loading heat_rate_curve
Loading gencost_before
Loading gencost_after
Loading branch
Loading dcline
Loading sub
Loading bus2sub
--> Loading ct
Transferring ScenarioList.csv from server
100%|#######################################| 445k/445k [00:00<00:00, 1.59Mb/s]
Traceback (most recent call last):
  File "C:\Python38\lib\site-packages\pandas\core\indexes\base.py", line 2891, in get_loc
    return self._engine.get_loc(casted_key)
  File "pandas\_libs\index.pyx", line 70, in pandas._libs.index.IndexEngine.get_loc
  File "pandas\_libs\index.pyx", line 101, in pandas._libs.index.IndexEngine.get_loc
  File "pandas\_libs\hashtable_class_helper.pxi", line 1675, in pandas._libs.hashtable.PyObjectHashTable.get_item
  File "pandas\_libs\hashtable_class_helper.pxi", line 1683, in pandas._libs.hashtable.PyObjectHashTable.get_item
KeyError: 'grid_model'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\Users\DanielOlsen\repos\bes\PowerSimData\powersimdata\input\grid.py", line 73, in get_grid_model
    return slm.get_scenario_table().loc[scenario_number, "grid_model"]
  File "C:\Python38\lib\site-packages\pandas\core\indexing.py", line 873, in __getitem__
    return self._getitem_tuple(key)
  File "C:\Python38\lib\site-packages\pandas\core\indexing.py", line 1044, in _getitem_tuple
    return self._getitem_lowerdim(tup)
  File "C:\Python38\lib\site-packages\pandas\core\indexing.py", line 810, in _getitem_lowerdim
    return getattr(section, self.name)[new_key]
  File "C:\Python38\lib\site-packages\pandas\core\indexing.py", line 879, in __getitem__
    return self._getitem_axis(maybe_callable, axis=axis)
  File "C:\Python38\lib\site-packages\pandas\core\indexing.py", line 1110, in _getitem_axis
    return self._get_label(key, axis=axis)
  File "C:\Python38\lib\site-packages\pandas\core\indexing.py", line 1059, in _get_label
    return self.obj.xs(label, axis=axis)
  File "C:\Python38\lib\site-packages\pandas\core\generic.py", line 3488, in xs
    loc = self.index.get_loc(key)
  File "C:\Python38\lib\site-packages\pandas\core\indexes\base.py", line 2893, in get_loc
    raise KeyError(key) from err
KeyError: 'grid_model'
```

### Time estimate
30 minutes.