### PR TITLE
Manage scenario/execute list using pandas

### DIFF
--- a/powersimdata/data_access/csv_store.py
+++ b/powersimdata/data_access/csv_store.py
@@ -48,9 +48,10 @@ class CsvStore:
         table.fillna("", inplace=True)
         return table.astype(str)
 
-    def _save_file(self, table):
-        """Save to local directory
+    def commit(self, table):
+        """Save to local directory and upload if needed
 
         :param pandas.DataFrame table: the data frame to save
         """
         table.to_csv(os.path.join(server_setup.LOCAL_DIR, self._FILE_NAME))
+        self.data_access.push(self._FILE_NAME)

--- a/powersimdata/data_access/csv_store.py
+++ b/powersimdata/data_access/csv_store.py
@@ -1,9 +1,26 @@
+import functools
 import os
 from pathlib import Path
 
 import pandas as pd
 
 from powersimdata.utility import server_setup
+
+
+def verify_hash(func):
+    """Utility function which verifies the sha1sum of the file before writing
+    it on the server. Operates on methods that return an updated scenario or
+    execute list.
+    """
+
+    @functools.wraps(func)
+    def wrapper(self, *args, **kwargs):
+        checksum = self.data_access.checksum(self._FILE_NAME)
+        table = func(self, *args, **kwargs)
+        self.commit(table, checksum)
+        return table
+
+    return wrapper
 
 
 class CsvStore:
@@ -17,12 +34,13 @@ class CsvStore:
         """Constructor"""
         self.data_access = data_access
 
-    def get_table(self, filename):
+    def get_table(self):
         """Read the given file from the server, falling back to local copy if
         unable to connect.
 
         :return: (*pandas.DataFrame*) -- the specified table as a data frame.
         """
+        filename = self._FILE_NAME
         local_path = Path(server_setup.LOCAL_DIR, filename)
 
         try:
@@ -48,10 +66,11 @@ class CsvStore:
         table.fillna("", inplace=True)
         return table.astype(str)
 
-    def commit(self, table):
+    def commit(self, table, checksum):
         """Save to local directory and upload if needed
 
         :param pandas.DataFrame table: the data frame to save
+        :param str checksum: the checksum prior to download
         """
         table.to_csv(os.path.join(server_setup.LOCAL_DIR, self._FILE_NAME))
-        self.data_access.push(self._FILE_NAME)
+        self.data_access.push(self._FILE_NAME, checksum)

--- a/powersimdata/data_access/csv_store.py
+++ b/powersimdata/data_access/csv_store.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 
 import pandas as pd
@@ -47,22 +48,9 @@ class CsvStore:
         table.fillna("", inplace=True)
         return table.astype(str)
 
-    def _execute_and_check_err(self, command, err_message):
-        """Executes command and checks for error.
+    def _save_file(self, table):
+        """Save to local directory
 
-        :param str command: command to execute over ssh.
-        :param str err_message: error message to be raised.
-        :raises IOError: if command is not successfully executed.
-        :return: (*list*) -- list of command output.
+        :param pandas.DataFrame table: the data frame to save
         """
-        stdin, stdout, stderr = self.data_access.execute_command(command)
-        command_output = stdout.readlines()
-        command_error = stderr.readlines()
-        if len(command_error) != 0:
-            command_error = [
-                i.replace("\t", " ").replace("\n", "") for i in command_error
-            ]
-            for ce in command_error:
-                print(ce)
-            raise IOError(err_message)
-        return command_output
+        table.to_csv(os.path.join(server_setup.LOCAL_DIR, self._FILE_NAME))

--- a/powersimdata/data_access/data_access.py
+++ b/powersimdata/data_access/data_access.py
@@ -345,7 +345,7 @@ class SSHDataAccess(DataAccess):
         :param str checksum: the checksum prior to download
         :raises IOError: if command generated stderr
         """
-        backup = f"{file_name}.bak"
+        backup = f"{file_name}.temp"
         self.move_to(file_name, change_name_to=backup, preserve=True)
 
         values = {

--- a/powersimdata/data_access/execute_list.py
+++ b/powersimdata/data_access/execute_list.py
@@ -135,7 +135,7 @@ class ExecuteListManager(CsvStore):
         """
         table = self.get_execute_table()
         scenario_id = int(scenario_info["id"])
-        table.drop(scenario_id)
+        table.drop(scenario_id, inplace=True)
 
         print("--> Deleting entry in execute table on server")
         return table

--- a/powersimdata/data_access/execute_list.py
+++ b/powersimdata/data_access/execute_list.py
@@ -125,15 +125,15 @@ class ExecuteListManager(CsvStore):
     def set_status(self, scenario_id, status):
         """Set the scenario status
 
-        :param int scenario_id: the scenario id
+        :param int/str scenario_id: the scenario id
         :param str status: the new status
         """
         table = self.get_execute_table()
-        table.loc[scenario_id, "status"] = status
+        table.loc[int(scenario_id), "status"] = status
         self._save_file(table)
 
         print(f"-->  Setting status={status} in execute table on server")
-        self.data_access.move_to(self._EXECUTE_LIST)
+        self.data_access.move_to(self._EXECUTE_LIST, force=True)
 
     def delete_entry(self, scenario_info):
         """Deletes entry from execute list on server.
@@ -146,4 +146,4 @@ class ExecuteListManager(CsvStore):
         self._save_file(table)
 
         print("--> Deleting entry in execute table on server")
-        self.data_access.move_to(self._EXECUTE_LIST)
+        self.data_access.move_to(self._EXECUTE_LIST, force=True)

--- a/powersimdata/data_access/execute_list.py
+++ b/powersimdata/data_access/execute_list.py
@@ -1,4 +1,3 @@
-import os
 import posixpath
 
 from powersimdata.data_access.csv_store import CsvStore
@@ -77,21 +76,12 @@ class ExecuteListManager(CsvStore):
     :param paramiko.client.SSHClient ssh_client: session with an SSH server.
     """
 
-    _EXECUTE_LIST = "ExecuteList.csv"
+    _FILE_NAME = "ExecuteList.csv"
 
     def __init__(self, ssh_client):
         """Constructor"""
         super().__init__(ssh_client)
-        self._server_path = posixpath.join(
-            server_setup.DATA_ROOT_DIR, self._EXECUTE_LIST
-        )
-
-    def _save_file(self, table):
-        """Save to local directory
-
-        :param pandas.DataFrame table: the execute list data frame
-        """
-        table.to_csv(os.path.join(server_setup.LOCAL_DIR, self._EXECUTE_LIST))
+        self._server_path = posixpath.join(server_setup.DATA_ROOT_DIR, self._FILE_NAME)
 
     def get_execute_table(self):
         """Returns execute table from server if possible, otherwise read local
@@ -99,7 +89,7 @@ class ExecuteListManager(CsvStore):
 
         :return: (*pandas.DataFrame*) -- execute list as a data frame.
         """
-        return self.get_table(self._EXECUTE_LIST)
+        return self.get_table(self._FILE_NAME)
 
     def get_status(self, scenario_id):
         """Return the status for the scenario
@@ -133,7 +123,7 @@ class ExecuteListManager(CsvStore):
         self._save_file(table)
 
         print(f"-->  Setting status={status} in execute table on server")
-        self.data_access.move_to(self._EXECUTE_LIST, force=True)
+        self.data_access.move_to(self._FILE_NAME, force=True)
 
     def delete_entry(self, scenario_info):
         """Deletes entry from execute list on server.
@@ -146,4 +136,4 @@ class ExecuteListManager(CsvStore):
         self._save_file(table)
 
         print("--> Deleting entry in execute table on server")
-        self.data_access.move_to(self._EXECUTE_LIST, force=True)
+        self.data_access.move_to(self._FILE_NAME, force=True)

--- a/powersimdata/data_access/execute_list.py
+++ b/powersimdata/data_access/execute_list.py
@@ -120,10 +120,9 @@ class ExecuteListManager(CsvStore):
         """
         table = self.get_execute_table()
         table.loc[int(scenario_id), "status"] = status
-        self._save_file(table)
 
         print(f"-->  Setting status={status} in execute table on server")
-        self.data_access.move_to(self._FILE_NAME, force=True)
+        self.commit(table)
 
     def delete_entry(self, scenario_info):
         """Deletes entry from execute list on server.
@@ -133,7 +132,6 @@ class ExecuteListManager(CsvStore):
         table = self.get_execute_table()
         scenario_id = int(scenario_info["id"])
         table.drop(scenario_id)
-        self._save_file(table)
 
         print("--> Deleting entry in execute table on server")
-        self.data_access.move_to(self._FILE_NAME, force=True)
+        self.commit(table)

--- a/powersimdata/data_access/execute_list.py
+++ b/powersimdata/data_access/execute_list.py
@@ -1,6 +1,6 @@
 import posixpath
 
-from powersimdata.data_access.csv_store import CsvStore
+from powersimdata.data_access.csv_store import CsvStore, verify_hash
 from powersimdata.data_access.sql_store import SqlStore, to_data_frame
 from powersimdata.utility import server_setup
 
@@ -89,7 +89,7 @@ class ExecuteListManager(CsvStore):
 
         :return: (*pandas.DataFrame*) -- execute list as a data frame.
         """
-        return self.get_table(self._FILE_NAME)
+        return self.get_table()
 
     def get_status(self, scenario_id):
         """Return the status for the scenario
@@ -112,26 +112,30 @@ class ExecuteListManager(CsvStore):
         scenario_id = int(scenario_info["id"])
         return self.set_status(scenario_id, "created")
 
+    @verify_hash
     def set_status(self, scenario_id, status):
         """Set the scenario status
 
         :param int/str scenario_id: the scenario id
         :param str status: the new status
+        :return: (*pandas.DataFrame*) -- the updated data frame
         """
         table = self.get_execute_table()
         table.loc[int(scenario_id), "status"] = status
 
         print(f"-->  Setting status={status} in execute table on server")
-        self.commit(table)
+        return table
 
+    @verify_hash
     def delete_entry(self, scenario_info):
         """Deletes entry from execute list on server.
 
         :param collections.OrderedDict scenario_info: entry to delete
+        :return: (*pandas.DataFrame*) -- the updated data frame
         """
         table = self.get_execute_table()
         scenario_id = int(scenario_info["id"])
         table.drop(scenario_id)
 
         print("--> Deleting entry in execute table on server")
-        self.commit(table)
+        return table

--- a/powersimdata/data_access/execute_list.py
+++ b/powersimdata/data_access/execute_list.py
@@ -61,13 +61,13 @@ class ExecuteTable(SqlStore):
             (status, scenario_id),
         )
 
-    def delete_entry(self, scenario_info):
+    def delete_entry(self, scenario_id):
         """Deletes entry from execute list.
 
-        :param collections.OrderedDict scenario_info: entry to delete
+        :param int/str scenario_id: the id of the scenario
         """
         sql = self.delete("id")
-        self.cur.execute(sql, (scenario_info["id"],))
+        self.cur.execute(sql, (scenario_id,))
 
 
 class ExecuteListManager(CsvStore):
@@ -127,15 +127,14 @@ class ExecuteListManager(CsvStore):
         return table
 
     @verify_hash
-    def delete_entry(self, scenario_info):
+    def delete_entry(self, scenario_id):
         """Deletes entry from execute list on server.
 
-        :param collections.OrderedDict scenario_info: entry to delete
+        :param int/str scenario_id: the id of the scenario
         :return: (*pandas.DataFrame*) -- the updated data frame
         """
         table = self.get_execute_table()
-        scenario_id = int(scenario_info["id"])
-        table.drop(scenario_id, inplace=True)
+        table.drop(int(scenario_id), inplace=True)
 
         print("--> Deleting entry in execute table on server")
         return table

--- a/powersimdata/data_access/scenario_list.py
+++ b/powersimdata/data_access/scenario_list.py
@@ -148,10 +148,9 @@ class ScenarioListManager(CsvStore):
         entry = pd.DataFrame({k: [v] for k, v in scenario_info.items()})
         table = table.append(entry)
         table.set_index("id", inplace=True)
-        self._save_file(table)
 
         print("--> Adding entry in %s on server" % self._FILE_NAME)
-        self.data_access.move_to(self._FILE_NAME, force=True)
+        self.commit(table)
 
     def delete_entry(self, scenario_info):
         """Deletes entry in scenario list.
@@ -161,7 +160,6 @@ class ScenarioListManager(CsvStore):
         table = self.get_scenario_table()
         scenario_id = int(scenario_info["id"])
         table.drop(scenario_id)
-        self._save_file(table)
 
         print("--> Deleting entry in %s on server" % self._FILE_NAME)
-        self.data_access.move_to(self._FILE_NAME, force=True)
+        self.commit(table)

--- a/powersimdata/data_access/scenario_list.py
+++ b/powersimdata/data_access/scenario_list.py
@@ -3,7 +3,7 @@ from collections import OrderedDict
 
 import pandas as pd
 
-from powersimdata.data_access.csv_store import CsvStore
+from powersimdata.data_access.csv_store import CsvStore, verify_hash
 from powersimdata.data_access.sql_store import SqlStore, to_data_frame
 from powersimdata.utility import server_setup
 
@@ -92,7 +92,7 @@ class ScenarioListManager(CsvStore):
 
         :return: (*pandas.DataFrame*) -- scenario list as a data frame.
         """
-        return self.get_table(self._FILE_NAME)
+        return self.get_table()
 
     def generate_scenario_id(self):
         """Generates scenario id.
@@ -138,10 +138,12 @@ class ScenarioListManager(CsvStore):
                 .to_dict("records", into=OrderedDict)[0]
             )
 
+    @verify_hash
     def add_entry(self, scenario_info):
         """Adds scenario to the scenario list file on server.
 
         :param collections.OrderedDict scenario_info: entry to add to scenario list.
+        :return: (*pandas.DataFrame*) -- the updated data frame
         """
         table = self.get_scenario_table()
         table.reset_index(inplace=True)
@@ -150,16 +152,18 @@ class ScenarioListManager(CsvStore):
         table.set_index("id", inplace=True)
 
         print("--> Adding entry in %s on server" % self._FILE_NAME)
-        self.commit(table)
+        return table
 
+    @verify_hash
     def delete_entry(self, scenario_info):
         """Deletes entry in scenario list.
 
         :param collections.OrderedDict scenario_info: entry to delete from scenario list.
+        :return: (*pandas.DataFrame*) -- the updated data frame
         """
         table = self.get_scenario_table()
         scenario_id = int(scenario_info["id"])
         table.drop(scenario_id)
 
         print("--> Deleting entry in %s on server" % self._FILE_NAME)
-        self.commit(table)
+        return table

--- a/powersimdata/data_access/scenario_list.py
+++ b/powersimdata/data_access/scenario_list.py
@@ -100,7 +100,7 @@ class ScenarioListManager(CsvStore):
 
         :return: (*str*) -- new scenario id.
         """
-        table = self.get_table(self._SCENARIO_LIST)
+        table = self.get_scenario_table()
         return str(table.index.max() + 1)
 
     def get_scenario(self, descriptor):
@@ -149,7 +149,7 @@ class ScenarioListManager(CsvStore):
 
         :param collections.OrderedDict scenario_info: entry to add to scenario list.
         """
-        table = self.get_table(self._SCENARIO_LIST)
+        table = self.get_scenario_table()
         table.reset_index()
         table.append(scenario_info)
         self._save_file(table)
@@ -162,7 +162,7 @@ class ScenarioListManager(CsvStore):
 
         :param collections.OrderedDict scenario_info: entry to delete from scenario list.
         """
-        table = self.get_table(self._SCENARIO_LIST)
+        table = self.get_scenario_table()
         scenario_id = int(scenario_info["id"])
         table.drop(scenario_id)
         self._save_file(table)

--- a/powersimdata/data_access/scenario_list.py
+++ b/powersimdata/data_access/scenario_list.py
@@ -64,13 +64,13 @@ class ScenarioTable(SqlStore):
         sql = self.insert(subset=scenario_info.keys())
         self.cur.execute(sql, tuple(scenario_info.values()))
 
-    def delete_entry(self, scenario_info):
+    def delete_entry(self, scenario_id):
         """Deletes entry in scenario list.
 
-        :param collections.OrderedDict scenario_info: entry to delete from scenario list.
+        :param int/str scenario_id: the id of the scenario
         """
         sql = self.delete("id")
-        self.cur.execute(sql, (scenario_info["id"],))
+        self.cur.execute(sql, (scenario_id,))
 
 
 class ScenarioListManager(CsvStore):
@@ -155,15 +155,14 @@ class ScenarioListManager(CsvStore):
         return table
 
     @verify_hash
-    def delete_entry(self, scenario_info):
+    def delete_entry(self, scenario_id):
         """Deletes entry in scenario list.
 
-        :param collections.OrderedDict scenario_info: entry to delete from scenario list.
+        :param int/str scenario_id: the id of the scenario
         :return: (*pandas.DataFrame*) -- the updated data frame
         """
         table = self.get_scenario_table()
-        scenario_id = int(scenario_info["id"])
-        table.drop(scenario_id)
+        table.drop(int(scenario_id), inplace=True)
 
         print("--> Deleting entry in %s on server" % self._FILE_NAME)
         return table

--- a/powersimdata/data_access/scenario_list.py
+++ b/powersimdata/data_access/scenario_list.py
@@ -1,4 +1,3 @@
-import os
 import posixpath
 from collections import OrderedDict
 
@@ -80,14 +79,12 @@ class ScenarioListManager(CsvStore):
     :param paramiko.client.SSHClient ssh_client: session with an SSH server.
     """
 
-    _SCENARIO_LIST = "ScenarioList.csv"
+    _FILE_NAME = "ScenarioList.csv"
 
     def __init__(self, ssh_client):
         """Constructor"""
         super().__init__(ssh_client)
-        self._server_path = posixpath.join(
-            server_setup.DATA_ROOT_DIR, self._SCENARIO_LIST
-        )
+        self._server_path = posixpath.join(server_setup.DATA_ROOT_DIR, self._FILE_NAME)
 
     def get_scenario_table(self):
         """Returns scenario table from server if possible, otherwise read local
@@ -95,7 +92,7 @@ class ScenarioListManager(CsvStore):
 
         :return: (*pandas.DataFrame*) -- scenario list as a data frame.
         """
-        return self.get_table(self._SCENARIO_LIST)
+        return self.get_table(self._FILE_NAME)
 
     def generate_scenario_id(self):
         """Generates scenario id.
@@ -141,13 +138,6 @@ class ScenarioListManager(CsvStore):
                 .to_dict("records", into=OrderedDict)[0]
             )
 
-    def _save_file(self, table):
-        """Save to local directory
-
-        :param pandas.DataFrame table: the scenario list data frame
-        """
-        table.to_csv(os.path.join(server_setup.LOCAL_DIR, self._SCENARIO_LIST))
-
     def add_entry(self, scenario_info):
         """Adds scenario to the scenario list file on server.
 
@@ -160,8 +150,8 @@ class ScenarioListManager(CsvStore):
         table.set_index("id", inplace=True)
         self._save_file(table)
 
-        print("--> Adding entry in %s on server" % self._SCENARIO_LIST)
-        self.data_access.move_to(self._SCENARIO_LIST, force=True)
+        print("--> Adding entry in %s on server" % self._FILE_NAME)
+        self.data_access.move_to(self._FILE_NAME, force=True)
 
     def delete_entry(self, scenario_info):
         """Deletes entry in scenario list.
@@ -173,5 +163,5 @@ class ScenarioListManager(CsvStore):
         table.drop(scenario_id)
         self._save_file(table)
 
-        print("--> Deleting entry in %s on server" % self._SCENARIO_LIST)
-        self.data_access.move_to(self._SCENARIO_LIST, force=True)
+        print("--> Deleting entry in %s on server" % self._FILE_NAME)
+        self.data_access.move_to(self._FILE_NAME, force=True)

--- a/powersimdata/data_access/tests/test_execute_csv.py
+++ b/powersimdata/data_access/tests/test_execute_csv.py
@@ -1,10 +1,16 @@
+import os
+import shutil
+from collections import OrderedDict
+
 import pandas as pd
 import pytest
 from numpy.testing import assert_array_equal
 from pandas.testing import assert_frame_equal
 
-from powersimdata.data_access.data_access import SSHDataAccess
+import powersimdata.utility.templates as templates
+from powersimdata.data_access.data_access import LocalDataAccess, SSHDataAccess
 from powersimdata.data_access.execute_list import ExecuteListManager
+from powersimdata.utility import server_setup
 
 
 @pytest.fixture
@@ -40,3 +46,68 @@ def test_get_execute_file_from_server_header(execute_table):
     header = ["status"]
     assert_array_equal(execute_table.columns, header)
     assert "id" == execute_table.index.name
+
+
+def clone_template():
+    orig = os.path.join(templates.__path__[0], "ExecuteList.csv")
+    backup = os.path.join(server_setup.LOCAL_DIR, "ExecuteList.csv.test")
+    shutil.copy(orig, backup)
+
+
+def mock_row():
+    return OrderedDict(
+        [
+            ("id", "1"),
+            ("state", "create"),
+            ("interconnect", "Western"),
+        ]
+    )
+
+
+@pytest.fixture
+def manager():
+    clone_template()
+    data_access = LocalDataAccess()
+    manager = ExecuteListManager(data_access)
+    manager._FILE_NAME = "ExecuteList.csv.test"
+    return manager
+
+
+def test_blank_csv_append(manager):
+    manager.add_entry(mock_row())
+    table = manager.get_execute_table()
+    assert table.shape == (1, 1)
+    status = manager.get_status(1)
+    assert status == "created"
+
+
+def test_set_status(manager):
+    manager.add_entry(mock_row())
+    asdf = "asdf"
+    result = manager.set_status(1, asdf)
+    assert result.loc[1, "status"] == asdf
+
+    foo = "foo"
+    result = manager.set_status("1", foo)
+    assert result.loc[1, "status"] == foo
+
+
+def test_get_status(manager):
+    manager.add_entry(mock_row())
+    status = manager.get_status(1)
+    assert status == "created"
+
+    status = manager.get_status("1")
+    assert status == "created"
+
+
+def test_delete(manager):
+    manager.add_entry(mock_row())
+    table = manager.get_execute_table()
+    assert table.shape == (1, 1)
+
+    table = manager.delete_entry(mock_row())
+    assert table.shape == (0, 1)
+
+    table = manager.get_execute_table()
+    assert table.shape == (0, 1)

--- a/powersimdata/data_access/tests/test_execute_csv.py
+++ b/powersimdata/data_access/tests/test_execute_csv.py
@@ -51,6 +51,7 @@ def test_get_execute_file_from_server_header(execute_table):
 def clone_template():
     orig = os.path.join(templates.__path__[0], "ExecuteList.csv")
     dest = os.path.join(server_setup.LOCAL_DIR, "ExecuteList.csv.test")
+    os.makedirs(server_setup.LOCAL_DIR, exist_ok=True)
     shutil.copy(orig, dest)
 
 

--- a/powersimdata/data_access/tests/test_execute_csv.py
+++ b/powersimdata/data_access/tests/test_execute_csv.py
@@ -7,10 +7,9 @@ import pytest
 from numpy.testing import assert_array_equal
 from pandas.testing import assert_frame_equal
 
-import powersimdata.utility.templates as templates
 from powersimdata.data_access.data_access import LocalDataAccess, SSHDataAccess
 from powersimdata.data_access.execute_list import ExecuteListManager
-from powersimdata.utility import server_setup
+from powersimdata.utility import server_setup, templates
 
 
 @pytest.fixture

--- a/powersimdata/data_access/tests/test_execute_csv.py
+++ b/powersimdata/data_access/tests/test_execute_csv.py
@@ -50,8 +50,8 @@ def test_get_execute_file_from_server_header(execute_table):
 
 def clone_template():
     orig = os.path.join(templates.__path__[0], "ExecuteList.csv")
-    backup = os.path.join(server_setup.LOCAL_DIR, "ExecuteList.csv.test")
-    shutil.copy(orig, backup)
+    dest = os.path.join(server_setup.LOCAL_DIR, "ExecuteList.csv.test")
+    shutil.copy(orig, dest)
 
 
 def mock_row():
@@ -106,7 +106,7 @@ def test_delete(manager):
     table = manager.get_execute_table()
     assert table.shape == (1, 1)
 
-    table = manager.delete_entry(mock_row())
+    table = manager.delete_entry(1)
     assert table.shape == (0, 1)
 
     table = manager.get_execute_table()

--- a/powersimdata/data_access/tests/test_execute_csv.py
+++ b/powersimdata/data_access/tests/test_execute_csv.py
@@ -53,6 +53,17 @@ def clone_template():
     dest = os.path.join(server_setup.LOCAL_DIR, "ExecuteList.csv.test")
     os.makedirs(server_setup.LOCAL_DIR, exist_ok=True)
     shutil.copy(orig, dest)
+    return dest
+
+
+@pytest.fixture
+def manager():
+    test_csv = clone_template()
+    data_access = LocalDataAccess()
+    manager = ExecuteListManager(data_access)
+    manager._FILE_NAME = "ExecuteList.csv.test"
+    yield manager
+    os.remove(test_csv)
 
 
 def mock_row():
@@ -63,15 +74,6 @@ def mock_row():
             ("interconnect", "Western"),
         ]
     )
-
-
-@pytest.fixture
-def manager():
-    clone_template()
-    data_access = LocalDataAccess()
-    manager = ExecuteListManager(data_access)
-    manager._FILE_NAME = "ExecuteList.csv.test"
-    return manager
 
 
 def test_blank_csv_append(manager):

--- a/powersimdata/data_access/tests/test_execute_table.py
+++ b/powersimdata/data_access/tests/test_execute_table.py
@@ -73,8 +73,9 @@ def test_add_entry(store):
 def test_update_entry(store):
     info = _get_test_row()
     store.add_entry(info)
-    store.update_execute_list("testing", info)
-    status = store.get_status(info["id"])
+    sid = info["id"]
+    store.set_status(sid, "testing")
+    status = store.get_status(sid)
     assert status.loc[0, "status"] == "testing"
 
 

--- a/powersimdata/data_access/tests/test_execute_table.py
+++ b/powersimdata/data_access/tests/test_execute_table.py
@@ -83,7 +83,8 @@ def test_update_entry(store):
 @pytest.mark.db
 def test_delete_entry(store):
     info = _get_test_row()
+    sid = info["id"]
     store.add_entry(info)
-    store.delete_entry(info)
-    status = store.get_status(info["id"])
+    store.delete_entry(sid)
+    status = store.get_status(sid)
     assert status.shape == (0, 0)

--- a/powersimdata/data_access/tests/test_scenario_csv.py
+++ b/powersimdata/data_access/tests/test_scenario_csv.py
@@ -68,6 +68,7 @@ def test_get_scenario_file_local(scenario_table):
 def clone_template():
     orig = os.path.join(templates.__path__[0], "ScenarioList.csv")
     dest = os.path.join(server_setup.LOCAL_DIR, "ScenarioList.csv.test")
+    os.makedirs(server_setup.LOCAL_DIR, exist_ok=True)
     shutil.copy(orig, dest)
 
 

--- a/powersimdata/data_access/tests/test_scenario_csv.py
+++ b/powersimdata/data_access/tests/test_scenario_csv.py
@@ -7,10 +7,9 @@ import pytest
 from numpy.testing import assert_array_equal
 from pandas.testing import assert_frame_equal
 
-import powersimdata.utility.templates as templates
 from powersimdata.data_access.data_access import LocalDataAccess, SSHDataAccess
 from powersimdata.data_access.scenario_list import ScenarioListManager
-from powersimdata.utility import server_setup
+from powersimdata.utility import server_setup, templates
 
 
 @pytest.fixture

--- a/powersimdata/data_access/tests/test_scenario_csv.py
+++ b/powersimdata/data_access/tests/test_scenario_csv.py
@@ -70,16 +70,17 @@ def clone_template():
     dest = os.path.join(server_setup.LOCAL_DIR, "ScenarioList.csv.test")
     os.makedirs(server_setup.LOCAL_DIR, exist_ok=True)
     shutil.copy(orig, dest)
+    return dest
 
 
 @pytest.fixture
 def manager():
-    clone_template()
+    test_csv = clone_template()
     data_access = LocalDataAccess()
     manager = ScenarioListManager(data_access)
     manager._FILE_NAME = "ScenarioList.csv.test"
     yield manager
-    data_access.close()
+    os.remove(test_csv)
 
 
 def mock_row(sid=1):

--- a/powersimdata/data_access/tests/test_scenario_csv.py
+++ b/powersimdata/data_access/tests/test_scenario_csv.py
@@ -1,10 +1,16 @@
+import os
+import shutil
+from collections import OrderedDict
+
 import pandas as pd
 import pytest
 from numpy.testing import assert_array_equal
 from pandas.testing import assert_frame_equal
 
-from powersimdata.data_access.data_access import SSHDataAccess
+import powersimdata.utility.templates as templates
+from powersimdata.data_access.data_access import LocalDataAccess, SSHDataAccess
 from powersimdata.data_access.scenario_list import ScenarioListManager
+from powersimdata.utility import server_setup
 
 
 @pytest.fixture
@@ -57,3 +63,70 @@ def test_get_scenario_file_local(scenario_table):
     scm = ScenarioListManager(None)
     from_local = scm.get_scenario_table()
     assert_frame_equal(from_local, scenario_table)
+
+
+def clone_template():
+    orig = os.path.join(templates.__path__[0], "ScenarioList.csv")
+    dest = os.path.join(server_setup.LOCAL_DIR, "ScenarioList.csv.test")
+    shutil.copy(orig, dest)
+
+
+@pytest.fixture
+def manager():
+    clone_template()
+    data_access = LocalDataAccess()
+    manager = ScenarioListManager(data_access)
+    manager._FILE_NAME = "ScenarioList.csv.test"
+    yield manager
+    data_access.close()
+
+
+def mock_row(sid=1):
+    return OrderedDict(
+        [
+            ("id", str(sid)),
+            ("plan", "test"),
+            ("name", "dummy"),
+            ("state", "create"),
+            ("grid_model", ""),
+            ("interconnect", "Western"),
+            ("base_demand", ""),
+            ("base_hydro", ""),
+            ("base_solar", ""),
+            ("base_wind", ""),
+            ("change_table", ""),
+            ("start_date", ""),
+            ("end_date", ""),
+            ("interval", ""),
+            ("engine", ""),
+        ]
+    )
+
+
+def test_generate_id(manager):
+    new_id = manager.generate_scenario_id()
+    assert new_id == "1"
+
+
+def test_blank_csv_append(manager):
+    manager.add_entry(mock_row(1))
+    table = manager.add_entry(mock_row(2))
+    assert table.shape == (2, 16)
+
+
+def test_get_scenario(manager):
+    manager.add_entry(mock_row(1))
+    manager.add_entry(mock_row(2))
+    manager.add_entry(mock_row(3))
+    entry = manager.get_scenario(2)
+    assert entry["id"] == "2"
+    entry = manager.get_scenario("2")
+    assert entry["id"] == "2"
+
+
+def test_delete_entry(manager):
+    manager.add_entry(mock_row(1))
+    manager.add_entry(mock_row(2))
+    manager.add_entry(mock_row(3))
+    table = manager.delete_entry(2)
+    assert table.shape == (2, 16)

--- a/powersimdata/data_access/tests/test_scenario_table.py
+++ b/powersimdata/data_access/tests/test_scenario_table.py
@@ -95,7 +95,8 @@ def test_add_entry_missing_required_raises():
 @pytest.mark.db
 def test_delete_entry(store):
     info = _get_test_row()
+    sid = info["id"]
     store.add_entry(info)
-    store.delete_entry(info)
-    entry = store.get_scenario_by_id(info["id"])
+    store.delete_entry(sid)
+    entry = store.get_scenario_by_id(sid)
     assert entry.shape == (0, 0)

--- a/powersimdata/scenario/execute.py
+++ b/powersimdata/scenario/execute.py
@@ -196,7 +196,7 @@ class Execute(State):
             extra_args.append("--threads " + str(threads))
 
         if solver:
-            extra_args.append("--solver", solver)
+            extra_args.append("--solver " + solver)
 
         if not isinstance(extract_data, bool):
             raise TypeError("extract_data must be a boolean: 'True' or 'False'")

--- a/powersimdata/scenario/execute.py
+++ b/powersimdata/scenario/execute.py
@@ -27,6 +27,8 @@ class Execute(State):
         """Constructor."""
         self._scenario_info = scenario.info
         self._scenario_status = scenario.status
+        self._scenario_id = int(self._scenario_info["id"])
+
         super().__init__(scenario)
 
         print(
@@ -68,13 +70,13 @@ class Execute(State):
 
     def _update_scenario_status(self):
         """Updates scenario status."""
-        scenario_id = self._scenario_info["id"]
-        self._scenario_status = self._execute_list_manager.get_status(scenario_id)
+        self._scenario_status = self._execute_list_manager.get_status(self._scenario_id)
 
     def _update_scenario_info(self):
         """Updates scenario information."""
-        scenario_id = self._scenario_info["id"]
-        self._scenario_info = self._scenario_list_manager.get_scenario(scenario_id)
+        self._scenario_info = self._scenario_list_manager.get_scenario(
+            self._scenario_id
+        )
 
     def _run_script(self, script, extra_args=None):
         """Returns running process
@@ -152,9 +154,7 @@ class Execute(State):
 
             si.prepare_mpc_file()
 
-            self._execute_list_manager.update_execute_list(
-                "prepared", self._scenario_info
-            )
+            self._execute_list_manager.set_status(self._scenario_id, "prepared")
         else:
             print("---------------------------")
             print("SCENARIO CANNOT BE PREPARED")
@@ -211,7 +211,7 @@ class Execute(State):
             None, which translates to gurobi
         :return: (*requests.Response*) -- the http response object
         """
-        scenario_id = self._scenario_info["id"]
+        scenario_id = self._scenario_id
         url = f"http://{server_setup.SERVER_ADDRESS}:5000/launch/{scenario_id}"
         resp = requests.post(url, params={"threads": threads, "solver": solver})
         if resp.status_code != 200:
@@ -274,7 +274,7 @@ class Execute(State):
         if mode != DeploymentMode.Container:
             raise NotImplementedError("Operation only supported for container mode")
 
-        scenario_id = self._scenario_info["id"]
+        scenario_id = self._scenario_id
         url = f"http://{server_setup.SERVER_ADDRESS}:5000/status/{scenario_id}"
         resp = requests.get(url)
         return resp.json()

--- a/powersimdata/scenario/execute.py
+++ b/powersimdata/scenario/execute.py
@@ -27,7 +27,6 @@ class Execute(State):
         """Constructor."""
         self._scenario_info = scenario.info
         self._scenario_status = scenario.status
-        self._scenario_id = int(self._scenario_info["id"])
 
         super().__init__(scenario)
 
@@ -39,6 +38,9 @@ class Execute(State):
         print("--> Status\n%s" % self._scenario_status)
 
         self._set_ct_and_grid()
+
+    def _scenario_id(self):
+        return self._scenario_info["id"]
 
     def _set_ct_and_grid(self):
         """Sets change table and grid."""
@@ -70,12 +72,14 @@ class Execute(State):
 
     def _update_scenario_status(self):
         """Updates scenario status."""
-        self._scenario_status = self._execute_list_manager.get_status(self._scenario_id)
+        self._scenario_status = self._execute_list_manager.get_status(
+            self._scenario_id()
+        )
 
     def _update_scenario_info(self):
         """Updates scenario information."""
         self._scenario_info = self._scenario_list_manager.get_scenario(
-            self._scenario_id
+            self._scenario_id()
         )
 
     def _run_script(self, script, extra_args=None):
@@ -154,7 +158,7 @@ class Execute(State):
 
             si.prepare_mpc_file()
 
-            self._execute_list_manager.set_status(self._scenario_id, "prepared")
+            self._execute_list_manager.set_status(self._scenario_id(), "prepared")
         else:
             print("---------------------------")
             print("SCENARIO CANNOT BE PREPARED")
@@ -211,7 +215,7 @@ class Execute(State):
             None, which translates to gurobi
         :return: (*requests.Response*) -- the http response object
         """
-        scenario_id = self._scenario_id
+        scenario_id = self._scenario_id()
         url = f"http://{server_setup.SERVER_ADDRESS}:5000/launch/{scenario_id}"
         resp = requests.post(url, params={"threads": threads, "solver": solver})
         if resp.status_code != 200:
@@ -274,7 +278,7 @@ class Execute(State):
         if mode != DeploymentMode.Container:
             raise NotImplementedError("Operation only supported for container mode")
 
-        scenario_id = self._scenario_id
+        scenario_id = self._scenario_id()
         url = f"http://{server_setup.SERVER_ADDRESS}:5000/status/{scenario_id}"
         resp = requests.get(url)
         return resp.json()

--- a/powersimdata/scenario/execute.py
+++ b/powersimdata/scenario/execute.py
@@ -27,7 +27,6 @@ class Execute(State):
         """Constructor."""
         self._scenario_info = scenario.info
         self._scenario_status = scenario.status
-
         super().__init__(scenario)
 
         print(

--- a/powersimdata/scenario/move.py
+++ b/powersimdata/scenario/move.py
@@ -39,7 +39,7 @@ class Move(State):
         backup.move_output_data()
         backup.move_temporary_folder()
 
-        sid = int(self._scenario_info["id"])
+        sid = self._scenario_info["id"]
         self._execute_list_manager.set_status(sid, "moved")
 
         # Delete attributes

--- a/powersimdata/scenario/move.py
+++ b/powersimdata/scenario/move.py
@@ -39,7 +39,8 @@ class Move(State):
         backup.move_output_data()
         backup.move_temporary_folder()
 
-        self._execute_list_manager.update_execute_list("moved", self._scenario_info)
+        sid = int(self._scenario_info["id"])
+        self._execute_list_manager.set_status(sid, "moved")
 
         # Delete attributes
         self._clean()

--- a/powersimdata/utility/server_setup.py
+++ b/powersimdata/utility/server_setup.py
@@ -10,7 +10,7 @@ EXECUTE_DIR = "tmp"
 BASE_PROFILE_DIR = "raw"
 INPUT_DIR = "data/input"
 OUTPUT_DIR = "data/output"
-LOCAL_DIR = os.path.join(str(Path.home()), "ScenarioData", "")
+LOCAL_DIR = os.path.join(Path.home(), "ScenarioData", "")
 MODEL_DIR = "/home/bes/pcm"
 
 

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
             "network/*/data/*.csv",
             "design/investment/data/*.csv",
             "design/investment/data/*/*",
+            "utility/templates/*.csv",
         ]
     },
     zip_safe=False,


### PR DESCRIPTION
### Purpose
Supports local usage on windows by limiting the assumption of a unix environment to the `SSHDataAccess` class (in the context of scenario/execute list only; there is more work to do for full windows support)

### What the code is doing
Implements the following pattern for scenario/execute list operations. For local environments: just modify and query using pandas. For the client/server environment:
* calculate `sha1sum` prior to download and save in a local variable
* download the file and modify as needed
* upload the file
* using `flock` to synchronize access, check if the current `sha1sum` of the file is the same as before, and if so, write the changes and create a backup (the `-b` option on `mv` command). 

The client/server operation basically extends the local variant by adding the integrity check, so we get some code reuse out of it. Other changes are mostly supporting functionality, with a few minor improvements thrown in.

### Testing
* Added unit tests (originally in plug, but realized they could go here). These test against an empty csv with headers, copied from the `powersimdata/utility/templates` for each test. 
* Tested in the standalone container setup by running a simulation from scratch
* Tested in the client/server container setup by creating and preparing a scenario (it's not set up to run one yet), as well as setting a breakpoint during the modification and editing the file in the server container to hit the error state

### Usage Example/Visuals
I could add some usage output if it's useful

### Time estimate
30 min
