### PR TITLE
fix: use os-specific path join for testing

### DIFF
--- a/powersimdata/data_access/tests/test_profile_helper.py
+++ b/powersimdata/data_access/tests/test_profile_helper.py
@@ -1,3 +1,5 @@
+import os
+
 from powersimdata.data_access.profile_helper import ProfileHelper
 
 
@@ -21,4 +23,4 @@ def test_get_file_components():
     s_info = {"base_wind": "v8", "grid_model": "europe"}
     file_name, from_dir = ProfileHelper.get_file_components(s_info, "wind")
     assert "wind_v8.csv" == file_name
-    assert "raw/europe" == from_dir
+    assert os.path.join("raw", "europe") == from_dir


### PR DESCRIPTION
### Purpose
The test currently fails on Windows, because it assumes a certain path format.
```python
__________________________ test_get_file_components ___________________________

    def test_get_file_components():
        s_info = {"base_wind": "v8", "grid_model": "europe"}
        file_name, from_dir = ProfileHelper.get_file_components(s_info, "wind")
        assert "wind_v8.csv" == file_name
>       assert "raw/europe" == from_dir
E       AssertionError: assert 'raw/europe' == 'raw\\europe'
E         - raw\europe
E         ?    ^
E         + raw/europe
E         ?    ^

powersimdata\data_access\tests\test_profile_helper.py:24: AssertionError
```

### Time estimate
10 seconds.
