### PR TITLE
feat: improve flexibility of MW-miles calculation, for Create state and new branches

### DIFF
--- a/powersimdata/design/transmission/tests/test_mwmiles.py
+++ b/powersimdata/design/transmission/tests/test_mwmiles.py
@@ -14,6 +14,7 @@ mock_branch = {
     "to_lat": [37.78, 47.66, 47.61, 47.61, 47.61],
     "to_lon": [-122.42, -117.43, -122.33, -122.33, -122.33],
     "branch_device_type": 2 * ["Line"] + 3 * ["Transformer"],
+    "x": 5 * [1],
 }
 
 expected_keys = {"mw_miles", "transformer_mw", "num_lines", "num_transformers"}

--- a/powersimdata/scenario/create.py
+++ b/powersimdata/scenario/create.py
@@ -1,7 +1,6 @@
 import copy
 import pickle
 import warnings
-from collections import OrderedDict
 
 import numpy as np
 import pandas as pd
@@ -39,24 +38,7 @@ class Create(State):
         self.grid = None
         self.ct = None
         self._scenario_status = None
-        self._scenario_info = OrderedDict(
-            [
-                ("plan", ""),
-                ("name", ""),
-                ("state", "create"),
-                ("grid_model", ""),
-                ("interconnect", ""),
-                ("base_demand", ""),
-                ("base_hydro", ""),
-                ("base_solar", ""),
-                ("base_wind", ""),
-                ("change_table", ""),
-                ("start_date", ""),
-                ("end_date", ""),
-                ("interval", ""),
-                ("engine", ""),
-            ]
-        )
+        self._scenario_info = scenario.info
         self.exported_methods = set(self.default_exported_methods)
         super().__init__(scenario)
 

--- a/powersimdata/scenario/scenario.py
+++ b/powersimdata/scenario/scenario.py
@@ -1,3 +1,5 @@
+from collections import OrderedDict
+
 import pandas as pd
 
 from powersimdata.data_access.context import Context
@@ -25,6 +27,22 @@ class Scenario(object):
         "_scenario_list_manager",
         "_execute_list_manager",
     }
+    _default_info = [
+        ("plan", ""),
+        ("name", ""),
+        ("state", "create"),
+        ("grid_model", ""),
+        ("interconnect", ""),
+        ("base_demand", ""),
+        ("base_hydro", ""),
+        ("base_solar", ""),
+        ("base_wind", ""),
+        ("change_table", ""),
+        ("start_date", ""),
+        ("end_date", ""),
+        ("interval", ""),
+        ("engine", ""),
+    ]
 
     def __init__(self, descriptor=None):
         """Constructor."""
@@ -38,6 +56,7 @@ class Scenario(object):
         self._execute_list_manager = ExecuteListManager(self.data_access)
 
         if not descriptor:
+            self.info = OrderedDict(self._default_info)
             self.state = Create(self)
         else:
             self._set_info(descriptor)


### PR DESCRIPTION
### Purpose
- Allow MW-miles calculations to be done on scenarios in Create state (closes #457).
- Include new branches in calculations of MW-miles (closes #458).
- ~Allow branches not in the base grid to be scaled via the change table.~ **EDIT**: removed. See comment: https://github.com/Breakthrough-Energy/PowerSimData/pull/463#issuecomment-826925439

### What the code is doing
- In **create.py** and **scenario.py**: we add the `info` parameter to the `Scenario` (see #457 for a discussion).
- ~In **transform_grid.py**: we move branch and DC line scaling after branch and DC line additions, to enable scaling of newly-added branches (we could equivalently scale the entries in `"new_branch"` and "`new_dcline"`, but this way allows `scale_congested_mesh_branches` to continue to work without modifications even when it identifies that a branch not in the base grid should be upgraded).~ **EDIT**: removed. See comment: https://github.com/Breakthrough-Energy/PowerSimData/pull/463#issuecomment-826925439
- In **mwmiles.py**: we make use of the `TransformGrid` class to be able to easily calculate differences in branch `rateA` for both scaled and new branches, and to automatically look up branch types, lats, and lons.
- In **test_mwmiles.py**: we add impedances to the fake data so that `TransformGrid` works properly.

### Testing
All unit tests still pass, and calculations work as expected on Scenarios with new branches (see 3822 or 3828 for examples). Testing on previously-analyzed scenarios with lots of branch upgrades (existing branches only) still produces identical results.


### Time estimate
15-30 minutes.
