### PR TITLE
fix: upload storage matfile to server

### DIFF
--- a/powersimdata/scenario/execute.py
+++ b/powersimdata/scenario/execute.py
@@ -362,6 +362,10 @@ class SimulationInput(object):
         self._data_access.move_to(
             file_name, self.REL_TMP_DIR, change_name_to="case.mat"
         )
+        if len(self.grid.storage["gen"]) > 0:
+            self._data_access.move_to(
+                storage_file_name, self.REL_TMP_DIR, change_name_to="case_storage.mat"
+            )
 
     def prepare_profile(self, kind, profile_as=None):
         """Prepares profile for simulation.


### PR DESCRIPTION
### Purpose
We introduced a bug in #406 where the "case_storage.mat" file is generated but not actually sent to the server and therefore not used in the simulation engine.

### Testing
Tested that this fixes the bug, and **case_storage.mat** gets uploaded to the server where previous scenarios run with the exact same script don't have it.

### Time estimate
5 minutes.
