### PR TITLE
fix: cleanup temp file and fix PermissionError when file is in use

### DIFF
--- a/powersimdata/data_access/csv_store.py
+++ b/powersimdata/data_access/csv_store.py
@@ -79,3 +79,5 @@ class CsvStore:
         shutil.copy(tmp_path, os.path.join(server_setup.LOCAL_DIR, self._FILE_NAME))
         tmp_name = os.path.basename(tmp_path)
         self.data_access.push(tmp_name, checksum, change_name_to=self._FILE_NAME)
+        if os.path.exists(tmp_path):  # only required if data_access is LocalDataAccess
+            os.remove(tmp_path)

--- a/powersimdata/data_access/data_access.py
+++ b/powersimdata/data_access/data_access.py
@@ -293,8 +293,9 @@ class SSHDataAccess(DataAccess):
             cbk, bar = progress_bar(ascii=True, unit="b", unit_scale=True)
             _, tmp_path = mkstemp()
             sftp.get(from_path, tmp_path, callback=cbk)
-            shutil.move(tmp_path, to_path)
             bar.close()
+        # wait for file handle to be available
+        shutil.move(tmp_path, to_path)
 
     def move_to(self, file_name, to_dir=None, change_name_to=None):
         """Copy a file from userspace to data store.


### PR DESCRIPTION
### Purpose
Small fixes for issues with the temp files

### What the code is doing
In `data_access.py` - wait til after the context manager to remove the file, so it won't be in use by paramiko
In `csv_store.py`  - delete the temp file if necessary. This prevents leftover copies generated by tests, and within containers (anything using `LocalDataAccess`, which does a no-op for it's `.push` method). 

### Testing
Only verified the temp file cleanup, hoping the other part is safe enough 

### Time estimate
5 min
