### PR TITLE
feat: allow congested mesh branches to be ranked by mean congestion

### DIFF
--- a/powersimdata/design/transmission/tests/test_upgrade.py
+++ b/powersimdata/design/transmission/tests/test_upgrade.py
@@ -213,7 +213,7 @@ class TestIdentifyMesh(unittest.TestCase):
         columns = mock_branch["branch_id"]
         congu = pd.DataFrame(congu_data, index=range(num_hours), columns=columns)
         congl = pd.DataFrame(congl_data, index=range(num_hours), columns=columns)
-        # Populate with dummy data
+        # Populate with dummy data, added in different hours for thorough testing
         # Branch 101 will have frequent, low congestion
         congu[101].iloc[-15:] = 1
         # Branch 102 will have less frequent, but greater congestion
@@ -221,6 +221,8 @@ class TestIdentifyMesh(unittest.TestCase):
         # Branch 103 will have only occassional congestion, but very high
         congu[103].iloc[10:13] = 20
         congl[103].iloc[20:23] = 30
+        # Branch 105 will have extremely high congestion in only one hour
+        congl[105].iloc[49] = 9000
         # Build dummy change table
         ct = {"branch": {"branch_id": {b: 1 for b in branch_indices}}}
 
@@ -324,6 +326,45 @@ class TestIdentifyMesh(unittest.TestCase):
         expected_return = {101}
         branches = _identify_mesh_branch_upgrades(
             self.mock_scenario, upgrade_n=1, cost_metric="MWmiles"
+        )
+        self.assertEqual(branches, expected_return)
+
+    def test_identify_mesh_mean(self):
+        # Not enough branches
+        with self.assertRaises(ValueError):
+            _identify_mesh_branch_upgrades(self.mock_scenario, congestion_metric="mean")
+
+    def test_identify_mesh_mean_n_4_specify_quantile(self):
+        with self.assertRaises(ValueError):
+            _identify_mesh_branch_upgrades(
+                self.mock_scenario, congestion_metric="mean", upgrade_n=4, quantile=0.99
+            )
+
+    def test_identify_mesh_mean_n_4(self):
+        expected_return = {101, 102, 103, 105}
+        branches = _identify_mesh_branch_upgrades(
+            self.mock_scenario, congestion_metric="mean", upgrade_n=4
+        )
+        self.assertEqual(branches, expected_return)
+
+    def test_identify_mesh_mean_n_3(self):
+        expected_return = {102, 103, 105}
+        branches = _identify_mesh_branch_upgrades(
+            self.mock_scenario, congestion_metric="mean", upgrade_n=3
+        )
+        self.assertEqual(branches, expected_return)
+
+    def test_identify_mesh_mean_n_2(self):
+        expected_return = {103, 105}
+        branches = _identify_mesh_branch_upgrades(
+            self.mock_scenario, congestion_metric="mean", upgrade_n=2
+        )
+        self.assertEqual(branches, expected_return)
+
+    def test_identify_mesh_mean_n_1(self):
+        expected_return = {105}
+        branches = _identify_mesh_branch_upgrades(
+            self.mock_scenario, congestion_metric="mean", upgrade_n=1
         )
         self.assertEqual(branches, expected_return)
 

--- a/powersimdata/design/transmission/tests/test_upgrade.py
+++ b/powersimdata/design/transmission/tests/test_upgrade.py
@@ -270,14 +270,14 @@ class TestIdentifyMesh(unittest.TestCase):
     def test_identify_mesh_MW_n_3(self):  # noqa: N802
         expected_return = {101, 102, 103}
         branches = _identify_mesh_branch_upgrades(
-            self.mock_scenario, upgrade_n=3, method="MW"
+            self.mock_scenario, upgrade_n=3, cost_metric="MW"
         )
         self.assertEqual(branches, expected_return)
 
     def test_identify_mesh_MW_n_2(self):  # noqa: N802
         expected_return = {101, 102}
         branches = _identify_mesh_branch_upgrades(
-            self.mock_scenario, upgrade_n=2, method="MW"
+            self.mock_scenario, upgrade_n=2, cost_metric="MW"
         )
         self.assertEqual(branches, expected_return)
 
@@ -285,7 +285,7 @@ class TestIdentifyMesh(unittest.TestCase):
         expected_return = {102, 103}
         allow_list = {102, 103, 104}
         branches = _identify_mesh_branch_upgrades(
-            self.mock_scenario, upgrade_n=2, method="MW", allow_list=allow_list
+            self.mock_scenario, upgrade_n=2, cost_metric="MW", allow_list=allow_list
         )
         self.assertEqual(branches, expected_return)
 
@@ -293,14 +293,14 @@ class TestIdentifyMesh(unittest.TestCase):
         expected_return = {101, 103}
         deny_list = [102, 105]
         branches = _identify_mesh_branch_upgrades(
-            self.mock_scenario, upgrade_n=2, method="MW", deny_list=deny_list
+            self.mock_scenario, upgrade_n=2, cost_metric="MW", deny_list=deny_list
         )
         self.assertEqual(branches, expected_return)
 
     def test_identify_mesh_MW_n_1(self):  # noqa: N802
         expected_return = {102}
         branches = _identify_mesh_branch_upgrades(
-            self.mock_scenario, upgrade_n=1, method="MW"
+            self.mock_scenario, upgrade_n=1, cost_metric="MW"
         )
         self.assertEqual(branches, expected_return)
 
@@ -309,21 +309,21 @@ class TestIdentifyMesh(unittest.TestCase):
     def test_identify_mesh_MWmiles_n_3(self):  # noqa: N802
         expected_return = {101, 102, 103}
         branches = _identify_mesh_branch_upgrades(
-            self.mock_scenario, upgrade_n=3, method="MWmiles"
+            self.mock_scenario, upgrade_n=3, cost_metric="MWmiles"
         )
         self.assertEqual(branches, expected_return)
 
     def test_identify_mesh_MWmiles_n_2(self):  # noqa: N802
         expected_return = {101, 102}
         branches = _identify_mesh_branch_upgrades(
-            self.mock_scenario, upgrade_n=2, method="MWmiles"
+            self.mock_scenario, upgrade_n=2, cost_metric="MWmiles"
         )
         self.assertEqual(branches, expected_return)
 
     def test_identify_mesh_MWmiles_n_1(self):  # noqa: N802
         expected_return = {101}
         branches = _identify_mesh_branch_upgrades(
-            self.mock_scenario, upgrade_n=1, method="MWmiles"
+            self.mock_scenario, upgrade_n=1, cost_metric="MWmiles"
         )
         self.assertEqual(branches, expected_return)
 
@@ -331,7 +331,7 @@ class TestIdentifyMesh(unittest.TestCase):
     def test_identify_mesh_bad_method(self):
         with self.assertRaises(ValueError):
             _identify_mesh_branch_upgrades(
-                self.mock_scenario, upgrade_n=2, method="does not exist"
+                self.mock_scenario, upgrade_n=2, cost_metric="does not exist"
             )
 
 

--- a/powersimdata/design/transmission/upgrade.py
+++ b/powersimdata/design/transmission/upgrade.py
@@ -246,24 +246,32 @@ def scale_congested_mesh_branches(
 def _identify_mesh_branch_upgrades(
     ref_scenario,
     upgrade_n=100,
-    quantile=0.95,
     allow_list=None,
     deny_list=None,
-    method="branches",
+    congestion_metric="quantile",
+    cost_metric="branches",
+    quantile=None,
 ):
     """Identify the N most congested branches in a previous scenario, based on
-    the quantile value of congestion duals. A quantile value of 0.95 obtains
-    the branches with highest dual in top 5% of hours.
+    the quantile value of congestion duals, where N is specified by ``upgrade_n``. A
+    quantile value of 0.95 obtains the branches with highest dual in top 5% of hours.
 
     :param powersimdata.scenario.scenario.Scenario ref_scenario: the reference
         scenario to be used to determine the most congested branches.
     :param int upgrade_n: the number of branches to upgrade.
-    :param float quantile: the quantile to use to judge branch congestion.
     :param list/set/tuple/None allow_list: only select from these branch IDs.
     :param list/set/tuple/None deny_list: never select any of these branch IDs.
-    :param str method: prioritization method: 'branches', 'MW', or 'MWmiles'.
-    :raises ValueError: if 'method' not recognized, or not enough branches to
-        upgrade.
+    :param str congestion_metric: numerator method: 'quantile' or 'mean'.
+    :param str cost_metric: denominator method: 'branches', 'cost', 'MW', or
+        'MWmiles'.
+    :param float quantile: if ``congestion_metric`` == 'quantile', this is the quantile
+        to use to judge branch congestion (otherwise it is unused). If None, a default
+        value of 0.95 is used, i.e. we evaluate the shadow price for the worst 5% of
+        hours.
+    :raises ValueError: if ``congestion_metric`` or ``cost_metric`` is not recognized,
+        ``congestion_metric`` == 'mean' but a ``quantile`` is specified, or
+        ``congestion_metric`` == 'quantile' but there are not enough branches which are
+        congested at the desired frequency based on the ``quantile`` specified.
     :return: (*set*) -- A set of ints representing branch indices.
     """
 
@@ -271,39 +279,61 @@ def _identify_mesh_branch_upgrades(
     cong_significance_cutoff = 1e-6  # $/MWh
     # If we rank by MW-miles, what 'length' do we give to zero-length branches?
     zero_length_value = 1  # miles
+    # If the quantile is not provided, what should we default to?
+    default_quantile = 0.95
 
-    # Validate method input
-    allowed_methods = ("branches", "MW", "MWmiles", "cost")
-    if method not in allowed_methods:
-        allowed_list = ", ".join(allowed_methods)
-        raise ValueError(f"method must be one of: {allowed_list}")
+    # Validate congestion_metric input
+    allowed_congestion_metrics = ("mean", "quantile")
+    if congestion_metric not in allowed_congestion_metrics:
+        allowed_list = ", ".join(allowed_congestion_metrics)
+        raise ValueError(f"congestion_metric must be one of: {allowed_list}")
+    if congestion_metric == "mean" and quantile is not None:
+        raise ValueError("quantile cannot be specified if congestion_metric is 'mean'")
+    if congestion_metric == "quantile" and quantile is None:
+        quantile = default_quantile
+
+    # Validate cost_metric input
+    allowed_cost_metrics = ("branches", "MW", "MWmiles", "cost")
+    if cost_metric not in allowed_cost_metrics:
+        allowed_list = ", ".join(allowed_cost_metrics)
+        raise ValueError(f"cost_metric must be one of: {allowed_list}")
 
     # Get raw congestion dual values, add them
     ref_cong_abs = ref_scenario.state.get_congu() + ref_scenario.state.get_congl()
     all_branches = set(ref_cong_abs.columns.tolist())
-    # Create validated composite allow list
+    # Create validated composite allow list, and filter shadow price data frame
     composite_allow_list = _construct_composite_allow_list(
         all_branches, allow_list, deny_list
     )
-
-    # Parse 2-D array to vector of quantile values
     ref_cong_abs = ref_cong_abs.filter(items=composite_allow_list)
-    quantile_cong_abs = ref_cong_abs.quantile(quantile)
-    # Filter out insignificant values
-    significance_bitmask = quantile_cong_abs > cong_significance_cutoff
-    quantile_cong_abs = quantile_cong_abs.where(significance_bitmask).dropna()
+
+    if congestion_metric == "mean":
+        congestion_metric_values = ref_cong_abs.mean()
+    if congestion_metric == "quantile":
+        congestion_metric_values = ref_cong_abs.quantile(quantile)
+
+    # Filter out 'insignificant' values
+    congestion_metric_values = congestion_metric_values.where(
+        congestion_metric_values > cong_significance_cutoff
+    ).dropna()
     # Filter based on composite allow list
-    congested_indices = list(quantile_cong_abs.index)
+    congested_indices = list(congestion_metric_values.index)
 
     # Ensure that we have enough congested branches to upgrade
-    num_congested = len(quantile_cong_abs)
+    num_congested = len(congested_indices)
     if num_congested < upgrade_n:
         err_msg = "not enough congested branches: "
         err_msg += f"{upgrade_n} desired, but only {num_congested} congested."
+        if congestion_metric == "quantile":
+            err_msg += (
+                f" The quantile used is {quantile}; increasing this value will increase"
+                " the number of branches which qualify as having 'frequent-enough'"
+                " congestion and can be selected for upgrades."
+            )
         raise ValueError(err_msg)
 
-    # Calculate selected metric for congested branches
-    if method == "cost":
+    # Calculate selected cost metric for congested branches
+    if cost_metric == "cost":
         # Calculate costs for an upgrade dataframe containing only composite_allow_list
         base_grid = Grid(
             ref_scenario.info["interconnect"], ref_scenario.info["grid_model"]
@@ -312,7 +342,7 @@ def _identify_mesh_branch_upgrades(
         upgrade_costs = _calculate_ac_inv_costs(base_grid, sum_results=False)
         # Merge the individual line/transformer data into a single Series
         merged_upgrade_costs = pd.concat([v for v in upgrade_costs.values()])
-    if method in ("MW", "MWmiles"):
+    if cost_metric in ("MW", "MWmiles"):
         ref_grid = ref_scenario.state.get_grid()
         branch_ratings = ref_grid.branch.loc[congested_indices, "rateA"]
         # Calculate 'original' branch capacities, since that's our increment
@@ -325,20 +355,21 @@ def _identify_mesh_branch_upgrades(
             {i: (branch_ct[i] if i in branch_ct else 1) for i in congested_indices}
         )
         branch_ratings = branch_ratings / branch_prev_scaling
-    if method == "MW":
-        branch_metric = quantile_cong_abs / branch_ratings
-    elif method == "MWmiles":
+    # Then, apply this metric
+    if cost_metric == "MW":
+        branch_metric = congestion_metric_values / branch_ratings
+    elif cost_metric == "MWmiles":
         branch_lengths = ref_grid.branch.loc[congested_indices].apply(
             lambda x: haversine((x.from_lat, x.from_lon), (x.to_lat, x.to_lon)), axis=1
         )
         # Replace zero-length branches by designated default, don't divide by 0
         branch_lengths = branch_lengths.replace(0, value=zero_length_value)
-        branch_metric = quantile_cong_abs / (branch_ratings * branch_lengths)
-    elif method == "cost":
-        branch_metric = quantile_cong_abs / merged_upgrade_costs
+        branch_metric = congestion_metric_values / (branch_ratings * branch_lengths)
+    elif cost_metric == "cost":
+        branch_metric = congestion_metric_values / merged_upgrade_costs
     else:
         # By process of elimination, all that's left is method 'branches'
-        branch_metric = quantile_cong_abs
+        branch_metric = congestion_metric_values
 
     # Sort by our metric, grab indexes for N largest values (tail), return
     ranked_branches = set(branch_metric.sort_values().tail(upgrade_n).index)


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
Allow congested mesh branches to be ranked by mean congestion, rather than only by a quantile value of congestion. Closes #439 (we will create a separate, more detailed issue for the third bullet of #439, which requires more design thought).

### What the code is doing
Previously, we had a `method` parameter, which only applied to the denominator of the `(congestion metric) / (upgrade cost proxy)` ratio. Now, we have `congestion_metric` and `cost_metric` (replaces `method`). Most of the code changes are simply renaming `method` -> `cost_metric`, and elaborating in the documentation. Within `_identify_mesh_branch_upgrades`, we call `.mean()` rather than `.quantile()` on the congestion data frame as applicable, and we rename some variables so that we create a `congestion_metric_values` variable regardless of whether it's a quantile or a mean (previously, this variable had been called `quantile_cong_abs`).

### Testing
Previous unit tests pass, new ones have been added which return different results if we select `"mean"` rather than `"quantile"` as the `congestion_metric`.

### Time estimate
15-30 minutes. Functional code changes are <10 lines, but a few other things are renamed or reorganized for clarity.
