### PR TITLE
ci: add workflow_dispatch trigger to docker build

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,6 +1,7 @@
 name: Publish docker image
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - 'develop'


### PR DESCRIPTION
### Purpose
Enable running the docker build workflow manually

### What the code is doing
Add a trigger to the workflow

### Testing
Same thing done in PostREISE

### Time estimate
1 min