### PR TITLE
Reduce chance of concurrency issues

### DIFF
--- a/powersimdata/data_access/csv_store.py
+++ b/powersimdata/data_access/csv_store.py
@@ -1,6 +1,8 @@
 import functools
 import os
+import shutil
 from pathlib import Path
+from tempfile import mkstemp
 
 import pandas as pd
 
@@ -72,5 +74,8 @@ class CsvStore:
         :param pandas.DataFrame table: the data frame to save
         :param str checksum: the checksum prior to download
         """
-        table.to_csv(os.path.join(server_setup.LOCAL_DIR, self._FILE_NAME))
-        self.data_access.push(self._FILE_NAME, checksum)
+        _, tmp_path = mkstemp(dir=server_setup.LOCAL_DIR)
+        table.to_csv(tmp_path)
+        shutil.copy(tmp_path, os.path.join(server_setup.LOCAL_DIR, self._FILE_NAME))
+        tmp_name = os.path.basename(tmp_path)
+        self.data_access.push(tmp_name, checksum, change_name_to=self._FILE_NAME)

--- a/powersimdata/data_access/csv_store.py
+++ b/powersimdata/data_access/csv_store.py
@@ -1,5 +1,7 @@
 import functools
 import os
+import shutil
+import tempfile
 from pathlib import Path
 
 import pandas as pd
@@ -72,5 +74,7 @@ class CsvStore:
         :param pandas.DataFrame table: the data frame to save
         :param str checksum: the checksum prior to download
         """
-        table.to_csv(os.path.join(server_setup.LOCAL_DIR, self._FILE_NAME))
-        self.data_access.push(self._FILE_NAME, checksum)
+        _, tmp_path = tempfile.mkstemp()
+        table.to_csv(tmp_path)
+        self.data_access.push(tmp_path, checksum)
+        shutil.move(tmp_path, os.path.join(server_setup.LOCAL_DIR, self._FILE_NAME))

--- a/powersimdata/data_access/csv_store.py
+++ b/powersimdata/data_access/csv_store.py
@@ -1,7 +1,5 @@
 import functools
 import os
-import shutil
-import tempfile
 from pathlib import Path
 
 import pandas as pd
@@ -74,7 +72,5 @@ class CsvStore:
         :param pandas.DataFrame table: the data frame to save
         :param str checksum: the checksum prior to download
         """
-        _, tmp_path = tempfile.mkstemp()
-        table.to_csv(tmp_path)
-        self.data_access.push(tmp_path, checksum)
-        shutil.move(tmp_path, os.path.join(server_setup.LOCAL_DIR, self._FILE_NAME))
+        table.to_csv(os.path.join(server_setup.LOCAL_DIR, self._FILE_NAME))
+        self.data_access.push(self._FILE_NAME, checksum)

--- a/powersimdata/data_access/data_access.py
+++ b/powersimdata/data_access/data_access.py
@@ -367,7 +367,7 @@ class SSHDataAccess(DataAccess):
         """
         backup = f"{file_name}.temp"
         _, tmp_path = mkstemp(dir=self.local_root)
-        shutil.copy(posixpath.join(self.local_root, file_name), tmp_path)
+        shutil.copy(os.path.join(self.local_root, file_name), tmp_path)
         temp_name = os.path.basename(tmp_path)
         self.move_to(temp_name, change_name_to=backup)
 

--- a/powersimdata/data_access/data_access.py
+++ b/powersimdata/data_access/data_access.py
@@ -359,7 +359,7 @@ class SSHDataAccess(DataAccess):
         return lines[0].strip()
 
     def push(self, file_name, checksum, change_name_to=None):
-        """Push file_name to remote root
+        """Push file to server and verify the checksum matches a prior value
 
         :param str file_name: the file name, located at the local root
         :param str checksum: the checksum prior to download

--- a/powersimdata/data_access/data_access.py
+++ b/powersimdata/data_access/data_access.py
@@ -319,7 +319,7 @@ class SSHDataAccess(DataAccess):
         self._check_file_exists(to_path, should_exist=False)
 
         with self.ssh.open_sftp() as sftp:
-            print(f"Transferring {from_path} to server")
+            print(f"Transferring {file_name} to server")
             sftp.put(from_path, to_path)
 
         os.remove(from_path)

--- a/powersimdata/data_access/data_access.py
+++ b/powersimdata/data_access/data_access.py
@@ -25,13 +25,12 @@ class DataAccess:
         """
         raise NotImplementedError
 
-    def move_to(self, file_name, to_dir, change_name_to=None, preserve=False):
+    def move_to(self, file_name, to_dir, change_name_to=None):
         """Copy a file from userspace to data store.
 
         :param str file_name: file name to copy.
         :param str to_dir: data store directory to copy file to.
         :param str change_name_to: new name for file when copied to data store.
-        :param bool preserve: whether to keep the local copy
         """
         raise NotImplementedError
 
@@ -163,13 +162,12 @@ class LocalDataAccess(DataAccess):
         """
         return "dummy_value"
 
-    def move_to(self, file_name, to_dir, change_name_to=None, preserve=False):
+    def move_to(self, file_name, to_dir, change_name_to=None):
         """Copy a file from userspace to data store.
 
         :param str file_name: file name to copy.
         :param str to_dir: data store directory to copy file to.
         :param str change_name_to: new name for file when copied to data store.
-        :param bool preserve: whether to keep the local copy
         """
         self._check_filename(file_name)
         src = posixpath.join(server_setup.LOCAL_DIR, file_name)
@@ -178,9 +176,8 @@ class LocalDataAccess(DataAccess):
         print(f"--> Moving file {src} to {dest}")
         self._check_file_exists(dest, should_exist=False)
         self.copy(src, dest)
-        if not preserve:
-            print("--> Deleting original copy")
-            self.remove(src)
+        print("--> Deleting original copy")
+        self.remove(src)
 
     def execute_command(self, command):
         """Execute a command locally at the data access.
@@ -304,7 +301,6 @@ class SSHDataAccess(DataAccess):
         :param str file_name: file name to copy.
         :param str to_dir: data store directory to copy file to.
         :param str change_name_to: new name for file when copied to data store.
-        :param bool preserve: whether to keep the local copy
         :raises FileNotFoundError: if specified file does not exist
         """
         self._check_filename(file_name)

--- a/powersimdata/data_access/execute_list.py
+++ b/powersimdata/data_access/execute_list.py
@@ -1,8 +1,5 @@
-import posixpath
-
 from powersimdata.data_access.csv_store import CsvStore, verify_hash
 from powersimdata.data_access.sql_store import SqlStore, to_data_frame
-from powersimdata.utility import server_setup
 
 
 class ExecuteTable(SqlStore):
@@ -71,17 +68,9 @@ class ExecuteTable(SqlStore):
 
 
 class ExecuteListManager(CsvStore):
-    """Storage abstraction for execute list using a csv file on the server.
-
-    :param paramiko.client.SSHClient ssh_client: session with an SSH server.
-    """
+    """Storage abstraction for execute list using a csv file."""
 
     _FILE_NAME = "ExecuteList.csv"
-
-    def __init__(self, ssh_client):
-        """Constructor"""
-        super().__init__(ssh_client)
-        self._server_path = posixpath.join(server_setup.DATA_ROOT_DIR, self._FILE_NAME)
 
     def get_execute_table(self):
         """Returns execute table from server if possible, otherwise read local

--- a/powersimdata/data_access/profile_helper.py
+++ b/powersimdata/data_access/profile_helper.py
@@ -52,7 +52,6 @@ class ProfileHelper:
                     f.write(chunk)
                     pbar.update(len(chunk))
 
-        print("--> Done!")
         return dest
 
     @staticmethod

--- a/powersimdata/data_access/scenario_list.py
+++ b/powersimdata/data_access/scenario_list.py
@@ -1,11 +1,9 @@
-import posixpath
 from collections import OrderedDict
 
 import pandas as pd
 
 from powersimdata.data_access.csv_store import CsvStore, verify_hash
 from powersimdata.data_access.sql_store import SqlStore, to_data_frame
-from powersimdata.utility import server_setup
 
 
 class ScenarioTable(SqlStore):
@@ -74,17 +72,9 @@ class ScenarioTable(SqlStore):
 
 
 class ScenarioListManager(CsvStore):
-    """Storage abstraction for scenario list using a csv file on the server.
-
-    :param paramiko.client.SSHClient ssh_client: session with an SSH server.
-    """
+    """Storage abstraction for scenario list using a csv file."""
 
     _FILE_NAME = "ScenarioList.csv"
-
-    def __init__(self, ssh_client):
-        """Constructor"""
-        super().__init__(ssh_client)
-        self._server_path = posixpath.join(server_setup.DATA_ROOT_DIR, self._FILE_NAME)
 
     def get_scenario_table(self):
         """Returns scenario table from server if possible, otherwise read local

--- a/powersimdata/data_access/scenario_list.py
+++ b/powersimdata/data_access/scenario_list.py
@@ -94,12 +94,12 @@ class ScenarioListManager(CsvStore):
         """
         return self.get_table()
 
-    def generate_scenario_id(self):
+    def _generate_scenario_id(self, table):
         """Generates scenario id.
 
+        :param pandas.DataFrame table: the current scenario list
         :return: (*str*) -- new scenario id.
         """
-        table = self.get_scenario_table()
         max_value = table.index.max()
         result = 1 if pd.isna(max_value) else max_value + 1
         return str(result)
@@ -146,6 +146,9 @@ class ScenarioListManager(CsvStore):
         :return: (*pandas.DataFrame*) -- the updated data frame
         """
         table = self.get_scenario_table()
+        scenario_id = self._generate_scenario_id(table)
+        scenario_info["id"] = scenario_id
+        scenario_info.move_to_end("id", last=False)
         table.reset_index(inplace=True)
         entry = pd.DataFrame({k: [v] for k, v in scenario_info.items()})
         table = table.append(entry)

--- a/powersimdata/data_access/tests/test_scenario_csv.py
+++ b/powersimdata/data_access/tests/test_scenario_csv.py
@@ -82,10 +82,9 @@ def manager():
     os.remove(test_csv)
 
 
-def mock_row(sid=1):
+def mock_row():
     return OrderedDict(
         [
-            ("id", str(sid)),
             ("plan", "test"),
             ("name", "dummy"),
             ("state", "create"),
@@ -104,21 +103,17 @@ def mock_row(sid=1):
     )
 
 
-def test_generate_id(manager):
-    new_id = manager.generate_scenario_id()
-    assert new_id == "1"
-
-
 def test_blank_csv_append(manager):
-    manager.add_entry(mock_row(1))
-    table = manager.add_entry(mock_row(2))
-    assert table.shape == (2, 16)
+    entry = mock_row()
+    table = manager.add_entry(entry)
+    assert entry["id"] == "1"
+    assert table.shape == (1, 16)
 
 
 def test_get_scenario(manager):
-    manager.add_entry(mock_row(1))
-    manager.add_entry(mock_row(2))
-    manager.add_entry(mock_row(3))
+    manager.add_entry(mock_row())
+    manager.add_entry(mock_row())
+    manager.add_entry(mock_row())
     entry = manager.get_scenario(2)
     assert entry["id"] == "2"
     entry = manager.get_scenario("2")
@@ -126,8 +121,8 @@ def test_get_scenario(manager):
 
 
 def test_delete_entry(manager):
-    manager.add_entry(mock_row(1))
-    manager.add_entry(mock_row(2))
-    manager.add_entry(mock_row(3))
+    manager.add_entry(mock_row())
+    manager.add_entry(mock_row())
+    manager.add_entry(mock_row())
     table = manager.delete_entry(2)
     assert table.shape == (2, 16)

--- a/powersimdata/scenario/create.py
+++ b/powersimdata/scenario/create.py
@@ -93,15 +93,6 @@ class Create(State):
             else:
                 self._scenario_info["change_table"] = "No"
 
-    def _add_entry_in_execute_list(self):
-        """Adds scenario to the execute list file on server and update status
-        information.
-
-        """
-        self._execute_list_manager.add_entry(self._scenario_info)
-        self._scenario_status = "created"
-        self.allowed.append("execute")
-
     def _upload_change_table(self):
         """Uploads change table to server."""
         print("--> Writing change table on local machine")
@@ -144,13 +135,14 @@ class Create(State):
             self._scenario_info["infeasibilities"] = ""
             self.grid = self.builder.get_grid()
             self.ct = self.builder.change_table.ct
-            # Add scenario to scenario list file on server
+            # Add to scenario list and set the id in scenario_info
             self._scenario_list_manager.add_entry(self._scenario_info)
-            # Upload change table to server
+
             if bool(self.builder.change_table.ct):
                 self._upload_change_table()
-            # Add scenario to execute list file on server
-            self._add_entry_in_execute_list()
+            self._execute_list_manager.add_entry(self._scenario_info)
+            self._scenario_status = "created"
+            self.allowed.append("execute")
 
             print(
                 "SCENARIO SUCCESSFULLY CREATED WITH ID #%s" % self._scenario_info["id"]

--- a/powersimdata/scenario/create.py
+++ b/powersimdata/scenario/create.py
@@ -93,12 +93,6 @@ class Create(State):
             else:
                 self._scenario_info["change_table"] = "No"
 
-    def _generate_and_set_scenario_id(self):
-        """Generates scenario id."""
-        scenario_id = self._scenario_list_manager.generate_scenario_id()
-        self._scenario_info["id"] = scenario_id
-        self._scenario_info.move_to_end("id", last=False)
-
     def _add_entry_in_execute_list(self):
         """Adds scenario to the execute list file on server and update status
         information.
@@ -144,8 +138,6 @@ class Create(State):
                 % (self._scenario_info["plan"], self._scenario_info["name"])
             )
 
-            # Generate scenario id
-            self._generate_and_set_scenario_id()
             # Add missing information
             self._scenario_info["state"] = "execute"
             self._scenario_info["runtime"] = ""


### PR DESCRIPTION
### Purpose
Address #426 

### What the code is doing
Reduce the window when files could be corrupted by doing the following:
* When downloading a file, save to a temp file first, then move to destination.
* When uploading the scenario/execute list, first copy to a temp file and send that copy to the server
* Move scenario id generation into the `add_entry` method which should be atomic due to the checksum verification. This prevents a possible race condition of multiple scenarios with the same id being written to the server

### Testing
Ran the demo and tests in plug. Also ran the same demo, up to `prepare_simulation_input` using the client/server container setup  (which uses the `SSHDataAccess` implementation). Things should at least still work for a single process, but could use more evidence that behavior is improved when multiple processes are involved.

### Time estimate
15 mins, maybe more 
