### PR TITLE
fix: correct bug with carried-over gencosts for new plants

### DIFF
--- a/powersimdata/input/tests/test_transform_grid.py
+++ b/powersimdata/input/tests/test_transform_grid.py
@@ -446,6 +446,7 @@ def test_add_gen_add_entries_in_gencost_data_frame(ct):
             "c1": 50,
             "c2": 0.5,
         },
+        {"type": "solar", "bus_id": 2050363, "Pmax": 15},
     ]
     ct.add_plant(new_plant)
     new_grid = TransformGrid(grid, ct.ct).get_grid()

--- a/powersimdata/input/transform_grid.py
+++ b/powersimdata/input/transform_grid.py
@@ -184,9 +184,9 @@ class TransformGrid(object):
 
     def _add_branch(self):
         """Adds branch(es) to the grid."""
-        new_branch = {c: 0 for c in self.grid.branch.columns}
         v2x = voltage_to_x_per_distance(self.grid)
         for entry in self.ct["new_branch"]:
+            new_branch = {c: 0 for c in self.grid.branch.columns}
             from_bus_id = entry["from_bus_id"]
             to_bus_id = entry["to_bus_id"]
             interconnect = self.grid.bus.loc[from_bus_id].interconnect
@@ -230,9 +230,9 @@ class TransformGrid(object):
             k: v[0] for k, v in bus.groupby("zone_id").interconnect.unique().items()
         }
         latlon2sub = self.grid.sub.groupby(["lat", "lon"]).groups
-        new_bus = {c: 0 for c in bus.columns}
         for entry in self.ct["new_bus"]:
             # Add to the bus dataframe
+            new_bus = {c: 0 for c in bus.columns}
             new_bus["type"] = 1
             new_bus["Pd"] = entry["Pd"]
             new_bus["zone_id"] = entry["zone_id"]
@@ -285,8 +285,8 @@ class TransformGrid(object):
 
     def _add_dcline(self):
         """Adds HVDC line(s) to the grid"""
-        new_dcline = {c: 0 for c in self.grid.dcline.columns}
         for entry in self.ct["new_dcline"]:
+            new_dcline = {c: 0 for c in self.grid.dcline.columns}
             from_bus_id = entry["from_bus_id"]
             to_bus_id = entry["to_bus_id"]
             from_interconnect = self.grid.bus.loc[from_bus_id].interconnect
@@ -312,8 +312,8 @@ class TransformGrid(object):
 
     def _add_plant(self):
         """Adds plant to the grid"""
-        new_plant = {c: 0 for c in self.grid.plant.columns}
         for entry in self.ct["new_plant"]:
+            new_plant = {c: 0 for c in self.grid.plant.columns}
             bus_id = entry["bus_id"]
             interconnect = self.grid.bus.loc[bus_id].interconnect
             zone_id = self.grid.bus.loc[bus_id].zone_id

--- a/powersimdata/input/transform_grid.py
+++ b/powersimdata/input/transform_grid.py
@@ -338,8 +338,8 @@ class TransformGrid(object):
 
     def _add_gencost(self):
         """Adds generation cost curves."""
-        new_gencost = {c: 0 for c in self.grid.gencost["before"].columns}
         for entry in self.ct["new_plant"]:
+            new_gencost = {c: 0 for c in self.grid.gencost["before"].columns}
             bus_id = entry["bus_id"]
             new_gencost["type"] = 2
             new_gencost["n"] = 3


### PR DESCRIPTION
### Purpose
Fix the bug, where new renewable generators added after a thermal generator inherit the thermal generator's cost curve coefficients.

### What the code is doing
The first commit reproduces the code in a test, the second commit fixes it by ensuring that no values are carried over.

### Time estimate
1 minute.