### PR TITLE
feat: allow scaling of added elements

### DIFF
--- a/powersimdata/input/change_table.py
+++ b/powersimdata/input/change_table.py
@@ -133,7 +133,7 @@ class ChangeTable(object):
         """
         self.grid = grid
         self.ct = {}
-        self.new_bus_cache = {}
+        self._new_element_caches = {k: {} for k in {"branch", "bus", "dcline", "plant"}}
 
     @staticmethod
     def _check_resource(resource):
@@ -262,10 +262,8 @@ class ChangeTable(object):
                 if len(self.ct[ct_key]["zone_id"]) == 0:
                     self.ct.pop(ct_key)
             if plant_id is not None:
-                plant_id_interconnect = set(
-                    self.grid.plant.groupby("type").get_group(resource).index
-                )
-                diff = set(plant_id.keys()).difference(plant_id_interconnect)
+                anticipated_plant = self._get_df_with_new_elements("plant")
+                diff = set(plant_id.keys()) - set(anticipated_plant.index)
                 if len(diff) != 0:
                     err_msg = f"No {resource} plant(s) with the following id: "
                     err_msg += ", ".join(sorted([str(d) for d in diff]))
@@ -354,6 +352,7 @@ class ChangeTable(object):
             is (are) the id of the line(s) and the associated value is the
             scaling factor for the increase/decrease in capacity of the line(s).
         """
+        anticipated_branch = self._get_df_with_new_elements("branch")
         if bool(zone_name) or bool(branch_id) is True:
             if "branch" not in self.ct:
                 self.ct["branch"] = {}
@@ -368,8 +367,7 @@ class ChangeTable(object):
                 for z in zone_name.keys():
                     self.ct["branch"]["zone_id"][self.grid.zone2id[z]] = zone_name[z]
             if branch_id is not None:
-                branch_id_interconnect = set(self.grid.branch.index)
-                diff = set(branch_id.keys()).difference(branch_id_interconnect)
+                diff = set(branch_id.keys()) - set(anticipated_branch.index)
                 if len(diff) != 0:
                     print("No branch with the following id:")
                     for i in list(diff):
@@ -394,7 +392,8 @@ class ChangeTable(object):
         """
         if "dcline" not in self.ct:
             self.ct["dcline"] = {}
-        diff = set(dcline_id.keys()).difference(set(self.grid.dcline.index))
+        anticipated_dcline = self._get_df_with_new_elements("dcline")
+        diff = set(dcline_id.keys()) - set(anticipated_dcline.index)
         if len(diff) != 0:
             print("No dc line with the following id:")
             for i in list(diff):
@@ -506,7 +505,7 @@ class ChangeTable(object):
             "terminal_min",
             "terminal_max",
         }
-        anticipated_bus = self._get_new_bus()
+        anticipated_bus = self._get_df_with_new_elements("bus")
         for i, storage in enumerate(info):
             self._check_entry_keys(storage, i, "storage", required, None, optional)
             if storage["bus_id"] not in anticipated_bus.index:
@@ -610,7 +609,7 @@ class ChangeTable(object):
         :raises ValueError: if any of the new lines to be added have nonsensical values.
         """
         info = copy.deepcopy(info)
-        anticipated_bus = self._get_new_bus()
+        anticipated_bus = self._get_df_with_new_elements("bus")
         new_lines = []
         required = {"from_bus_id", "to_bus_id"}
         xor_sets = {("capacity", "Pmax"), ("capacity", "Pmin")}
@@ -685,7 +684,7 @@ class ChangeTable(object):
             raise TypeError("Argument enclosing new plant(s) must be a list")
 
         info = copy.deepcopy(info)
-        anticipated_bus = self._get_new_bus()
+        anticipated_bus = self._get_df_with_new_elements("bus")
         new_plants = []
         required = {"bus_id", "Pmax", "type"}
         optional = {"c0", "c1", "c2", "Pmin"}
@@ -782,16 +781,24 @@ class ChangeTable(object):
             self.ct["new_bus"] = []
         self.ct["new_bus"] += new_buses
 
-    def _get_new_bus(self):
-        if "new_bus" not in self.ct:
-            return self.grid.bus
-        new_bus_tuple = tuple(tuple(sorted(b.items())) for b in self.ct["new_bus"])
-        if new_bus_tuple in self.new_bus_cache:
-            return self.new_bus_cache[new_bus_tuple]
+    def _get_df_with_new_elements(self, table):
+        """Get a post-transformation data table, for use with adding elements at new
+        buses, or scaling new elements.
+
+        :param str table: the table of the grid to be fetched:
+            'branch', 'bus', 'dcline', or 'plant'.
+        :return: (*pandas.DataFrame*) -- the post-transformation table.
+        """
+        add_key = f"new_{table}"
+        if add_key not in self.ct:
+            return getattr(self.grid, table)
+        new_elements_tuple = tuple(tuple(sorted(b.items())) for b in self.ct[add_key])
+        if new_elements_tuple in self._new_element_caches[table]:
+            return self._new_element_caches[table][new_elements_tuple]
         else:
-            bus = TransformGrid(self.grid, self.ct).get_grid().bus
-            self.new_bus_cache[new_bus_tuple] = bus
-            return bus
+            transformed = getattr(TransformGrid(self.grid, self.ct).get_grid(), table)
+            self._new_element_caches[table][new_elements_tuple] = transformed
+            return transformed.copy()
 
     def write(self, scenario_id):
         """Saves change table to disk.

--- a/powersimdata/input/tests/test_transform_grid.py
+++ b/powersimdata/input/tests/test_transform_grid.py
@@ -365,6 +365,29 @@ def test_add_branch(ct):
     )
 
 
+def test_added_branch_scaled(ct):
+    new_branch = [
+        {"capacity": 150, "from_bus_id": 8, "to_bus_id": 100},
+        {"capacity": 250, "from_bus_id": 8000, "to_bus_id": 30000},
+        {"capacity": 50, "from_bus_id": 1, "to_bus_id": 655},
+        {"capacity": 125, "from_bus_id": 3001005, "to_bus_id": 3008157},
+    ]
+    ct.add_branch(new_branch)
+    prev_max_branch_id = grid.branch.index.max()
+    new_branch_ids = list(
+        range(prev_max_branch_id + 1, prev_max_branch_id + 1 + len(new_branch))
+    )
+    ct.scale_branch_capacity(branch_id={new_branch_ids[0]: 2})
+    new_grid = TransformGrid(grid, ct.ct).get_grid()
+    new_capacity = new_grid.branch.rateA
+
+    for i, new_id in enumerate(new_branch_ids):
+        if i == 0:
+            assert new_capacity.loc[new_branch_ids[i]] == new_branch[i]["capacity"] * 2
+        else:
+            assert new_capacity.loc[new_id] == new_branch[i]["capacity"]
+
+
 def test_add_dcline(ct):
     new_dcline = [
         {"capacity": 2000, "from_bus_id": 200, "to_bus_id": 2000},


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
Allow scaling to be applied to elements that are added (i.e., not in the base grid). Closes #464.

### What the code is doing
We separate the scaling functions into scaling-by-zone and scaling-by-ID. We apply scaling-by-zone, then additions, then scaling-by-ID.

### Testing
Tested on Scenario 3856, which was created using test code along these lines, so the change table that's on the server is not valid with the current implementation of TransformGrid. With the new code, it works.
```python
from powersimdata import Scenario
from powersimdata.design.transmission.mwmiles import calculate_mw_miles
scenario = Scenario(3856)
calculate_mw_miles(scenario)
```

### Time estimate
15 minutes.
