### PR TITLE
Correct bug for Scenario init with bad descriptor

### DIFF
--- a/powersimdata/scenario/scenario.py
+++ b/powersimdata/scenario/scenario.py
@@ -85,8 +85,12 @@ class Scenario(object):
         :param str descriptor: scenario descriptor.
         """
         info = self._scenario_list_manager.get_scenario(descriptor)
-        if info is not None:
-            self.info = info
+        if info is None:
+            raise ValueError(
+                f"{descriptor} not found in Scenario List. "
+                "See available scenarios with Scenario().get_scenario_table()"
+            )
+        self.info = info
 
     def _set_status(self):
         """Sets execution status of scenario."""

--- a/powersimdata/scenario/tests/test_scenario.py
+++ b/powersimdata/scenario/tests/test_scenario.py
@@ -1,0 +1,10 @@
+import pytest
+
+from powersimdata.scenario.scenario import Scenario
+
+
+@pytest.mark.ssh
+def test_bad_scenario_name():
+    # This test will fail if we do add a scenario with this name
+    with pytest.raises(ValueError):
+        Scenario("this_scenario_does_not_exist")


### PR DESCRIPTION
### Purpose
Add a test to check a bug for when we try to get a Scenario that isn't in the ScenarioList, and then fix the bug. This bug was introduced in https://github.com/Breakthrough-Energy/PowerSimData/pull/420.

### What the code is doing
We raise a `ValueError` before a `RecursionError` would be created (the previous bug).

### Testing
Unit test finds the error before (or crashed python), and confirms that the fix works.

### Time estimate
5 minutes.
