### PR TITLE
doc/refactor: improve documentation and usability of investment costs

### DIFF
--- a/powersimdata/design/investment/investment_costs.py
+++ b/powersimdata/design/investment/investment_costs.py
@@ -514,13 +514,13 @@ def _calculate_gen_inv_costs(grid_new, year, cost_case, sum_results=True):
     )
 
     # multiply all together to get summed CAPEX ($)
-    plants.loc[:, "CAPEX_total"] = (
+    plants.loc[:, "cost"] = (
         plants["CAPEX"] * plants["Pmax"] * plants["reg_cap_cost_mult"]
     )
 
     # sum cost by technology
-    plants.loc[:, "CAPEX_total"] *= calculate_inflation(2018)
+    plants.loc[:, "cost"] *= calculate_inflation(2018)
     if sum_results:
-        return plants.groupby(["Technology"])["CAPEX_total"].sum()
+        return plants.groupby(["Technology"])["cost"].sum()
     else:
-        return plants
+        return plants["cost"]

--- a/powersimdata/design/investment/investment_costs.py
+++ b/powersimdata/design/investment/investment_costs.py
@@ -327,8 +327,12 @@ def calculate_gen_inv_costs(scenario, year, cost_case, sum_results=True):
     :param int/str year: building year.
     :param str cost_case: ATB cost case of data. *'Moderate'*: mid cost case,
         *'Conservative'*: generally higher costs, *'Advanced'*: generally lower costs
-    :return: (*pandas.DataFrame*) -- total generation investment cost summed by
-        technology.
+    :param bool sum_results: whether to sum data frame for plant costs.
+    :return: (*pandas.Series*) -- Overnight generation investment cost. If sum_results,
+        indices are technologies and values are total cost. Otherwise, indices are IDs
+        of plants (including storage, which is given pseudo-plant-IDs), and values are
+        individual generator costs. Whether summed or not, values are $USD,
+        inflation-adjusted to today.
 
     .. todo:: it currently uses one (arbitrary) sub-technology. The rest of the costs
         are dropped. Wind and solar will need to be fixed based on the resource supply
@@ -370,11 +374,14 @@ def _calculate_gen_inv_costs(grid_new, year, cost_case, sum_results=True):
         *'Conservative'*: generally higher costs, *'Advanced'*: generally lower costs.
     :raises ValueError: if year not 2020 - 2050, or cost case not an allowed option.
     :raises TypeError: if year not int/str or cost_case not str.
-    :return: (*pandas.Series*) -- total generation investment cost, summed by
-        technology.
+    :return: (*pandas.Series*) -- Overnight generation investment cost. If sum_results,
+        indices are technologies and values are total cost. Otherwise, indices are IDs
+        of plants (including storage, which is given pseudo-plant-IDs), and values are
+        individual generator costs. Whether summed or not, values are $USD,
+        inflation-adjusted to today.
 
     .. note:: the function computes the total capital cost as:
-        CAPEX_total = CAPEX ($/MW) * Pmax (MW) * regional multiplier
+        CAPEX_total = overnight CAPEX ($/MW) * Power capacity (MW) * regional multiplier
     """
 
     def load_cost(year, cost_case):

--- a/powersimdata/design/investment/investment_costs.py
+++ b/powersimdata/design/investment/investment_costs.py
@@ -45,8 +45,10 @@ def calculate_ac_inv_costs(scenario, sum_results=True, exclude_branches=None):
     NEEM regions are used to find regional multipliers.
 
     :param powersimdata.scenario.scenario.Scenario scenario: scenario instance.
-    :param bool sum_results: sum data frame for each branch type.
-    :return: (*dict*) -- cost of upgrading branches in $2010.
+    :param bool sum_results: whether to sum data frame for each branch type.
+    :return: (*dict*) -- keys are {'line_cost', 'transformer_cost'}, values are either
+        float if sum_results, or data frames indexed by branch ID, with a 'Cost' column
+        (float). Whether summed or not, values are $USD, inflation-adjusted to today.
     """
 
     base_grid = Grid(scenario.info["interconnect"].split("_"))
@@ -72,8 +74,10 @@ def _calculate_ac_inv_costs(grid_new, sum_results=True):
     as a transformer.
 
     :param powersimdata.input.grid.Grid grid_new: grid instance.
-    :param bool sum_results: sum data frame for each branch type.
-    :return: (*dict*) -- cost of upgrading branches in $2010.
+    :param bool sum_results: whether to sum data frame for each branch type.
+    :return: (*dict*) -- keys are {'line_cost', 'transformer_cost'}, values are either
+        float if sum_results, or data frames indexed by branch ID, with a 'Cost' column
+        (float). Whether summed or not, values are $USD, inflation-adjusted to today.
     """
 
     def select_mw(x, cost_df):

--- a/powersimdata/design/investment/investment_costs.py
+++ b/powersimdata/design/investment/investment_costs.py
@@ -45,9 +45,10 @@ def calculate_ac_inv_costs(scenario, sum_results=True, exclude_branches=None):
     NEEM regions are used to find regional multipliers.
 
     :param powersimdata.scenario.scenario.Scenario scenario: scenario instance.
-    :param bool sum_results: whether to sum data frame for each branch type.
+    :param bool sum_results: whether to sum data frame for each branch type. Defaults to
+        True.
     :return: (*dict*) -- keys are {'line_cost', 'transformer_cost'}, values are either
-        float if sum_results, or pandas Series indexed by branch ID.
+        float if ``sum_results``, or pandas Series indexed by branch ID.
         Whether summed or not, values are $USD, inflation-adjusted to today.
     """
 
@@ -74,9 +75,10 @@ def _calculate_ac_inv_costs(grid_new, sum_results=True):
     as a transformer.
 
     :param powersimdata.input.grid.Grid grid_new: grid instance.
-    :param bool sum_results: whether to sum data frame for each branch type.
+    :param bool sum_results: whether to sum data frame for each branch type. Defaults to
+        True.
     :return: (*dict*) -- keys are {'line_cost', 'transformer_cost'}, values are either
-        float if sum_results, or pandas Series indexed by branch ID.
+        float if ``sum_results``, or pandas Series indexed by branch ID.
         Whether summed or not, values are $USD, inflation-adjusted to today.
     """
 

--- a/powersimdata/design/investment/investment_costs.py
+++ b/powersimdata/design/investment/investment_costs.py
@@ -333,12 +333,13 @@ def calculate_gen_inv_costs(scenario, year, cost_case, sum_results=True):
     :param int/str year: building year.
     :param str cost_case: ATB cost case of data. *'Moderate'*: mid cost case,
         *'Conservative'*: generally higher costs, *'Advanced'*: generally lower costs
-    :param bool sum_results: whether to sum data frame for plant costs.
-    :return: (*pandas.Series*) -- Overnight generation investment cost. If sum_results,
-        indices are technologies and values are total cost. Otherwise, indices are IDs
-        of plants (including storage, which is given pseudo-plant-IDs), and values are
-        individual generator costs. Whether summed or not, values are $USD,
-        inflation-adjusted to today.
+    :param bool sum_results: whether to sum data frame for plant costs. Defaults to
+        True.
+    :return: (*pandas.Series*) -- Overnight generation investment cost.
+        If ``sum_results``, indices are technologies and values are total cost.
+        Otherwise, indices are IDs of plants (including storage, which is given
+        pseudo-plant-IDs), and values are individual generator costs.
+        Whether summed or not, values are $USD, inflation-adjusted to today.
 
     .. todo:: it currently uses one (arbitrary) sub-technology. The rest of the costs
         are dropped. Wind and solar will need to be fixed based on the resource supply
@@ -380,11 +381,13 @@ def _calculate_gen_inv_costs(grid_new, year, cost_case, sum_results=True):
         *'Conservative'*: generally higher costs, *'Advanced'*: generally lower costs.
     :raises ValueError: if year not 2020 - 2050, or cost case not an allowed option.
     :raises TypeError: if year not int/str or cost_case not str.
-    :return: (*pandas.Series*) -- Overnight generation investment cost. If sum_results,
-        indices are technologies and values are total cost. Otherwise, indices are IDs
-        of plants (including storage, which is given pseudo-plant-IDs), and values are
-        individual generator costs. Whether summed or not, values are $USD,
-        inflation-adjusted to today.
+    :param bool sum_results: whether to sum data frame for plant costs. Defaults to
+        True.
+    :return: (*pandas.Series*) -- Overnight generation investment cost.
+        If ``sum_results``, indices are technologies and values are total cost.
+        Otherwise, indices are IDs of plants (including storage, which is given
+        pseudo-plant-IDs), and values are individual generator costs.
+        Whether summed or not, values are $USD, inflation-adjusted to today.
 
     .. note:: the function computes the total capital cost as:
         CAPEX_total = overnight CAPEX ($/MW) * Power capacity (MW) * regional multiplier

--- a/powersimdata/design/investment/investment_costs.py
+++ b/powersimdata/design/investment/investment_costs.py
@@ -257,8 +257,9 @@ def calculate_dc_inv_costs(scenario, sum_results=True):
     """Calculate cost of upgrading HVDC lines in a scenario.
 
     :param powersimdata.scenario.scenario.Scenario scenario: scenario instance.
-    :param bool sum_results: sum series to return total cost.
-    :return: (*pandas.Series/float*) -- cost of upgrading HVDC lines in $2015.
+    :param bool sum_results: whether to sum series to return total cost.
+    :return: (*pandas.Series/float*) -- cost of upgrading HVDC lines, in $USD,
+        inflation-adjusted to today.
     """
     base_grid = Grid(scenario.info["interconnect"].split("_"))
     grid = scenario.state.get_grid()
@@ -278,8 +279,9 @@ def _calculate_dc_inv_costs(grid_new, sum_results=True):
     """Calculate cost of upgrading HVDC lines.
 
     :param powersimdata.input.grid.Grid grid_new: grid instance.
-    :param bool sum_results: sum series to return total cost.
-    :return: (*pandas.Series/float*) -- cost of upgrading HVDC lines in $2015.
+    :param bool sum_results: whether to sum series to return total cost.
+    :return: (*pandas.Series/float*) -- cost of upgrading HVDC lines, in $USD,
+        inflation-adjusted to today.
     """
 
     def _calculate_single_line_cost(line, bus):

--- a/powersimdata/design/investment/investment_costs.py
+++ b/powersimdata/design/investment/investment_costs.py
@@ -215,7 +215,7 @@ def _calculate_ac_inv_costs(grid_new, sum_results=True):
     lines.loc[:, "MWmi"] = lines["lengthMi"] * lines["rateA"]
 
     # calculate cost of each line
-    lines.loc[:, "Cost"] = lines["MWmi"] * lines["costMWmi"] * lines["mult"]
+    lines.loc[:, "cost"] = lines["MWmi"] * lines["costMWmi"] * lines["mult"]
 
     # calculate transformer costs
     if len(transformers) > 0:
@@ -238,19 +238,19 @@ def _calculate_ac_inv_costs(grid_new, sum_results=True):
         transformers["per_MW_cost"] = []
         transformers["mult"] = []
 
-    transformers["Cost"] = (
+    transformers["cost"] = (
         transformers["rateA"] * transformers["per_MW_cost"] * transformers["mult"]
     )
 
-    lines.Cost *= calculate_inflation(2010)
-    transformers.Cost *= calculate_inflation(2020)
+    lines.cost *= calculate_inflation(2010)
+    transformers.cost *= calculate_inflation(2020)
     if sum_results:
         return {
-            "line_cost": lines.Cost.sum(),
-            "transformer_cost": transformers.Cost.sum(),
+            "line_cost": lines.cost.sum(),
+            "transformer_cost": transformers.cost.sum(),
         }
     else:
-        return {"line_cost": lines, "transformer_cost": transformers}
+        return {"line_cost": lines.cost, "transformer_cost": transformers.cost}
 
 
 def calculate_dc_inv_costs(scenario, sum_results=True):

--- a/powersimdata/design/investment/investment_costs.py
+++ b/powersimdata/design/investment/investment_costs.py
@@ -47,8 +47,8 @@ def calculate_ac_inv_costs(scenario, sum_results=True, exclude_branches=None):
     :param powersimdata.scenario.scenario.Scenario scenario: scenario instance.
     :param bool sum_results: whether to sum data frame for each branch type.
     :return: (*dict*) -- keys are {'line_cost', 'transformer_cost'}, values are either
-        float if sum_results, or data frames indexed by branch ID, with a 'Cost' column
-        (float). Whether summed or not, values are $USD, inflation-adjusted to today.
+        float if sum_results, or pandas Series indexed by branch ID.
+        Whether summed or not, values are $USD, inflation-adjusted to today.
     """
 
     base_grid = Grid(scenario.info["interconnect"].split("_"))
@@ -76,8 +76,8 @@ def _calculate_ac_inv_costs(grid_new, sum_results=True):
     :param powersimdata.input.grid.Grid grid_new: grid instance.
     :param bool sum_results: whether to sum data frame for each branch type.
     :return: (*dict*) -- keys are {'line_cost', 'transformer_cost'}, values are either
-        float if sum_results, or data frames indexed by branch ID, with a 'Cost' column
-        (float). Whether summed or not, values are $USD, inflation-adjusted to today.
+        float if sum_results, or pandas Series indexed by branch ID.
+        Whether summed or not, values are $USD, inflation-adjusted to today.
     """
 
     def select_mw(x, cost_df):

--- a/powersimdata/design/investment/investment_costs.py
+++ b/powersimdata/design/investment/investment_costs.py
@@ -259,9 +259,11 @@ def calculate_dc_inv_costs(scenario, sum_results=True):
     """Calculate cost of upgrading HVDC lines in a scenario.
 
     :param powersimdata.scenario.scenario.Scenario scenario: scenario instance.
-    :param bool sum_results: whether to sum series to return total cost.
+    :param bool sum_results: whether to sum series to return total cost. Defaults to
+        True.
     :return: (*pandas.Series/float*) -- cost of upgrading HVDC lines, in $USD,
-        inflation-adjusted to today.
+        inflation-adjusted to today. If ``sum_results``, a float is returned, otherwise
+        a Series.
     """
     base_grid = Grid(scenario.info["interconnect"].split("_"))
     grid = scenario.state.get_grid()
@@ -281,9 +283,11 @@ def _calculate_dc_inv_costs(grid_new, sum_results=True):
     """Calculate cost of upgrading HVDC lines.
 
     :param powersimdata.input.grid.Grid grid_new: grid instance.
-    :param bool sum_results: whether to sum series to return total cost.
+    :param bool sum_results: whether to sum series to return total cost. Defaults to
+        True.
     :return: (*pandas.Series/float*) -- cost of upgrading HVDC lines, in $USD,
-        inflation-adjusted to today.
+        inflation-adjusted to today. If ``sum_results``, a float is returned, otherwise
+        a Series.
     """
 
     def _calculate_single_line_cost(line, bus):

--- a/powersimdata/design/investment/tests/test_investment_costs.py
+++ b/powersimdata/design/investment/tests/test_investment_costs.py
@@ -167,7 +167,7 @@ def test_calculate_ac_inv_costs_not_summed(mock_grid):
     for branch_type, upgrade_costs in expected_ac_cost.items():
         assert set(upgrade_costs.keys()) == set(ac_cost[branch_type].index)
         for branch, cost in upgrade_costs.items():
-            assert cost == pytest.approx(ac_cost[branch_type].loc[branch, "Cost"])
+            assert cost == pytest.approx(ac_cost[branch_type].loc[branch])
 
 
 def test_calculate_dc_inv_costs(mock_grid):
@@ -244,6 +244,4 @@ def test_calculate_gen_inv_costs_not_summed(mock_grid):
     expected_gen_inv_cost = {k: v * inflation for k, v in expected_gen_inv_cost.items()}
     assert set(gen_inv_cost.index) == set(expected_gen_inv_cost.keys())
     for k in gen_inv_cost.index:
-        assert gen_inv_cost.loc[k, "CAPEX_total"] == pytest.approx(
-            expected_gen_inv_cost[k]
-        )
+        assert gen_inv_cost.loc[k] == pytest.approx(expected_gen_inv_cost[k])

--- a/powersimdata/design/transmission/upgrade.py
+++ b/powersimdata/design/transmission/upgrade.py
@@ -301,7 +301,7 @@ def _identify_mesh_branch_upgrades(
         base_grid.branch = base_grid.branch.filter(items=congested_indices, axis=0)
         upgrade_costs = _calculate_ac_inv_costs(base_grid, sum_results=False)
         # Merge the individual line/transformer data into a single Series
-        merged_upgrade_costs = pd.concat([v.Cost for v in upgrade_costs.values()])
+        merged_upgrade_costs = pd.concat([v for v in upgrade_costs.values()])
     if method in ("MW", "MWmiles"):
         ref_grid = ref_scenario.state.get_grid()
         branch_ratings = ref_grid.branch.loc[congested_indices, "rateA"]


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
- Update docstrings to reflect latest code details (which already include inflation calculations).

### What the code is doing
- In **investment_costs.py**: Most of the changes are docstrings, adding info that the costs are automatically brought to today using the inflation calculations. The other changes are that when we don't sum all costs together, we now return a single Series containing the cost data, rather than a data frame (the current practice for gen costs and ac costs) with many columns, one of which is `"Cost"` (AC line calculations) or `"CAPEX_total"` (plant calculations). This should be more intuitive for the user, who shouldn't have to wade through many unrelated columns when they are really just interested in cost. The indices are still preserved, in case they want to do grouping using more info in the Grid's `plant` or `branch` data frames. We also update the docstrings for these changed return types.
- In **test_investment_costs.py**: We update the test case according to the new return types.
- In **upgrade.py**: for the cost-prioritization for congested branch upgrades, we update the code based on the new return type for AC branches.

### Testing
Existing tests still pass. The refactor of the cost-prioritized upgrades for congested mesh branches has been tested manually, since it is tough to create an automated test due to the instantiation of a base Grid within this algorithm:
```python
from powersimdata import Scenario
ref_scenario = Scenario(3101)
new_scenario = Scenario()
new_scenario.set_grid(interconnect="Western")
new_scenario.change_table.scale_congested_mesh_branches(ref_scenario, upgrade_n=5, method="cost")
```
(completes successfully)

As far as I can tell, this is the only use of the changed code in this repo that is not already covered by unit tests.

### Time estimate
5-10 minutes.