### PR TITLE
fix/refactor: return grid model for ScenarioGrid, reduce repeated get_grid_model calls

### DIFF
--- a/powersimdata/design/generation/clean_capacity_scaling.py
+++ b/powersimdata/design/generation/clean_capacity_scaling.py
@@ -101,11 +101,12 @@ def _make_zonename2target(grid, targets):
     :raises ValueError: if a zone is not present in any target areas, or
         if a zone is present in more than one target area.
     """
+    grid_model = grid.get_grid_model()
     target_zones = {
-        target_name: area_to_loadzone(grid.get_grid_model(), target_name)
+        target_name: area_to_loadzone(grid_model, target_name)
         if pd.isnull(targets.loc[target_name, "area_type"])
         else area_to_loadzone(
-            grid.get_grid_model(), target_name, targets.loc[target_name, "area_type"]
+            grid_model, target_name, targets.loc[target_name, "area_type"]
         )
         for target_name in targets.index.tolist()
     }

--- a/powersimdata/design/transmission/upgrade.py
+++ b/powersimdata/design/transmission/upgrade.py
@@ -175,8 +175,9 @@ def get_branches_by_area(grid, area_names, method="either"):
 
     branch = grid.branch
     selected_branches = set()
+    grid_model = grid.get_grid_model()
     for a in area_names:
-        load_zone_names = area_to_loadzone(grid.get_grid_model(), a)
+        load_zone_names = area_to_loadzone(grid_model, a)
         to_bus_in_area = branch.to_zone_name.isin(load_zone_names)
         from_bus_in_area = branch.from_zone_name.isin(load_zone_names)
         if method in ("internal", "either"):

--- a/powersimdata/input/grid.py
+++ b/powersimdata/input/grid.py
@@ -69,7 +69,7 @@ class Grid(object):
         :return: (*str*).
         """
         if os.path.isfile(self.data_loc):
-            _get_grid_model_from_scenario_list(self.data_loc)
+            return _get_grid_model_from_scenario_list(self.data_loc)
         elif os.path.isdir(self.data_loc):
             return self.data_loc.split(os.sep)[-2]
 


### PR DESCRIPTION
### Purpose
Return grid model for ScenarioGrid, reduce repeated get_grid_model calls

### What the code is doing
The first commit in **grid.py** fixes a bug where the grid model is determined but not returned.
The next commits in **clean_capacity_scaling.py** and **upgrade.py** move the `Grid.get_grid_model()` call out of a loop, since every call to `get_grid_model()` for a `ScenarioGrid` requires a fresh download of the ScenarioList to complete the `ScenarioListManager.get_scenario` call.

### Time estimate
5 minutes.
