### PR TITLE
ci: build and push docker image

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,25 @@
+name: Publish docker image
+
+on:
+  push:
+    branches:
+      - 'develop'
+
+jobs:
+  push_to_registry:
+    name: Push Docker image to GitHub Packages
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.CR_PAT }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: |
+            ghcr.io/breakthrough-energy/powersimdata:latest


### PR DESCRIPTION
### Purpose
Build and push the docker image when we merge to `develop` branch. This will make it available in our github [packages](https://github.com/orgs/Breakthrough-Energy/packages/container/package/powersimdata) and allow anyone to use it without having to clone this repo and build locally. 

See breakthrough-energy/plug#10 for more info.

### What the code is doing
Define the workflow to build and push, taking advantage of existing actions (see the [build-push-action](https://github.com/docker/build-push-action)) provided by docker. For now we just use the `latest` tag but can get fancy later if needed. Something like this [meta-action](https://github.com/crazy-max/ghaction-docker-meta) can generate all sorts of tags and metadata. 

### Testing
Set the workflow trigger to run on all branches and got it to push an image. This sets it back to only run for develop branch so it stays up to date.

### Usage Example/Visuals
`docker pull ghcr.io/breakthrough-energy/powersimdata:latest`

### Time estimate
5 min