### PR TITLE
feat: add optional solver parameter to launch_simulation

### DIFF
--- a/powersimdata/scenario/execute.py
+++ b/powersimdata/scenario/execute.py
@@ -219,6 +219,18 @@ class Execute(State):
             )
         return resp
 
+    def _check_threads(self, threads):
+        if threads:
+            if not isinstance(threads, int):
+                raise TypeError("threads must be an int")
+            if threads < 1:
+                raise ValueError("threads must be a positive value")
+
+    def _check_solver(self, solver):
+        solvers = ("gurobi", "glpk")
+        if solver is not None and solver.lower() not in solvers:
+            raise ValueError(f"Invalid solver: options are {solvers}")
+
     def launch_simulation(self, threads=None, extract_data=True, solver=None):
         """Launches simulation on target environment (server or container)
 
@@ -229,17 +241,14 @@ class Execute(State):
         :param str solver: the solver used for optimization. This defaults to
             None, which translates to gurobi
         :raises TypeError: if threads is not an int
-        :raises ValueError: if threads is not a positive value
+        :raises ValueError: if threads is not a positive value or invalid
+            solver provided
         :return: (*subprocess.Popen*) or (*requests.Response*) - either the
             process (if using ssh to server) or http response (if run in container)
         """
         self._check_if_ready()
-
-        if threads:
-            if not isinstance(threads, int):
-                raise TypeError("threads must be an int")
-            if threads < 1:
-                raise ValueError("threads must be a positive value")
+        self._check_threads(threads)
+        self._check_solver(solver)
 
         mode = get_deployment_mode()
         print(f"--> Launching simulation on {mode.lower()}")

--- a/powersimdata/scenario/execute.py
+++ b/powersimdata/scenario/execute.py
@@ -220,6 +220,12 @@ class Execute(State):
         return resp
 
     def _check_threads(self, threads):
+        """Validate threads argument
+
+        :param int threads: the number of threads to be used
+        :raises TypeError: if threads is not an int
+        :raises ValueError: if threads is not a positive value
+        """
         if threads:
             if not isinstance(threads, int):
                 raise TypeError("threads must be an int")
@@ -227,6 +233,11 @@ class Execute(State):
                 raise ValueError("threads must be a positive value")
 
     def _check_solver(self, solver):
+        """Validate solver argument
+
+        :param str solver: the solver used for the optimization
+        :raises ValueError: if invalid solver provided
+        """
         solvers = ("gurobi", "glpk")
         if solver is not None and solver.lower() not in solvers:
             raise ValueError(f"Invalid solver: options are {solvers}")
@@ -240,9 +251,6 @@ class Execute(State):
             automatically extracted after the simulation has run. This defaults to True.
         :param str solver: the solver used for optimization. This defaults to
             None, which translates to gurobi
-        :raises TypeError: if threads is not an int
-        :raises ValueError: if threads is not a positive value or invalid
-            solver provided
         :return: (*subprocess.Popen*) or (*requests.Response*) - either the
             process (if using ssh to server) or http response (if run in container)
         """


### PR DESCRIPTION
### Purpose
Corresponding changes for the new solver option in REISE.jl. This allows a user to specify either gurobi or glpk when launching a simulation, which closes the loop Daniel started by allowing multiple solvers. 

### What the code is doing
Expose the solver parameter which defaults to gurobi. This is passed to both the server and container "launch" methods for consistency.

### Testing
Built the container and tested the solver argument in "container mode". This didn't invoke the `_launch_on_server` overload but it's essentially copy paste (same logic is used by the [api](https://github.com/Breakthrough-Energy/REISE.jl/blob/develop/pyreisejl/utility/app.py#L38) when launched via http)

### Time estimate
5 min
