### PR TITLE
Download profiles from blob storage

### DIFF
--- a/powersimdata/data_access/data_access.py
+++ b/powersimdata/data_access/data_access.py
@@ -1,4 +1,3 @@
-import json
 import operator
 import os
 import posixpath
@@ -203,18 +202,9 @@ class LocalDataAccess(DataAccess):
         :param str kind: *'demand'*, *'hydro'*, *'solar'* or *'wind'*.
         :return: (*list*) -- available profile version.
         """
-        blob_versions = super().get_profile_version(grid_model, kind)
-        version_file = os.path.join(server_setup.LOCAL_DIR, "version.json")
-        if not os.path.exists(version_file):
-            return blob_versions
-        with open(version_file) as f:
-            version = json.load(f)
-            return list(
-                set(
-                    blob_versions
-                    + ProfileHelper.parse_version(grid_model, kind, version)
-                )
-            )
+        blob_version = super().get_profile_version(grid_model, kind)
+        local_version = ProfileHelper.get_profile_version_local(grid_model, kind)
+        return list(set(blob_version + local_version))
 
 
 class SSHDataAccess(DataAccess):

--- a/powersimdata/data_access/data_access.py
+++ b/powersimdata/data_access/data_access.py
@@ -117,6 +117,12 @@ class DataAccess:
         raise NotImplementedError
 
     def get_profile_version(self, grid_model, kind):
+        """Returns available raw profile from blob storage
+
+        :param str grid_model: grid model.
+        :param str kind: *'demand'*, *'hydro'*, *'solar'* or *'wind'*.
+        :return: (*list*) -- available profile version.
+        """
         return ProfileHelper.get_profile_version_cloud(grid_model, kind)
 
     def close(self):

--- a/powersimdata/data_access/data_access.py
+++ b/powersimdata/data_access/data_access.py
@@ -117,7 +117,7 @@ class DataAccess:
         raise NotImplementedError
 
     def get_profile_version(self, grid_model, kind):
-        return ProfileHelper.get_profile_version(grid_model, kind)
+        return ProfileHelper.get_profile_version_cloud(grid_model, kind)
 
     def close(self):
         """Perform any necessary cleanup for the object."""

--- a/powersimdata/data_access/profile_helper.py
+++ b/powersimdata/data_access/profile_helper.py
@@ -48,13 +48,7 @@ class ProfileHelper:
         :param str kind: *'demand'*, *'hydro'*, *'solar'* or *'wind'*.
         :param dict version: json response
         :return: (*list*) -- available profile version.
-        :raises ValueError: if kind not one of *'demand'*, *'hydro'*, *'solar'* or
-            *'wind'*.
         """
-        profile_kind = {"demand", "hydro", "solar", "wind"}
-        if kind not in profile_kind:
-            raise ValueError("kind must be one of %s" % " | ".join(profile_kind))
-
         if grid_model in version and kind in version[grid_model]:
             return version[grid_model][kind]
         print("No %s profiles available." % kind)

--- a/powersimdata/data_access/profile_helper.py
+++ b/powersimdata/data_access/profile_helper.py
@@ -12,6 +12,13 @@ class ProfileHelper:
 
     @staticmethod
     def get_file_components(scenario_info, field_name):
+        """Get the file name and relative path for the given profile and
+        scenario.
+
+        :param dict scenario_info: a ScenarioInfo instance
+        :param str field_name: the kind of profile
+        :return: (*tuple*) -- file name and path
+        """
         version = scenario_info["base_" + field_name]
         file_name = field_name + "_" + version + ".csv"
         grid_model = scenario_info["grid_model"]
@@ -20,6 +27,12 @@ class ProfileHelper:
 
     @staticmethod
     def download_file(file_name, from_dir):
+        """Download the profile from blob storage at the given path
+
+        :param str file_name: profile csv
+        :param str from_dir: the path relative to the blob container
+        :return: (*str*) -- path to downloaded file
+        """
         print(f"--> Downloading {file_name} from blob storage.")
         url = f"{ProfileHelper.BASE_URL}/{from_dir}/{file_name}"
         dest = os.path.join(server_setup.LOCAL_DIR, from_dir, file_name)

--- a/powersimdata/data_access/profile_helper.py
+++ b/powersimdata/data_access/profile_helper.py
@@ -1,0 +1,72 @@
+import os
+
+import requests
+from tqdm.auto import tqdm
+
+from powersimdata.utility import server_setup
+
+
+class ProfileHelper:
+    BASE_URL = "https://bescienceswebsite.blob.core.windows.net/profiles"
+
+    @staticmethod
+    def get_file_components(scenario_info, field_name):
+        version = scenario_info["base_" + field_name]
+        file_name = field_name + "_" + version + ".csv"
+        grid_model = scenario_info["grid_model"]
+        from_dir = f"raw/{grid_model}"
+        return file_name, from_dir
+
+    @staticmethod
+    def download_file(file_name, from_dir):
+        print(f"--> Downloading {file_name} from blob storage.")
+        url = f"{ProfileHelper.BASE_URL}/{from_dir}/{file_name}"
+        dest = os.path.join(server_setup.LOCAL_DIR, from_dir, file_name)
+        os.makedirs(os.path.dirname(dest), exist_ok=True)
+        resp = requests.get(url, stream=True)
+        content_length = int(resp.headers.get("content-length", 0))
+        with open(dest, "wb") as f:
+            with tqdm(
+                unit="B",
+                unit_scale=True,
+                unit_divisor=1024,
+                miniters=1,
+                total=content_length,
+            ) as pbar:
+                for chunk in resp.iter_content(chunk_size=4096):
+                    f.write(chunk)
+                    pbar.update(len(chunk))
+
+        print("--> Done!")
+        return dest
+
+    @staticmethod
+    def parse_version(grid_model, kind, version):
+        """Parse available versions from the given spec
+
+        :param str grid_model: grid model.
+        :param str kind: *'demand'*, *'hydro'*, *'solar'* or *'wind'*.
+        :param dict version: json response
+        :return: (*list*) -- available profile version.
+        :raises ValueError: if kind not one of *'demand'*, *'hydro'*, *'solar'* or
+            *'wind'*.
+        """
+        profile_kind = {"demand", "hydro", "solar", "wind"}
+        if kind not in profile_kind:
+            raise ValueError("kind must be one of %s" % " | ".join(profile_kind))
+
+        if grid_model in version and kind in version[grid_model]:
+            return version[grid_model][kind]
+        print("No %s profiles available." % kind)
+
+    @staticmethod
+    def get_profile_version(grid_model, kind):
+        """Returns available raw profile from blob storage
+
+        :param str grid_model: grid model.
+        :param str kind: *'demand'*, *'hydro'*, *'solar'* or *'wind'*.
+        :return: (*list*) -- available profile version.
+        """
+
+        resp = requests.get(f"{ProfileHelper.BASE_URL}/version.json")
+        return ProfileHelper.parse_version(grid_model, kind, resp.json())

--- a/powersimdata/data_access/profile_helper.py
+++ b/powersimdata/data_access/profile_helper.py
@@ -22,7 +22,7 @@ class ProfileHelper:
         version = scenario_info["base_" + field_name]
         file_name = field_name + "_" + version + ".csv"
         grid_model = scenario_info["grid_model"]
-        from_dir = f"raw/{grid_model}"
+        from_dir = os.path.join("raw", grid_model)
         return file_name, from_dir
 
     @staticmethod
@@ -34,7 +34,8 @@ class ProfileHelper:
         :return: (*str*) -- path to downloaded file
         """
         print(f"--> Downloading {file_name} from blob storage.")
-        url = f"{ProfileHelper.BASE_URL}/{from_dir}/{file_name}"
+        url_path = "/".join(os.path.split(from_dir))
+        url = f"{ProfileHelper.BASE_URL}/{url_path}/{file_name}"
         dest = os.path.join(server_setup.LOCAL_DIR, from_dir, file_name)
         os.makedirs(os.path.dirname(dest), exist_ok=True)
         resp = requests.get(url, stream=True)

--- a/powersimdata/data_access/profile_helper.py
+++ b/powersimdata/data_access/profile_helper.py
@@ -56,7 +56,7 @@ class ProfileHelper:
         return []
 
     @staticmethod
-    def get_profile_version(grid_model, kind):
+    def get_profile_version_cloud(grid_model, kind):
         """Returns available raw profile from blob storage
 
         :param str grid_model: grid model.

--- a/powersimdata/data_access/profile_helper.py
+++ b/powersimdata/data_access/profile_helper.py
@@ -1,3 +1,4 @@
+import json
 import os
 
 import requests
@@ -46,12 +47,13 @@ class ProfileHelper:
 
         :param str grid_model: grid model.
         :param str kind: *'demand'*, *'hydro'*, *'solar'* or *'wind'*.
-        :param dict version: json response
+        :param dict version: version information per grid model
         :return: (*list*) -- available profile version.
         """
         if grid_model in version and kind in version[grid_model]:
             return version[grid_model][kind]
         print("No %s profiles available." % kind)
+        return []
 
     @staticmethod
     def get_profile_version(grid_model, kind):
@@ -64,3 +66,19 @@ class ProfileHelper:
 
         resp = requests.get(f"{ProfileHelper.BASE_URL}/version.json")
         return ProfileHelper.parse_version(grid_model, kind, resp.json())
+
+    @staticmethod
+    def get_profile_version_local(grid_model, kind):
+        """Returns available raw profile from local file
+
+        :param str grid_model: grid model.
+        :param str kind: *'demand'*, *'hydro'*, *'solar'* or *'wind'*.
+        :return: (*list*) -- available profile version.
+        """
+
+        version_file = os.path.join(server_setup.LOCAL_DIR, "version.json")
+        if not os.path.exists(version_file):
+            return []
+        with open(version_file) as f:
+            version = json.load(f)
+            return ProfileHelper.parse_version(grid_model, kind, version)

--- a/powersimdata/data_access/tests/test_profile_helper.py
+++ b/powersimdata/data_access/tests/test_profile_helper.py
@@ -1,0 +1,24 @@
+from powersimdata.data_access.profile_helper import ProfileHelper
+
+
+def test_parse_version_default():
+    assert [] == ProfileHelper.parse_version("usa_tamu", "solar", {})
+
+
+def test_parse_version_missing_key():
+    version = {"solar": ["v123"]}
+    assert [] == ProfileHelper.parse_version("usa_tamu", "solar", version)
+
+
+def test_parse_version():
+    expected = ["v123", "v456"]
+    version = {"usa_tamu": {"solar": expected}}
+    assert expected == ProfileHelper.parse_version("usa_tamu", "solar", version)
+    assert [] == ProfileHelper.parse_version("usa_tamu", "hydro", version)
+
+
+def test_get_file_components():
+    s_info = {"base_wind": "v8", "grid_model": "europe"}
+    file_name, from_dir = ProfileHelper.get_file_components(s_info, "wind")
+    assert "wind_v8.csv" == file_name
+    assert "raw/europe" == from_dir

--- a/powersimdata/input/input_data.py
+++ b/powersimdata/input/input_data.py
@@ -12,13 +12,14 @@ _cache = MemoryCache()
 
 profile_kind = {"demand", "hydro", "solar", "wind"}
 
-BLOB_STORAGE = "https://bescienceswebsite.blob.core.windows.net/profiles"
-
 
 _file_extension = {
     **{"ct": "pkl", "grid": "mat"},
     **{k: "csv" for k in profile_kind},
 }
+
+
+BASE_URL = "https://bescienceswebsite.blob.core.windows.net/profiles"
 
 
 class InputHelper:
@@ -49,7 +50,7 @@ class ProfileHelper:
     @staticmethod
     def download_file(file_name, from_dir):
         print(f"--> Downloading {file_name} from blob storage.")
-        url = f"{BLOB_STORAGE}/{from_dir}/{file_name}"
+        url = f"{BASE_URL}/{from_dir}/{file_name}"
         dest = os.path.join(server_setup.LOCAL_DIR, from_dir, file_name)
         os.makedirs(os.path.dirname(dest), exist_ok=True)
         resp = requests.get(url, stream=True)
@@ -146,12 +147,11 @@ class InputData(object):
         if kind not in profile_kind:
             raise ValueError("kind must be one of %s" % " | ".join(profile_kind))
 
-        resp = requests.get(f"{BLOB_STORAGE}/raw/{grid_model}/version.json")
-        versions = resp.json()
-        if kind not in versions:
-            print("No %s profiles available." % kind)
-        else:
-            return versions[kind]
+        resp = requests.get(f"{BASE_URL}/version.json")
+        version = resp.json()
+        if grid_model in version and kind in version[grid_model]:
+            return version[grid_model][kind]
+        print("No %s profiles available." % kind)
 
 
 def _read_data(filepath):

--- a/powersimdata/input/input_data.py
+++ b/powersimdata/input/input_data.py
@@ -44,7 +44,7 @@ class ProfileHelper:
         version = scenario_info["base_" + field_name]
         file_name = field_name + "_" + version + "." + ext
         grid_model = scenario_info["grid_model"]
-        from_dir = f"{server_setup.BASE_PROFILE_DIR}/{grid_model}"
+        from_dir = f"raw/{grid_model}"
         return file_name, from_dir
 
     @staticmethod

--- a/powersimdata/input/input_data.py
+++ b/powersimdata/input/input_data.py
@@ -42,17 +42,21 @@ class ProfileHelper:
         ext = _file_extension[field_name]
         version = scenario_info["base_" + field_name]
         file_name = field_name + "_" + version + "." + ext
-        from_dir = scenario_info["grid_model"]
+        grid_model = scenario_info["grid_model"]
+        from_dir = f"{server_setup.BASE_PROFILE_DIR}/{grid_model}"
         return file_name, from_dir
 
     @staticmethod
     def download_file(file_name, from_dir):
+        print(f"--> Downloading {file_name} from blob storage.")
         url = f"{BLOB_STORAGE}/{from_dir}/{file_name}"
-        dest = os.path.join(server_setup.LOCAL_DIR, file_name)
+        dest = os.path.join(server_setup.LOCAL_DIR, from_dir, file_name)
+        os.makedirs(os.path.dirname(dest), exist_ok=True)
         with requests.get(url, stream=True) as r:
             with open(dest, "wb") as f:
                 shutil.copyfileobj(r.raw, f)
 
+        print("--> Done!")
         return dest
 
 
@@ -132,7 +136,7 @@ class InputData(object):
         if kind not in profile_kind:
             raise ValueError("kind must be one of %s" % " | ".join(profile_kind))
 
-        resp = requests.get(f"{BLOB_STORAGE}/{grid_model}/version.json")
+        resp = requests.get(f"{BLOB_STORAGE}/raw/{grid_model}/version.json")
         versions = resp.json()
         if kind not in versions:
             print("No %s profiles available." % kind)

--- a/powersimdata/input/input_data.py
+++ b/powersimdata/input/input_data.py
@@ -24,12 +24,23 @@ class InputHelper:
 
     @staticmethod
     def get_file_components(scenario_info, field_name):
+        """Get the file name and relative path for either ct or grid
+
+        :param dict scenario_info: a ScenarioInfo instance
+        :param str field_name: the input file type
+        :return: (*tuple*) -- file name and path
+        """
         ext = _file_extension[field_name]
         file_name = scenario_info["id"] + "_" + field_name + "." + ext
         from_dir = server_setup.INPUT_DIR
         return file_name, from_dir
 
     def download_file(self, file_name, from_dir):
+        """Download the file if using server, otherwise no-op
+
+        :param str file_name: either grid or ct file name
+        :param str from_dir: the path relative to the root dir
+        """
         self.data_access.copy_from(file_name, from_dir)
 
 

--- a/powersimdata/input/tests/test_input_data.py
+++ b/powersimdata/input/tests/test_input_data.py
@@ -1,0 +1,20 @@
+import pytest
+
+from powersimdata.input.input_data import InputHelper, _check_field
+
+
+def test_get_file_components():
+    s_info = {"id": "123"}
+    ct_file, _ = InputHelper.get_file_components(s_info, "ct")
+    grid_file, from_dir = InputHelper.get_file_components(s_info, "grid")
+    assert "123_ct.pkl" == ct_file
+    assert "123_grid.mat" == grid_file
+    assert "data/input" == from_dir
+
+
+def test_check_field():
+    _check_field("demand")
+    _check_field("hydro")
+    with pytest.raises(ValueError):
+        _check_field("foo")
+        _check_field("coal")

--- a/powersimdata/input/transform_profile.py
+++ b/powersimdata/input/transform_profile.py
@@ -103,7 +103,7 @@ class TransformProfile(object):
         :return: (*pandas.DataFrame*) -- data frame of demand.
         """
         zone_id = sorted(self.grid.bus.zone_id.unique())
-        demand = self._input_data.get_data(self.scenario_info, "demand")[zone_id]
+        demand = self._input_data.get_data(self.scenario_info, "demand").loc[:, zone_id]
         if bool(self.ct) and "demand" in list(self.ct.keys()):
             for key, value in self.ct["demand"]["zone_id"].items():
                 print(

--- a/powersimdata/scenario/create.py
+++ b/powersimdata/scenario/create.py
@@ -334,7 +334,7 @@ class _Builder(object):
         :param str kind: one of *'demand'*, *'hydro'*, *'solar'*, *'wind'*.
         :return: (*list*) -- available version for selected profile kind.
         """
-        return InputData().get_profile_version(self.grid_model, kind)
+        return InputData.get_profile_version(self.grid_model, kind)
 
     def set_base_profile(self, kind, version):
         """Sets demand profile.

--- a/powersimdata/scenario/create.py
+++ b/powersimdata/scenario/create.py
@@ -334,7 +334,7 @@ class _Builder(object):
         :param str kind: one of *'demand'*, *'hydro'*, *'solar'*, *'wind'*.
         :return: (*list*) -- available version for selected profile kind.
         """
-        return InputData.get_profile_version(self.grid_model, kind)
+        return InputData().get_profile_version(self.grid_model, kind)
 
     def set_base_profile(self, kind, version):
         """Sets demand profile.

--- a/powersimdata/scenario/move.py
+++ b/powersimdata/scenario/move.py
@@ -35,7 +35,6 @@ class Move(State):
         backup = BackUpDisk(self._data_access, self._scenario_info)
 
         backup.move_input_data()
-        backup.copy_base_profile()
         backup.move_output_data()
         backup.move_temporary_folder()
 
@@ -75,22 +74,6 @@ class BackUpDisk(object):
         target = self.backup_config.input_dir()
         self._data_access.copy(source, target, update=True)
         self._data_access.remove(source, recursive=True, force=True)
-
-    def copy_base_profile(self):
-        """Copies base profile"""
-        print("--> Copying base profiles to backup disk")
-        for kind in ["demand", "hydro", "solar", "wind"]:
-            src = posixpath.join(
-                self.server_config.base_profile_dir(),
-                self._scenario_info["grid_model"],
-                kind + "_" + self._scenario_info["base_" + kind] + ".csv",
-            )
-            dest = posixpath.join(
-                self.backup_config.base_profile_dir(), self._scenario_info["grid_model"]
-            )
-            _, stdout, stderr = self._data_access.copy(src, dest, update=True)
-            print(stdout.readlines())
-            print(stderr.readlines())
 
     def move_output_data(self):
         """Moves output data"""

--- a/powersimdata/utility/server_setup.py
+++ b/powersimdata/utility/server_setup.py
@@ -7,7 +7,6 @@ SERVER_SSH_PORT = os.getenv("BE_SERVER_SSH_PORT", 22)
 BACKUP_DATA_ROOT_DIR = "/mnt/RE-Storage/v2"
 DATA_ROOT_DIR = "/mnt/bes/pcm"
 EXECUTE_DIR = "tmp"
-BASE_PROFILE_DIR = "raw"
 INPUT_DIR = "data/input"
 OUTPUT_DIR = "data/output"
 LOCAL_DIR = os.path.join(Path.home(), "ScenarioData", "")
@@ -35,9 +34,6 @@ class PathConfig:
 
     def execute_dir(self):
         return self._join(EXECUTE_DIR)
-
-    def base_profile_dir(self):
-        return self._join(BASE_PROFILE_DIR)
 
     def input_dir(self):
         return self._join(INPUT_DIR)


### PR DESCRIPTION
### Purpose
Use blob storage as the source for profiles, downloading as needed. 

### What the code is doing
Added a [version.json](https://bescienceswebsite.blob.core.windows.net/profiles/version.json) file to support listing available versions. The profiles are in the `raw/usa_tamu` folder in the blob container to mimic the structure elsewhere. Similar to before, we download if it doesn't exist locally. 

### Testing
Deleted local copies of the profiles and ran a simulation using plug, which shows the files being downloaded (during the call to `prepare_simulation_input`). 

### Usage Example/Visuals
Example query (no change in usage, other than switching to static method)
```
In [18]: InputData.get_profile_version("usa_tamu", "solar")
Out[18]: ['vJan2021']
```

Snippet of files being downloaded
```
In [7]: scenario.state.prepare_simulation_input()
---------------------------
PREPARING SIMULATION INPUTS
---------------------------
--> Creating temporary folder on server for simulation inputs
--> Loading demand
demand_vJan2021.csv not found in /root/ScenarioData/ on local machine
--> Downloading demand_vJan2021.csv from blob storage.
100%|████████████████████████████████████████████████████████████████████████████| 5.15M/5.15M [00:00<00:00, 6.17MB/s]
--> Done!
Multiply demand in Far West (#301) by 1.09
/usr/local/lib/python3.8/site-packages/pandas/core/indexing.py:1843: SettingWithCopyWarning:
A value is trying to be set on a copy of a slice from a DataFrame.
Try using .loc[row_indexer,col_indexer] = value instead

See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy
  self.obj[item_labels[indexer[info_axis]]] = value
Multiply demand in North (#302) by 1.09
Multiply demand in West (#303) by 1.09
Multiply demand in South (#304) by 1.09
Multiply demand in North Central (#305) by 1.09
Multiply demand in South Central (#306) by 1.09
Multiply demand in Coast (#307) by 1.09
Multiply demand in East (#308) by 1.09
Writing scaled demand profile in /root/ScenarioData/ on local machine
--> Moving file /root/ScenarioData/1_demand.csv to /mnt/bes/pcm/tmp/scenario_1/demand.csv
--> Deleting original copy
--> Loading hydro
hydro_vJan2021.csv not found in /root/ScenarioData/ on local machine
--> Downloading hydro_vJan2021.csv from blob storage.
100%|██████████████████████████████████████████████████████████████████████████████| 222M/222M [00:40<00:00, 5.74MB/s]
--> Done!
```

### Time estimate
20 mins
