### PR TITLE
fix: ensure that per-element investment cost are calculated accurately

### DIFF
--- a/powersimdata/design/investment/investment_costs.py
+++ b/powersimdata/design/investment/investment_costs.py
@@ -1,4 +1,5 @@
 import copy as cp
+import warnings
 
 import numpy as np
 import pandas as pd
@@ -388,6 +389,17 @@ def _calculate_gen_inv_costs(grid_new, year, cost_case, sum_results=True):
         cost.rename(columns={"value": "CAPEX"}, inplace=True)
 
         # select scenario of interest
+        if cost_case != "Moderate":
+            # The 2020 ATB only has "Moderate" for nuclear, so we need to make due.
+            warnings.warn(
+                f"No cost data available for Nuclear for {cost_case} cost case, "
+                "using Moderate cost case data instead"
+            )
+            new_nuclear = cost.query(
+                "Technology == 'Nuclear' and CostCase == 'Moderate'"
+            ).copy()
+            new_nuclear.CostCase = cost_case
+            cost = cost.append(new_nuclear, ignore_index=True)
         cost = cost[cost["CostCase"] == cost_case]
         cost.drop(["CostCase"], axis=1, inplace=True)
 

--- a/powersimdata/design/investment/investment_costs.py
+++ b/powersimdata/design/investment/investment_costs.py
@@ -406,7 +406,10 @@ def _calculate_gen_inv_costs(grid_new, year, cost_case, sum_results=True):
     else:
         raise TypeError("cost_case must be str.")
 
-    plants = append_keep_index_name(grid_new.plant, grid_new.storage["gen"])
+    storage_plants = grid_new.storage["gen"].set_index(
+        grid_new.storage["StorageData"].UnitIdx.astype(int)
+    )
+    plants = append_keep_index_name(grid_new.plant, storage_plants)
     plants = plants[
         ~plants.type.isin(["dfo", "other"])
     ]  # drop these technologies, no cost data

--- a/powersimdata/design/investment/investment_costs.py
+++ b/powersimdata/design/investment/investment_costs.py
@@ -209,16 +209,25 @@ def _calculate_ac_inv_costs(grid_new, sum_results=True):
     lines.loc[:, "Cost"] = lines["MWmi"] * lines["costMWmi"] * lines["mult"]
 
     # calculate transformer costs
-    transformers["per_MW_cost"] = transformers.apply(
-        lambda x: xfmr_cost.iloc[
-            xfmr_cost.index.get_loc(bus.loc[x.from_bus_id, "baseKV"], method="nearest"),
-            xfmr_cost.columns.get_loc(bus.loc[x.to_bus_id, "baseKV"], method="nearest"),
-        ],
-        axis=1,
-    )
-    transformers["mult"] = transformers.apply(
-        lambda x: get_branch_mult(x, bus_reg, ac_reg_mult), axis=1
-    )
+    if len(transformers) > 0:
+        transformers["per_MW_cost"] = transformers.apply(
+            lambda x: xfmr_cost.iloc[
+                xfmr_cost.index.get_loc(
+                    bus.loc[x.from_bus_id, "baseKV"], method="nearest"
+                ),
+                xfmr_cost.columns.get_loc(
+                    bus.loc[x.to_bus_id, "baseKV"], method="nearest"
+                ),
+            ],
+            axis=1,
+        )
+        transformers["mult"] = transformers.apply(
+            lambda x: get_branch_mult(x, bus_reg, ac_reg_mult), axis=1
+        )
+    else:
+        # Properly handle case with no transformers, where apply returns wrong dims
+        transformers["per_MW_cost"] = []
+        transformers["mult"] = []
 
     transformers["Cost"] = (
         transformers["rateA"] * transformers["per_MW_cost"] * transformers["mult"]

--- a/powersimdata/design/investment/investment_costs.py
+++ b/powersimdata/design/investment/investment_costs.py
@@ -24,6 +24,21 @@ def merge_keep_index(df1, df2, **kwargs):
     return df1.reset_index().merge(df2, **kwargs).set_index(df1.index.names)
 
 
+def append_keep_index_name(df1, other, *args, **kwargs):
+    """Execute a pandas DataFrame append, preserving the index name of the dataframe.
+
+    :param pandas.DataFrame df1: first data frame, to call pandas append from.
+    :param pandas.DataFrame/pandas.Series/list: first argument to pandas append method.
+    :param \\*args: arbitrary positional arguments passed to pandas append call.
+    :param \\*\\*kwargs: arbitrary keyword arguments passed to pandas append call.
+    :return: (*pandas.DataFrame*) -- df1 appended with other with index name preserved.
+    """
+    original_index_name = df1.index.name
+    new_df = df1.append(other, *args, **kwargs)
+    new_df.index.name = original_index_name
+    return new_df
+
+
 def calculate_ac_inv_costs(scenario, sum_results=True, exclude_branches=None):
     """Calculate cost of upgrading AC lines and/or transformers in a scenario.
     NEEM regions are used to find regional multipliers.
@@ -404,7 +419,7 @@ def _calculate_gen_inv_costs(grid_new, year, cost_case, sum_results=True):
     else:
         raise TypeError("cost_case must be str.")
 
-    plants = grid_new.plant.append(grid_new.storage["gen"])
+    plants = append_keep_index_name(grid_new.plant, grid_new.storage["gen"])
     plants = plants[
         ~plants.type.isin(["dfo", "other"])
     ]  # drop these technologies, no cost data

--- a/powersimdata/design/investment/tests/test_investment_costs.py
+++ b/powersimdata/design/investment/tests/test_investment_costs.py
@@ -130,6 +130,22 @@ def test_calculate_ac_inv_costs_lines_only(mock_grid):
         assert ac_cost[k] == pytest.approx(expected_ac_cost[k])
 
 
+def test_calculate_ac_inv_costs_transformers_only(mock_grid):
+    expected_ac_cost = {
+        # ((reg_mult1 + reg_mult2) / 2) * sum(basecost * rateA * miles)
+        "line_cost": 0,
+        # for each: rateA * basecost * regional multiplier
+        "transformer_cost": ((30 * 7670 * 1) + (40 * 8880 * 2.25))
+        * calculate_inflation(2020),
+    }
+    this_grid = copy.deepcopy(mock_grid)
+    this_grid.branch = this_grid.branch.query("branch_device_type == 'Transformer'")
+    ac_cost = _calculate_ac_inv_costs(this_grid)
+    assert ac_cost.keys() == expected_ac_cost.keys()
+    for k in ac_cost.keys():
+        assert ac_cost[k] == pytest.approx(expected_ac_cost[k])
+
+
 def test_calculate_ac_inv_costs_not_summed(mock_grid):
     inflation_2010 = calculate_inflation(2010)
     inflation_2020 = calculate_inflation(2020)

--- a/powersimdata/input/change_table.py
+++ b/powersimdata/input/change_table.py
@@ -676,8 +676,7 @@ class ChangeTable(object):
             Required keys: "bus_id", "Pmax", "type".
             Optional keys: "c0", "c1", "c2", "Pmin".
             "c0", "c1", and "c2" are the coefficients for the cost curve, representing
-            the fixed cost ($/hour), linear cost ($/MWh),
-            and quadratic cost ($/:math:`\rm{MW}^2 \rm{h}`).
+            the fixed cost ($/hour), linear cost ($/MWh), and quadratic cost ($/MW^2·h).
             These are optional for hydro, solar, and wind, and required for other types.
         :raises TypeError: if ``info`` is not a list.
         :raises ValueError: if any of the new plants to be added have bad values.

--- a/powersimdata/tests/mock_grid.py
+++ b/powersimdata/tests/mock_grid.py
@@ -14,7 +14,7 @@ indices = {
 }
 
 gencost_names = {"gencost_before": "before", "gencost_after": "after"}
-storage_names = {"storage_gen": "gen"}
+storage_names = {"storage_gen": "gen", "storage_StorageData": "StorageData"}
 acceptable_keys = (
     set(indices.keys()) | set(gencost_names.keys()) | set(storage_names.keys())
 )
@@ -151,6 +151,22 @@ plant_columns = [
 storage_columns = {
     # The first 21 columns of plant are all that's necessary
     "gen": plant_columns[:21],
+    "StorageData": [
+        "UnitIdx",
+        "InitialStorage",
+        "InitialStorageLowerBound",
+        "InitialStorageUpperBound",
+        "InitialStorageCost",
+        "TerminalStoragePrice",
+        "MinStorageLevel",
+        "MaxStorageLevel",
+        "OutEff",
+        "InEff",
+        "LossFactor",
+        "rho",
+        "ExpectedTerminalStorageMax",
+        "ExpectedTerminalStorageMin",
+    ],
 }
 
 


### PR DESCRIPTION
### Purpose
- As originally mentioned in https://github.com/Breakthrough-Energy/PowerSimData/pull/297, fix AC investment cost calculations so that we don't use underground line costs when not appropriate (lines of appropriate rating.voltage that are entirely within `NEISO` and `NYISO J-K` regions).
- Add tests of individual element cost calculations, which illustrate some bugs (e.g. branches within the `SOCO` [Southern Company] region were getting `NaN` cost estimates, and underground line costs were being applied inappropriately to some branches).
- Fix the bugs.
- Cleanup from https://github.com/Breakthrough-Energy/PowerSimData/pull/391, where we enabled the cost calculation of nuclear generators, but didn't ensure that costs would be calculated for costs cases other than `"Moderate"`.

These code fixes are necessary for https://github.com/Breakthrough-Energy/PowerSimData/issues/439.

### What the code is doing
- In **powersimdata/tests/mock_grid.py**: we allow the user to pass data to the `MockGrid.storage["StorageData"]` field for tests.
- In **powersimdata/design/investment/tests/test_investment_costs.py**: we add tests of the individual element cost calculations (which initially fail)
- In **powersimdata/design/investment/investment_costs.py**:
  - We add a new function `merge_keep_index`, which lets us perform a dataframe merge without losing the index of the first dataframe (as demonstrated in the comments on https://github.com/Breakthrough-Energy/PowerSimData/issues/439), and we use this wherever we had been doing a `pandas.DataFrame.merge`.
  - We add a new function `append_keep_index_name` which lets us perform an append without losing the name of the first dataframe index, which we need for `merge_keep_index`.
  - In `_calculate_ac_inv_costs`:
    - We update the `select_mw` function to ensure that we only select the cost class for underground lines if the line is entirely within one of the two zones which have significant shares of underground lines (based on the data in the **LineRegMult.csv** file).
    - We generalize the `get_transformer_mult` function to be `get_branch_mult`, so that it can operate on all types of branches to return the average of the regional multiplier for the to & from ends of the branch. In the process, we fix a bug where if a Line has endpoints with no regional multiplier defined, it would return a `NaN` multiplier and then this branch would not count towards the total cost (and not be meaningful when results are returned un-summed).
    - Adding data to the branch data frame is moved after adding data to the bus data frame, so that we can take advantage of knowing the bus regions within the new `get_branch_mult` function.
  - In `calculate_gen_inv_costs`:
    - We modify the `load_cost` function so that if we request a cost case that is not `"Moderate"`, then we copy the `"Moderate"` nuclear costs into what we will return, and warn the user. This allows us to calculate costs for the `"Advanced"` and `"Conservative"` cost cases without having `NaN`s for nuclear.
    - We ensure that the indices of the storage units that we append to the plant data frame are preserved, so that there is no collision with the plant IDs in the returned non-summed data frame. We generate these non-colliding indices automatically whenever we add storage to the Grid, but they live in the `StorageData` storage table due to legacy design around the Matpower/MOST schema)

### Testing
Unit tests are added which detect the bugs, and the changes fix the bugs so that the tests run successfully. This branch has also been tested (with some additional code in the `daniel/congestion_cost_upgrade` branch) to successfully analyze per-branch upgrade costs for a real Eastern scenario.

### Time estimate
30-60 minutes. The `investment_cost` module is big, and requires aggregating many different tables to produce results, so it takes a while to trace through all the places where bugs can be introduced. There is definitely room to refactor this module to be structured a bit better, but that is of lower priority than fixing these bugs, which need to be addressed for the trainings that are coming up soon.