### PR TITLE
fix: close temp file before trying to move/delete

### DIFF
--- a/powersimdata/data_access/csv_store.py
+++ b/powersimdata/data_access/csv_store.py
@@ -74,9 +74,10 @@ class CsvStore:
         :param pandas.DataFrame table: the data frame to save
         :param str checksum: the checksum prior to download
         """
-        _, tmp_path = mkstemp(dir=server_setup.LOCAL_DIR)
+        tmp_file, tmp_path = mkstemp(dir=server_setup.LOCAL_DIR)
         table.to_csv(tmp_path)
         shutil.copy(tmp_path, os.path.join(server_setup.LOCAL_DIR, self._FILE_NAME))
+        os.close(tmp_file)
         tmp_name = os.path.basename(tmp_path)
         self.data_access.push(tmp_name, checksum, change_name_to=self._FILE_NAME)
         if os.path.exists(tmp_path):  # only required if data_access is LocalDataAccess

--- a/powersimdata/data_access/data_access.py
+++ b/powersimdata/data_access/data_access.py
@@ -291,9 +291,10 @@ class SSHDataAccess(DataAccess):
         with self.ssh.open_sftp() as sftp:
             print(f"Transferring {file_name} from server")
             cbk, bar = progress_bar(ascii=True, unit="b", unit_scale=True)
-            _, tmp_path = mkstemp()
+            tmp_file, tmp_path = mkstemp()
             sftp.get(from_path, tmp_path, callback=cbk)
             bar.close()
+            os.close(tmp_file)
         # wait for file handle to be available
         shutil.move(tmp_path, to_path)
 


### PR DESCRIPTION
### Purpose
Fix the PermissionsErrors we had been getting on Windows.

### What the code is doing
After writing to the tempfile, we tell the os to close the file before we try to do anything with it (e.g. move, delete). I got this from this stackoverflow post: https://stackoverflow.com/questions/34716996/cant-remove-a-file-which-created-by-tempfile-mkstemp-on-windows

### Testing
Tests on Windows now pass, and I've successfully tested that this can create/prepare/launch a scenario on the server (previously had been failing so I fell back to the 'v0.4.1' branch).

Previously all **test_execute_csv** and **test_scenario_csv** tests failed with an error like:
`PermissionError: [WinError 32] The process cannot access the file because it is being used by another process: 'C:\\Users\\DanielOlsen\\ScenarioData\\tmpmvu_jnyl'`

### Time estimate
5-15 minutes, depending on how far you want to go down the low level file API rabbit hole.
