### PR TITLE
fix: ensure that get_bus_demand works in Create state

### DIFF
--- a/powersimdata/input/input_data.py
+++ b/powersimdata/input/input_data.py
@@ -144,8 +144,8 @@ def get_bus_demand(scenario_info, grid):
     :param powersimdata.input.grid.Grid grid: grid to construct bus demand for.
     :return: (*pandas.DataFrame*) -- data frame of demand.
     """
-    demand = InputData().get_data(scenario_info, "demand")
     bus = grid.bus
+    demand = InputData().get_data(scenario_info, "demand")[bus.zone_id.unique()]
     bus["zone_Pd"] = bus.groupby("zone_id")["Pd"].transform("sum")
     bus["zone_share"] = bus["Pd"] / bus["zone_Pd"]
     zone_bus_shares = pd.DataFrame(

--- a/powersimdata/scenario/create.py
+++ b/powersimdata/scenario/create.py
@@ -149,6 +149,7 @@ class Create(State):
 
         :return: (*pandas.DataFrame*) -- data frame of demand (hour, bus).
         """
+        self._update_scenario_info()
         grid = self.get_grid()
         return get_bus_demand(self._scenario_info, grid)
 

--- a/powersimdata/scenario/tests/test_create.py
+++ b/powersimdata/scenario/tests/test_create.py
@@ -1,0 +1,11 @@
+import pytest
+
+from powersimdata.scenario.scenario import Scenario
+
+
+@pytest.mark.ssh
+def test_get_bus_demand():
+    scenario = Scenario("")
+    scenario.state.set_builder(interconnect="Texas")
+    scenario.state.builder.set_base_profile("demand", "vJan2021")
+    scenario.state.get_bus_demand()


### PR DESCRIPTION
### Purpose
Fixes a couple of bugs when trying to get bus_demand from a Scenario in Create state. Closes #421.

### What the code is doing
- **test_create.py** adds a test that initially fails.
- In **create.py**, we ensure that the `scenario_info` gets updated before we call `get_bus_demand`.
- In **input_data.py**, we ensure that we only try to apply demand for the zones that are in this particular Grid.

### Testing
The automated tests don't cover this, because getting the demand profiles requires ssh, but you can check that tests pass locally using `python -m pytest`.

### Time estimate
5 minutes.
