### PR TITLE
Additional support for windows

### DIFF
--- a/powersimdata/data_access/data_access.py
+++ b/powersimdata/data_access/data_access.py
@@ -219,9 +219,9 @@ class LocalDataAccess(DataAccess):
         :param str change_name_to: new name for file when copied to data store.
         """
         self._check_filename(file_name)
-        src = os.path.join(server_setup.LOCAL_DIR, file_name)
+        src = self.join(server_setup.LOCAL_DIR, file_name)
         file_name = file_name if change_name_to is None else change_name_to
-        dest = os.path.join(self.root, to_dir, file_name)
+        dest = self.join(self.root, to_dir, file_name)
         print(f"--> Moving file {src} to {dest}")
         self._check_file_exists(dest, should_exist=False)
         self.makedir(os.path.dirname(dest))
@@ -248,10 +248,10 @@ class LocalDataAccess(DataAccess):
         :param bool recursive: create directories recursively
         :param bool update: ignored
         """
-        self.makedir(dest)
         if recursive:
             shutil.copytree(src, dest)
         else:
+            self.makedir(dest)
             func = lambda s: shutil.copy(s, dest)  # noqa: E731
             LocalDataAccess._fapply(func, src)
 
@@ -366,7 +366,7 @@ class SSHDataAccess(DataAccess):
         to_dir = os.path.join(self.local_root, from_dir)
         os.makedirs(to_dir, exist_ok=True)
 
-        from_path = posixpath.join(self.root, from_dir, file_name)
+        from_path = self.join(self.root, from_dir, file_name)
         to_path = os.path.join(to_dir, file_name)
         self._check_file_exists(from_path, should_exist=True)
 
@@ -397,8 +397,8 @@ class SSHDataAccess(DataAccess):
             )
 
         file_name = file_name if change_name_to is None else change_name_to
-        to_dir = posixpath.join(self.root, "" if to_dir is None else to_dir)
-        to_path = posixpath.join(to_dir, file_name)
+        to_dir = self.join(self.root, "" if to_dir is None else to_dir)
+        to_path = self.join(to_dir, file_name)
         self.makedir(to_dir)
         self._check_file_exists(to_path, should_exist=False)
 
@@ -434,7 +434,7 @@ class SSHDataAccess(DataAccess):
         :param str relative_path: path relative to root
         :return: (*str*) -- the checksum of the file
         """
-        full_path = posixpath.join(self.root, relative_path)
+        full_path = self.join(self.root, relative_path)
         self._check_file_exists(full_path)
 
         command = f"sha1sum {full_path}"
@@ -455,9 +455,9 @@ class SSHDataAccess(DataAccess):
         self.move_to(file_name, change_name_to=backup)
 
         values = {
-            "original": posixpath.join(self.root, new_name),
-            "updated": posixpath.join(self.root, backup),
-            "lockfile": posixpath.join(self.root, "scenario.lockfile"),
+            "original": self.join(self.root, new_name),
+            "updated": self.join(self.root, backup),
+            "lockfile": self.join(self.root, "scenario.lockfile"),
             "checksum": checksum,
         }
 

--- a/powersimdata/data_access/data_access.py
+++ b/powersimdata/data_access/data_access.py
@@ -42,6 +42,13 @@ class DataAccess:
         raise NotImplementedError
 
     def get_base_dir(self, kind, backup=False):
+        """Get path to given kind relative to instance root
+
+        :param str kind: one of {input, output, tmp}
+        :param bool backup: pass True if relative to backup root dir
+        :raises ValueError: if kind is invalid
+        :return: (*str*) -- the specified path
+        """
         _allowed = ("input", "output", "tmp")
         if kind not in _allowed:
             raise ValueError(f"Invalid 'kind', must be one of {_allowed}")
@@ -52,6 +59,13 @@ class DataAccess:
         return self.join(root, "data", kind)
 
     def match_scenario_files(self, scenario_id, kind, backup=False):
+        """Get path matching the given kind of scenario data
+
+        :param int/str scenario_id: the scenario id
+        :param str kind: one of {input, output, tmp}
+        :param bool backup: pass True if relative to backup root dir
+        :return: (*str*) -- the specified path
+        """
         base_dir = self.get_base_dir(kind, backup)
         if kind == "tmp":
             return self.join(base_dir, f"scenario_{scenario_id}")
@@ -514,8 +528,9 @@ class SSHDataAccess(DataAccess):
         return len(stderr.readlines()) == 0
 
     def close(self):
-        """Close the connection that was opened when the object was created."""
-        self.ssh.close()
+        """Close the connection if one is open"""
+        if self._ssh is not None:
+            self._ssh.close()
 
 
 def progress_bar(*args, **kwargs):

--- a/powersimdata/data_access/data_access.py
+++ b/powersimdata/data_access/data_access.py
@@ -14,6 +14,12 @@ from powersimdata.data_access.profile_helper import ProfileHelper
 from powersimdata.utility import server_setup
 from powersimdata.utility.helpers import CommandBuilder
 
+_dirs = {
+    "tmp": (server_setup.EXECUTE_DIR,),
+    "input": server_setup.INPUT_DIR,
+    "output": server_setup.OUTPUT_DIR,
+}
+
 
 class DataAccess:
     """Interface to a local or remote data store."""
@@ -49,14 +55,12 @@ class DataAccess:
         :raises ValueError: if kind is invalid
         :return: (*str*) -- the specified path
         """
-        _allowed = ("input", "output", "tmp")
+        _allowed = list(_dirs.keys())
         if kind not in _allowed:
             raise ValueError(f"Invalid 'kind', must be one of {_allowed}")
 
         root = self.root if not backup else self.backup_root
-        if kind == "tmp":
-            return self.join(root, "tmp")
-        return self.join(root, "data", kind)
+        return self.join(root, *_dirs[kind])
 
     def match_scenario_files(self, scenario_id, kind, backup=False):
         """Get path matching the given kind of scenario data

--- a/powersimdata/data_access/data_access.py
+++ b/powersimdata/data_access/data_access.py
@@ -91,7 +91,7 @@ class DataAccess:
         """
         raise NotImplementedError
 
-    def execute_command(self, command):
+    def _execute_command(self, command):
         """Execute a command locally at the data access.
 
         :param list command: list of str to be passed to command line.
@@ -366,7 +366,7 @@ class SSHDataAccess(DataAccess):
 
         os.remove(from_path)
 
-    def execute_command(self, command):
+    def _execute_command(self, command):
         """Execute a command locally at the data access.
 
         :param list command: list of str to be passed to command line.
@@ -396,7 +396,7 @@ class SSHDataAccess(DataAccess):
         self._check_file_exists(full_path)
 
         command = f"sha1sum {full_path}"
-        _, stdout, _ = self.execute_command(command)
+        _, stdout, _ = self._execute_command(command)
         lines = stdout.readlines()
         return lines[0].strip()
 
@@ -427,7 +427,7 @@ class SSHDataAccess(DataAccess):
                 200>{lockfile}"
 
         command = template.format(**values)
-        _, _, stderr = self.execute_command(command)
+        _, _, stderr = self._execute_command(command)
 
         errors = stderr.readlines()
         if len(errors) > 0:
@@ -441,7 +441,7 @@ class SSHDataAccess(DataAccess):
         :param str full_path: the path, excluding filename
         :raises IOError: if command generated stderr
         """
-        _, _, stderr = self.execute_command(f"mkdir -p {full_path}")
+        _, _, stderr = self._execute_command(f"mkdir -p {full_path}")
         errors = stderr.readlines()
         if len(errors) > 0:
             raise IOError(f"Failed to create {full_path} on server")
@@ -457,7 +457,7 @@ class SSHDataAccess(DataAccess):
         """
         self.makedir(dest)
         command = CommandBuilder.copy(src, dest, recursive, update)
-        _, _, stderr = self.execute_command(command)
+        _, _, stderr = self._execute_command(command)
         if len(stderr.readlines()) != 0:
             raise IOError(f"Failed to execute {command}")
 
@@ -475,7 +475,7 @@ class SSHDataAccess(DataAccess):
             if confirmed.lower() != "y":
                 print("Operation cancelled.")
                 return
-        _, _, stderr = self.execute_command(command)
+        _, _, stderr = self._execute_command(command)
         if len(stderr.readlines()) != 0:
             raise IOError(f"Failed to delete target={target} on server")
         print("--> Done!")
@@ -486,7 +486,7 @@ class SSHDataAccess(DataAccess):
         :param str filepath: the path to the file
         :return: (*bool*) -- whether the file exists
         """
-        _, _, stderr = self.execute_command(f"ls {filepath}")
+        _, _, stderr = self._execute_command(f"ls {filepath}")
         return len(stderr.readlines()) == 0
 
     def close(self):

--- a/powersimdata/data_access/profile_helper.py
+++ b/powersimdata/data_access/profile_helper.py
@@ -17,26 +17,25 @@ class ProfileHelper:
 
         :param dict scenario_info: a ScenarioInfo instance
         :param str field_name: the kind of profile
-        :return: (*tuple*) -- file name and path
+        :return: (*tuple*) -- file name and list of path components
         """
         version = scenario_info["base_" + field_name]
         file_name = field_name + "_" + version + ".csv"
         grid_model = scenario_info["grid_model"]
-        from_dir = os.path.join("raw", grid_model)
-        return file_name, from_dir
+        return file_name, ("raw", grid_model)
 
     @staticmethod
     def download_file(file_name, from_dir):
         """Download the profile from blob storage at the given path
 
         :param str file_name: profile csv
-        :param str from_dir: the path relative to the blob container
+        :param tuple from_dir: tuple of path components
         :return: (*str*) -- path to downloaded file
         """
         print(f"--> Downloading {file_name} from blob storage.")
-        url_path = "/".join(os.path.split(from_dir))
+        url_path = "/".join(from_dir)
         url = f"{ProfileHelper.BASE_URL}/{url_path}/{file_name}"
-        dest = os.path.join(server_setup.LOCAL_DIR, from_dir, file_name)
+        dest = os.path.join(server_setup.LOCAL_DIR, *from_dir, file_name)
         os.makedirs(os.path.dirname(dest), exist_ok=True)
         resp = requests.get(url, stream=True)
         content_length = int(resp.headers.get("content-length", 0))

--- a/powersimdata/data_access/tests/test_data_access.py
+++ b/powersimdata/data_access/tests/test_data_access.py
@@ -108,7 +108,7 @@ def test_move_to_multi_path(mock_data_access, make_temp):
     remote_path = mock_data_access.root / rel_path
     remote_path.mkdir(parents=True)
     fname = make_temp(remote=False)
-    mock_data_access.move_to(fname, rel_path)
+    mock_data_access.move_to(fname, str(rel_path))
     _check_content(os.path.join(remote_path, fname))
 
 

--- a/powersimdata/data_access/tests/test_data_access.py
+++ b/powersimdata/data_access/tests/test_data_access.py
@@ -99,7 +99,7 @@ def test_match_scenario_files(data_access):
 @pytest.mark.integration
 @pytest.mark.ssh
 def test_setup_server_connection(data_access):
-    _, stdout, _ = data_access._execute_command("whoami")
+    _, stdout, _ = data_access.ssh.exec_command("whoami")
     assert stdout.read().decode("utf-8").strip() == server_setup.get_server_user()
 
 

--- a/powersimdata/data_access/tests/test_data_access.py
+++ b/powersimdata/data_access/tests/test_data_access.py
@@ -7,7 +7,7 @@ import pytest
 
 from powersimdata.data_access.data_access import SSHDataAccess
 from powersimdata.tests.mock_ssh import MockConnection
-from powersimdata.utility.server_setup import get_server_user
+from powersimdata.utility import server_setup
 
 CONTENT = b"content"
 
@@ -67,11 +67,40 @@ def _check_content(filepath):
         assert CONTENT == f.read()
 
 
+root_dir = server_setup.DATA_ROOT_DIR
+backup_root = server_setup.BACKUP_DATA_ROOT_DIR
+
+
+def test_base_dir(data_access):
+    input_dir = data_access.get_base_dir("input")
+    assert f"{root_dir}/data/input" == input_dir
+
+    output_dir = data_access.get_base_dir("output", backup=True)
+    assert f"{backup_root}/data/output" == output_dir
+
+    tmp_dir = data_access.get_base_dir("tmp")
+    assert f"{root_dir}/tmp" == tmp_dir
+
+    with pytest.raises(ValueError):
+        data_access.get_base_dir("foo")
+
+
+def test_match_scenario_files(data_access):
+    output_files = data_access.match_scenario_files(99, "output")
+    assert f"{root_dir}/data/output/99_*" == output_files
+
+    tmp_files = data_access.match_scenario_files(42, "tmp", backup=True)
+    assert f"{backup_root}/tmp/scenario_42" == tmp_files
+
+    with pytest.raises(ValueError):
+        data_access.match_scenario_files(1, "foo")
+
+
 @pytest.mark.integration
 @pytest.mark.ssh
 def test_setup_server_connection(data_access):
     _, stdout, _ = data_access._execute_command("whoami")
-    assert stdout.read().decode("utf-8").strip() == get_server_user()
+    assert stdout.read().decode("utf-8").strip() == server_setup.get_server_user()
 
 
 def test_mocked_correctly(mock_data_access):

--- a/powersimdata/data_access/tests/test_data_access.py
+++ b/powersimdata/data_access/tests/test_data_access.py
@@ -70,7 +70,7 @@ def _check_content(filepath):
 @pytest.mark.integration
 @pytest.mark.ssh
 def test_setup_server_connection(data_access):
-    _, stdout, _ = data_access.execute_command("whoami")
+    _, stdout, _ = data_access._execute_command("whoami")
     assert stdout.read().decode("utf-8").strip() == get_server_user()
 
 

--- a/powersimdata/data_access/tests/test_profile_helper.py
+++ b/powersimdata/data_access/tests/test_profile_helper.py
@@ -1,5 +1,3 @@
-import os
-
 from powersimdata.data_access.profile_helper import ProfileHelper
 
 
@@ -23,4 +21,4 @@ def test_get_file_components():
     s_info = {"base_wind": "v8", "grid_model": "europe"}
     file_name, from_dir = ProfileHelper.get_file_components(s_info, "wind")
     assert "wind_v8.csv" == file_name
-    assert os.path.join("raw", "europe") == from_dir
+    assert ("raw", "europe") == from_dir

--- a/powersimdata/input/input_data.py
+++ b/powersimdata/input/input_data.py
@@ -28,19 +28,19 @@ class InputHelper:
 
         :param dict scenario_info: a ScenarioInfo instance
         :param str field_name: the input file type
-        :return: (*tuple*) -- file name and path
+        :return: (*tuple*) -- file name and list of path components
         """
         ext = _file_extension[field_name]
         file_name = scenario_info["id"] + "_" + field_name + "." + ext
-        from_dir = server_setup.INPUT_DIR
-        return file_name, from_dir
+        return file_name, server_setup.INPUT_DIR
 
     def download_file(self, file_name, from_dir):
         """Download the file if using server, otherwise no-op
 
         :param str file_name: either grid or ct file name
-        :param str from_dir: the path relative to the root dir
+        :param tuple from_dir: tuple of path components
         """
+        from_dir = self.data_access.join(*from_dir)
         self.data_access.copy_from(file_name, from_dir)
 
 
@@ -90,7 +90,7 @@ class InputData(object):
 
         file_name, from_dir = helper.get_file_components(scenario_info, field_name)
 
-        filepath = os.path.join(server_setup.LOCAL_DIR, from_dir, file_name)
+        filepath = os.path.join(server_setup.LOCAL_DIR, *from_dir, file_name)
         key = cache_key(filepath)
         cached = _cache.get(key)
         if cached is not None:

--- a/powersimdata/input/tests/test_input_data.py
+++ b/powersimdata/input/tests/test_input_data.py
@@ -9,7 +9,7 @@ def test_get_file_components():
     grid_file, from_dir = InputHelper.get_file_components(s_info, "grid")
     assert "123_ct.pkl" == ct_file
     assert "123_grid.mat" == grid_file
-    assert "data/input" == from_dir
+    assert ("data", "input") == from_dir
 
 
 def test_check_field():

--- a/powersimdata/output/output_data.py
+++ b/powersimdata/output/output_data.py
@@ -36,7 +36,7 @@ class OutputData(object):
         print("--> Loading %s" % field_name)
         file_name = scenario_id + "_" + field_name + ".pkl"
         from_dir = server_setup.OUTPUT_DIR
-        filepath = os.path.join(server_setup.LOCAL_DIR, from_dir, file_name)
+        filepath = os.path.join(server_setup.LOCAL_DIR, *from_dir, file_name)
 
         try:
             return pd.read_pickle(filepath)
@@ -46,7 +46,8 @@ class OutputData(object):
         except FileNotFoundError:
             print(f"{filepath} not found on local machine")
 
-        self._data_access.copy_from(file_name, from_dir)
+        remote_dir = self._data_access.join(*from_dir)
+        self._data_access.copy_from(file_name, remote_dir)
         return pd.read_pickle(filepath)
 
 

--- a/powersimdata/scenario/create.py
+++ b/powersimdata/scenario/create.py
@@ -80,7 +80,8 @@ class Create(State):
         print("--> Writing change table on local machine")
         self.builder.change_table.write(self._scenario_info["id"])
         file_name = self._scenario_info["id"] + "_ct.pkl"
-        self._data_access.move_to(file_name, server_setup.INPUT_DIR)
+        input_dir = self._data_access.join(*server_setup.INPUT_DIR)
+        self._data_access.move_to(file_name, input_dir)
 
     def get_bus_demand(self):
         """Returns demand profiles, by bus.

--- a/powersimdata/scenario/delete.py
+++ b/powersimdata/scenario/delete.py
@@ -1,5 +1,4 @@
 import os
-import posixpath
 
 from powersimdata.data_access.data_access import LocalDataAccess
 from powersimdata.scenario.state import State
@@ -41,25 +40,21 @@ class Delete(State):
         self._scenario_list_manager.delete_entry(scenario_id)
         self._execute_list_manager.delete_entry(scenario_id)
 
-        wildcard = f"{scenario_id}_*"
-
         print("--> Deleting scenario input data on server")
-        target = posixpath.join(self.path_config.input_dir(), wildcard)
+        target = self._data_access.match_scenario_files(scenario_id, "input")
         self._data_access.remove(target, recursive=False, confirm=confirm)
 
         print("--> Deleting scenario output data on server")
-        target = posixpath.join(self.path_config.output_dir(), wildcard)
+        target = self._data_access.match_scenario_files(scenario_id, "output")
         self._data_access.remove(target, recursive=False, confirm=confirm)
 
         # Delete temporary folder enclosing simulation inputs
         print("--> Deleting temporary folder on server")
-        tmp_dir = posixpath.join(
-            self.path_config.execute_dir(), f"scenario_{scenario_id}"
-        )
+        tmp_dir = self._data_access.match_scenario_files(scenario_id, "tmp")
         self._data_access.remove(tmp_dir, recursive=True, confirm=confirm)
 
         print("--> Deleting input and output data on local machine")
-        target = os.path.join(server_setup.LOCAL_DIR, "data", "**", wildcard)
+        target = os.path.join(server_setup.LOCAL_DIR, "data", "**", f"{scenario_id}_*")
         LocalDataAccess().remove(target, recursive=False, confirm=confirm)
 
         # Delete attributes

--- a/powersimdata/scenario/delete.py
+++ b/powersimdata/scenario/delete.py
@@ -1,5 +1,3 @@
-import os
-
 from powersimdata.data_access.data_access import LocalDataAccess
 from powersimdata.scenario.state import State
 from powersimdata.utility import server_setup
@@ -40,22 +38,25 @@ class Delete(State):
         self._scenario_list_manager.delete_entry(scenario_id)
         self._execute_list_manager.delete_entry(scenario_id)
 
-        print("--> Deleting scenario input data on server")
+        print("--> Deleting scenario input data")
         target = self._data_access.match_scenario_files(scenario_id, "input")
         self._data_access.remove(target, recursive=False, confirm=confirm)
 
-        print("--> Deleting scenario output data on server")
+        print("--> Deleting scenario output data")
         target = self._data_access.match_scenario_files(scenario_id, "output")
         self._data_access.remove(target, recursive=False, confirm=confirm)
 
         # Delete temporary folder enclosing simulation inputs
-        print("--> Deleting temporary folder on server")
+        print("--> Deleting temporary folder")
         tmp_dir = self._data_access.match_scenario_files(scenario_id, "tmp")
         self._data_access.remove(tmp_dir, recursive=True, confirm=confirm)
 
         print("--> Deleting input and output data on local machine")
-        target = os.path.join(server_setup.LOCAL_DIR, "data", "**", f"{scenario_id}_*")
-        LocalDataAccess().remove(target, recursive=False, confirm=confirm)
+        local_data_access = LocalDataAccess()
+        target = local_data_access.join(
+            server_setup.LOCAL_DIR, "data", "**", f"{scenario_id}_*"
+        )
+        local_data_access.remove(target, recursive=False, confirm=confirm)
 
         # Delete attributes
         self._clean()

--- a/powersimdata/scenario/execute.py
+++ b/powersimdata/scenario/execute.py
@@ -331,16 +331,12 @@ class SimulationInput(object):
         self._scenario_info = scenario_info
         self.grid = grid
         self.ct = ct
-        self.server_config = server_setup.PathConfig(server_setup.DATA_ROOT_DIR)
         self.scenario_id = scenario_info["id"]
-        self.scenario_folder = "scenario_%s" % self.scenario_id
 
-        self.REL_TMP_DIR = posixpath.join(
-            server_setup.EXECUTE_DIR, self.scenario_folder
+        self.REL_TMP_DIR = self._data_access.join(
+            server_setup.EXECUTE_DIR, f"scenario_{self.scenario_id}"
         )
-        self.TMP_DIR = posixpath.join(
-            self.server_config.execute_dir(), self.scenario_folder
-        )
+        self.TMP_DIR = self._data_access.match_scenario_files(self.scenario_id, "tmp")
 
     def create_folder(self):
         """Creates folder on server that will enclose simulation inputs."""
@@ -382,9 +378,6 @@ class SimulationInput(object):
                 file_name, self.REL_TMP_DIR, change_name_to=f"{kind}.csv"
             )
         else:
-            from_dir = posixpath.join(
-                self.server_config.execute_dir(),
-                f"scenario_{profile_as}",
-            )
+            from_dir = self._data_access.match_scenario_files(profile_as, "tmp")
             to_dir = self.TMP_DIR
             self._data_access.copy(f"{from_dir}/{kind}.csv", to_dir)

--- a/powersimdata/scenario/execute.py
+++ b/powersimdata/scenario/execute.py
@@ -340,7 +340,8 @@ class SimulationInput(object):
 
     def create_folder(self):
         """Creates folder on server that will enclose simulation inputs."""
-        print("--> Creating temporary folder on server for simulation inputs")
+        description = self._data_access.description
+        print(f"--> Creating temporary folder on {description} for simulation inputs")
         self._data_access.makedir(self.TMP_DIR)
 
     def prepare_mpc_file(self):

--- a/powersimdata/scenario/move.py
+++ b/powersimdata/scenario/move.py
@@ -1,7 +1,4 @@
-import posixpath
-
 from powersimdata.scenario.state import State
-from powersimdata.utility import server_setup
 
 
 class Move(State):
@@ -68,39 +65,28 @@ class BackUpDisk(object):
         """Constructor."""
         self._data_access = data_access
         self._scenario_info = scenario_info
-        self.backup_config = server_setup.PathConfig(server_setup.BACKUP_DATA_ROOT_DIR)
-        self.server_config = server_setup.PathConfig(server_setup.DATA_ROOT_DIR)
         self.scenario_id = self._scenario_info["id"]
-        self.wildcard = f"{self.scenario_id}_*"
 
     def move_input_data(self, confirm=True):
         """Moves input data."""
         print("--> Moving scenario input data to backup disk")
-        source = posixpath.join(
-            self.server_config.input_dir(),
-            self.wildcard,
-        )
-        target = self.backup_config.input_dir()
+        source = self._data_access.match_scenario_files(self.scenario_id, "input")
+        target = self._data_access.get_base_dir("input", backup=True)
         self._data_access.copy(source, target, update=True)
         self._data_access.remove(source, recursive=False, confirm=confirm)
 
     def move_output_data(self, confirm=True):
         """Moves output data"""
         print("--> Moving scenario output data to backup disk")
-        source = posixpath.join(
-            self.server_config.output_dir(),
-            self.wildcard,
-        )
-        target = self.backup_config.output_dir()
+        source = self._data_access.match_scenario_files(self.scenario_id, "output")
+        target = self._data_access.get_base_dir("output", backup=True)
         self._data_access.copy(source, target, update=True)
         self._data_access.remove(source, recursive=False, confirm=confirm)
 
     def move_temporary_folder(self, confirm=True):
         """Moves temporary folder."""
         print("--> Moving temporary folder to backup disk")
-        source = posixpath.join(
-            self.server_config.execute_dir(), "scenario_" + self.scenario_id
-        )
-        target = self.backup_config.execute_dir()
+        source = self._data_access.match_scenario_files(self.scenario_id, "tmp")
+        target = self._data_access.get_base_dir("tmp", backup=True)
         self._data_access.copy(source, target, recursive=True, update=True)
         self._data_access.remove(source, recursive=True, confirm=confirm)

--- a/powersimdata/scenario/state.py
+++ b/powersimdata/scenario/state.py
@@ -1,6 +1,5 @@
 from powersimdata.data_access.execute_list import ExecuteListManager
 from powersimdata.data_access.scenario_list import ScenarioListManager
-from powersimdata.utility import server_setup
 
 
 class State(object):
@@ -22,7 +21,6 @@ class State(object):
         self._data_access = scenario.data_access
         self._scenario_list_manager = ScenarioListManager(self._data_access)
         self._execute_list_manager = ExecuteListManager(self._data_access)
-        self.path_config = server_setup.PathConfig(server_setup.DATA_ROOT_DIR)
 
     def switch(self, state):
         """Switches state.

--- a/powersimdata/utility/server_setup.py
+++ b/powersimdata/utility/server_setup.py
@@ -6,8 +6,8 @@ SERVER_SSH_PORT = os.getenv("BE_SERVER_SSH_PORT", 22)
 BACKUP_DATA_ROOT_DIR = "/mnt/RE-Storage/v2"
 DATA_ROOT_DIR = "/mnt/bes/pcm"
 EXECUTE_DIR = "tmp"
-INPUT_DIR = "data/input"
-OUTPUT_DIR = "data/output"
+INPUT_DIR = ("data", "input")
+OUTPUT_DIR = ("data", "output")
 LOCAL_DIR = os.path.join(Path.home(), "ScenarioData", "")
 MODEL_DIR = "/home/bes/pcm"
 

--- a/powersimdata/utility/server_setup.py
+++ b/powersimdata/utility/server_setup.py
@@ -1,5 +1,4 @@
 import os
-import posixpath
 from pathlib import Path
 
 SERVER_ADDRESS = os.getenv("BE_SERVER_ADDRESS", "becompute01.gatesventures.com")
@@ -23,23 +22,6 @@ def get_deployment_mode():
     if mode is None:
         return DeploymentMode.Server
     return DeploymentMode.Container
-
-
-class PathConfig:
-    def __init__(self, root=None):
-        self.root = root
-
-    def _join(self, rel_path):
-        return posixpath.join(self.root, rel_path)
-
-    def execute_dir(self):
-        return self._join(EXECUTE_DIR)
-
-    def input_dir(self):
-        return self._join(INPUT_DIR)
-
-    def output_dir(self):
-        return self._join(OUTPUT_DIR)
 
 
 def get_server_user():


### PR DESCRIPTION
### Purpose
Address several places that were not platform independent.

### What the code is doing
* Finished splitting up commands between local/ssh and removed the `execute_command` in the local case, as it relied on `/bin/bash`
* Add the `DataAccess.join` attribute according to the subclass, removing hard coded `posixpath.join` in calling code
* Added `get_base_dir` and `match_scenario_files` to encapsulate the logic of creating paths, along with tests for these
* Fix potential issue in `InputData` and `OutputData` which were relying on the values from `server_setup.py`, which had posixpath implicitly hard coded (e.g. `INPUT_DIR = data/input`). We delay the path join by using a tuple instead

### Testing
* Ran a scenario in docker (using `LocalDataAccess`)
* Created and prepared a scenario on the server and deleted it (using `SSHDataAccess`)
* Added a few unit tests

### Time estimate
20 mins
