### PR TITLE
fix: add deepcopy on the way into MemoryCache

### DIFF
--- a/powersimdata/utility/helpers.py
+++ b/powersimdata/utility/helpers.py
@@ -63,7 +63,7 @@ class MemoryCache:
         :param tuple key: a tuple used to lookup the cached value
         :param Any obj: the object to cache
         """
-        self._cache[key] = obj
+        self._cache[key] = copy.deepcopy(obj)
 
     def get(self, key):
         """Retrieve the value associated with key if it exists.

--- a/powersimdata/utility/tests/test_helpers.py
+++ b/powersimdata/utility/tests/test_helpers.py
@@ -68,6 +68,17 @@ def test_mem_cache_get_returns_copy():
     assert id(cache.get(key)) != id(obj)
 
 
+def test_mem_cache_put_version_never_changes():
+    cache = MemoryCache()
+    key = cache_key("foo", 4)
+    obj = {"key1": "value1"}
+    cache.put(key, obj)
+    obj["key2"] = "value2"
+    assert "key1" in cache.get(key)
+    assert "key2" not in cache.get(key)
+    assert "key2" in obj
+
+
 def test_copy_command():
     expected = r"\cp -p source dest"
     command = CommandBuilder.copy("source", "dest")


### PR DESCRIPTION
### Purpose
Addresses #443.

### What is the code doing
Add a deepcopy on the way into the cache, so any modifications to the first returned object don't affect the object in the cache.

### Testing
```python
>>> from powersimdata import Grid
>>> grid1 = Grid("Texas")
Reading bus.csv
Reading plant.csv
Reading gencost.csv
Reading branch.csv
Reading dcline.csv
Reading sub.csv
Reading bus2sub.csv
Reading zone.csv
>>> grid1.plant.groupby("type").sum().Pmax
type
coal       14501.59
hydro        555.10
ng         68642.42
nuclear     5138.60
solar       2460.20
wind       19062.63
Name: Pmax, dtype: float64
>>> grid1.plant.Pmax = 0
>>> grid1.plant.groupby("type").sum().Pmax
type
coal       0
hydro      0
ng         0
nuclear    0
solar      0
wind       0
Name: Pmax, dtype: int64
>>> grid2 = Grid("Texas")
>>> grid2.plant.groupby("type").sum().Pmax
type
coal       14501.59
hydro        555.10
ng         68642.42
nuclear     5138.60
solar       2460.20
wind       19062.63
Name: Pmax, dtype: float64
```

### Time estimate
30 seconds to understand, more time possibly to discuss.
