### PR TITLE
feat: change makedir implementation to be os agnostic

### DIFF
--- a/powersimdata/scenario/execute.py
+++ b/powersimdata/scenario/execute.py
@@ -334,9 +334,6 @@ class SimulationInput(object):
         self.server_config = server_setup.PathConfig(server_setup.DATA_ROOT_DIR)
         self.scenario_folder = "scenario_%s" % scenario_info["id"]
 
-        self.TMP_DIR = posixpath.join(
-            self.server_config.execute_dir(), self.scenario_folder
-        )
         self.REL_TMP_DIR = posixpath.join(
             server_setup.EXECUTE_DIR, self.scenario_folder
         )

--- a/powersimdata/scenario/execute.py
+++ b/powersimdata/scenario/execute.py
@@ -342,14 +342,9 @@ class SimulationInput(object):
         )
 
     def create_folder(self):
-        """Creates folder on server that will enclose simulation inputs.
-
-        :raises IOError: if folder cannot be created.
-        """
+        """Creates folder on server that will enclose simulation inputs."""
         print("--> Creating temporary folder on server for simulation inputs")
-        _, _, stderr = self._data_access.makedir(self.TMP_DIR)
-        if len(stderr.readlines()) != 0:
-            raise IOError("Failed to create %s on server" % self.TMP_DIR)
+        self._data_access.makedir(self.REL_TMP_DIR)
 
     def prepare_mpc_file(self):
         """Creates MATPOWER case file."""


### PR DESCRIPTION
### Purpose
Breaking the refactoring to support native windows users into smaller chunks. This one simply defines the `DataAccess.makedir` method separately for local/ssh subclasses. 

### What the code is doing
Change `mkdir` command to `os.makedirs` for local calls. 

### Testing
Ran `prepare_simulation_input()` on new scenario in fresh container. The code used for the server is the same as before.

### Time estimate
5 min
