### PR TITLE
refactor: improve usability of Scenario object

### DIFF
--- a/powersimdata/__init__.py
+++ b/powersimdata/__init__.py
@@ -1,0 +1,2 @@
+from powersimdata.input.grid import Grid  # noqa: F401
+from powersimdata.scenario.scenario import Scenario  # noqa: F401

--- a/powersimdata/scenario/analyze.py
+++ b/powersimdata/scenario/analyze.py
@@ -20,6 +20,27 @@ class Analyze(State):
 
     name = "analyze"
     allowed = []
+    exported_methods = {
+        "get_averaged_cong",
+        "get_bus_demand",
+        "get_congl",
+        "get_congu",
+        "get_ct",
+        "get_demand",
+        "get_hydro",
+        "get_grid",
+        "get_dcline_pf",
+        "get_lmp",
+        "get_load_shed",
+        "get_pf",
+        "get_pg",
+        "get_solar",
+        "get_storage_e",
+        "get_storage_pg",
+        "get_wind",
+        "print_infeasibilities",
+        "print_scenario_info",
+    }
 
     def __init__(self, scenario):
         """Constructor."""

--- a/powersimdata/scenario/create.py
+++ b/powersimdata/scenario/create.py
@@ -69,6 +69,13 @@ class Create(State):
         else:
             raise AttributeError(f"Create object has no attribute {name}")
 
+    def __setattr__(self, name, value):
+        if name in _Builder.exported_methods:
+            raise AttributeError(
+                f"{name} is exported from Create.builder, edit it there if necessary"
+            )
+        super().__setattr__(name, value)
+
     def _update_scenario_info(self):
         """Updates scenario information."""
         if self.builder is not None:

--- a/powersimdata/scenario/create.py
+++ b/powersimdata/scenario/create.py
@@ -1,5 +1,6 @@
 import copy
 import pickle
+import warnings
 from collections import OrderedDict
 
 import numpy as np
@@ -20,6 +21,7 @@ default_exported_methods = (
     "get_bus_demand",
     "print_scenario_info",
     "set_builder",
+    "set_grid",
 )
 
 
@@ -173,8 +175,15 @@ class Create(State):
         for key, val in self._scenario_info.items():
             print("%s: %s" % (key, val))
 
-    def set_builder(self, grid_model="usa_tamu", interconnect="USA"):
-        """Sets builder.
+    def set_builder(self, *args, **kwargs):
+        """Alias to set_grid."""
+        warnings.warn(
+            "set_builder is deprecated, use set_grid instead", DeprecationWarning
+        )
+        self.set_grid(*args, **kwargs)
+
+    def set_grid(self, grid_model="usa_tamu", interconnect="USA"):
+        """Sets grid builder.
 
         :param str grid_model: name of grid model. Default is *'usa_tamu'*.
         :param str/list interconnect: name of interconnect(s). Default is *'USA'*.

--- a/powersimdata/scenario/create.py
+++ b/powersimdata/scenario/create.py
@@ -62,19 +62,12 @@ class Create(State):
         super().__init__(scenario)
 
     def __getattr__(self, name):
-        if self.builder is not None:
-            if name in self.builder.exported_methods:
-                return getattr(self.builder, name)
-            else:
-                raise AttributeError(f"Create object has no attribute {name}")
+        if self.builder is not None and name in self.builder.exported_methods:
+            return getattr(self.builder, name)
+        if self.builder is None and name in _Builder.exported_methods:
+            raise AttributeError(f"Call set_grid first to access {name} attribute")
         else:
-            raise AttributeError(
-                f"Create object without a builder set has no attribute {name}. "
-                "Did you forget to run set_builder?"
-            )
-
-    def _custom_getattr_error_message(self, name):
-        return self.__getattr__(name)
+            raise AttributeError(f"Create object has no attribute {name}")
 
     def _update_scenario_info(self):
         """Updates scenario information."""

--- a/powersimdata/scenario/create.py
+++ b/powersimdata/scenario/create.py
@@ -16,14 +16,6 @@ from powersimdata.scenario.execute import Execute
 from powersimdata.scenario.state import State
 from powersimdata.utility import server_setup
 
-default_exported_methods = (
-    "create_scenario",
-    "get_bus_demand",
-    "print_scenario_info",
-    "set_builder",
-    "set_grid",
-)
-
 
 class Create(State):
     """Scenario is in a state of being created.
@@ -33,6 +25,13 @@ class Create(State):
 
     name = "create"
     allowed = []
+    default_exported_methods = (
+        "create_scenario",
+        "get_bus_demand",
+        "print_scenario_info",
+        "set_builder",
+        "set_grid",
+    )
 
     def __init__(self, scenario):
         """Constructor."""
@@ -58,7 +57,7 @@ class Create(State):
                 ("engine", ""),
             ]
         )
-        self.exported_methods = set(default_exported_methods)
+        self.exported_methods = set(self.default_exported_methods)
         super().__init__(scenario)
 
     def __getattr__(self, name):

--- a/powersimdata/scenario/create.py
+++ b/powersimdata/scenario/create.py
@@ -24,6 +24,18 @@ class Create(State):
 
     name = "create"
     allowed = []
+    exported_methods = {
+        "create_scenario",
+        "get_ct",
+        "get_grid",
+        "get_demand",
+        "get_bus_demand",
+        "get_hydro",
+        "get_solar",
+        "get_wind",
+        "print_scenario_info",
+        "set_builder",
+    }
 
     def __init__(self, scenario):
         """Constructor."""

--- a/powersimdata/scenario/delete.py
+++ b/powersimdata/scenario/delete.py
@@ -11,6 +11,10 @@ class Delete(State):
 
     name = "delete"
     allowed = []
+    exported_methods = {
+        "delete_scenario",
+        "print_scenario_info",
+    }
 
     def print_scenario_info(self):
         """Prints scenario information.

--- a/powersimdata/scenario/execute.py
+++ b/powersimdata/scenario/execute.py
@@ -22,6 +22,16 @@ class Execute(State):
 
     name = "execute"
     allowed = []
+    exported_methods = {
+        "check_progress",
+        "extract_simulation_output",
+        "get_ct",
+        "get_grid",
+        "launch_simulation",
+        "prepare_simulation_input",
+        "print_scenario_info",
+        "print_scenario_status",
+    }
 
     def __init__(self, scenario):
         """Constructor."""

--- a/powersimdata/scenario/move.py
+++ b/powersimdata/scenario/move.py
@@ -12,6 +12,10 @@ class Move(State):
 
     name = "move"
     allowed = []
+    exported_methods = {
+        "move_scenario",
+        "print_scenario_info",
+    }
 
     def print_scenario_info(self):
         """Prints scenario information."""

--- a/powersimdata/scenario/scenario.py
+++ b/powersimdata/scenario/scenario.py
@@ -45,8 +45,8 @@ class Scenario(object):
     def __getattr__(self, name):
         if name in self.state.exported_methods:
             return getattr(self.state, name)
-        elif hasattr(self.state, "_custom_getattr_error_message"):
-            return self.state._custom_getattr_error_message(name)
+        elif hasattr(self.state, "__getattr__"):
+            return self.state.__getattr__(name)
         else:
             raise AttributeError(
                 f"Scenario object in {self.state.name} state "

--- a/powersimdata/scenario/scenario.py
+++ b/powersimdata/scenario/scenario.py
@@ -13,14 +13,15 @@ pd.set_option("display.max_colwidth", None)
 class Scenario(object):
     """Handles scenario.
 
-    :param int/str descriptor: scenario name or index.
+    :param int/str descriptor: scenario name or index. If None, default to a Scenario
+        in Create state.
     """
 
-    def __init__(self, descriptor):
+    def __init__(self, descriptor=None):
         """Constructor."""
         if isinstance(descriptor, int):
             descriptor = str(descriptor)
-        if not isinstance(descriptor, str):
+        if descriptor is not None and not isinstance(descriptor, str):
             raise TypeError("Descriptor must be a string or int (for a Scenario ID)")
 
         self.data_access = Context.get_data_access()

--- a/powersimdata/scenario/scenario.py
+++ b/powersimdata/scenario/scenario.py
@@ -45,6 +45,8 @@ class Scenario(object):
     def __getattr__(self, name):
         if name in self.state.exported_methods:
             return getattr(self.state, name)
+        elif hasattr(self.state, "_custom_getattr_error_message"):
+            return self.state._custom_getattr_error_message(name)
         else:
             raise AttributeError(
                 f"Scenario object in {self.state.name} state "

--- a/powersimdata/scenario/scenario.py
+++ b/powersimdata/scenario/scenario.py
@@ -42,6 +42,18 @@ class Scenario(object):
             except AttributeError:
                 return
 
+    def __getattr__(self, name):
+        if name in self.state.exported_methods:
+            return getattr(self.state, name)
+        else:
+            raise AttributeError(
+                f"Scenario object in {self.state.name} state "
+                f"has no attribute {name}"
+            )
+
+    def __dir__(self):
+        return sorted(super().__dir__() + list(self.state.exported_methods))
+
     def _set_info(self, descriptor):
         """Sets scenario information.
 

--- a/powersimdata/scenario/state.py
+++ b/powersimdata/scenario/state.py
@@ -34,7 +34,7 @@ class State(object):
             print("State switching: %s --> %s" % (self, state.name))
             self._leave()
             self.__class__ = state
-            self._enter()
+            self._enter(state)
         else:
             raise Exception(
                 "State switching: %s --> %s not permitted" % (self, state.name)
@@ -55,6 +55,6 @@ class State(object):
             del self.grid
             del self.ct
 
-    def _enter(self):
+    def _enter(self, state):
         """Initializes when entering state."""
-        pass
+        self.exported_methods = state.exported_methods

--- a/powersimdata/scenario/tests/test_create.py
+++ b/powersimdata/scenario/tests/test_create.py
@@ -6,6 +6,6 @@ from powersimdata.scenario.scenario import Scenario
 @pytest.mark.ssh
 def test_get_bus_demand():
     scenario = Scenario("")
-    scenario.state.set_builder(interconnect="Texas")
+    scenario.state.set_grid(interconnect="Texas")
     scenario.state.builder.set_base_profile("demand", "vJan2021")
     scenario.state.get_bus_demand()


### PR DESCRIPTION
### Purpose
Improve usability of the main framework classes (`Scenario` and `Grid`). Closes #418.

### What the code is doing
- The Scenario can now be instantiated with no arguments (`Scenario()`)
- The `Scenario` and `Grid` objects are imported into the name namespace, so that we can do something like:
```python
import powersimdata as psd
scenario = psd.Scenario()
```
- The state methods can be accessed from the Scenario object (`scenario.create_scenario()` maps to `scenario.state.create_scenario()`, if the scenario is in `create` state).

### Usage Example/Visuals
```python
>>> import powersimdata as psd
>>> scenario = psd.Scenario()
>>> scenario.create_scenario()
-------------------
MISSING INFORMATION
-------------------
plan
name
grid_model
interconnect
base_demand
base_hydro
base_solar
base_wind
change_table
start_date
end_date
interval
engine
>>> scenario.launch_simulation()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\Users\DanielOlsen\repos\bes\PowerSimData\powersimdata\scenario\scenario.py", line 49, in __getattr__
    raise AttributeError(
AttributeError: Scenario object in create state has no attribute launch_simulation
```

### Time estimate
15 minutes.
