### PR TITLE
Support local+native usage

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,3 +7,7 @@ build
 **/__pycache__
 .ipynb_checkpoints
 **/.ropeproject
+.env
+.venv
+.dockerignore
+config.ini

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # This is specific to this package
 powersimdata/utility/.server_user
+config.ini
 
 # The remainder of this file taken from github/gitignore
 # https://github.com/github/gitignore/blob/master/Python.gitignore

--- a/powersimdata/data_access/context.py
+++ b/powersimdata/data_access/context.py
@@ -1,4 +1,5 @@
 from powersimdata.data_access.data_access import LocalDataAccess, SSHDataAccess
+from powersimdata.data_access.launcher import HttpLauncher, NativeLauncher, SSHLauncher
 from powersimdata.utility import server_setup
 from powersimdata.utility.config import DeploymentMode, get_deployment_mode
 
@@ -23,3 +24,16 @@ class Context:
         if mode == DeploymentMode.Server:
             return SSHDataAccess(root)
         return LocalDataAccess(root)
+
+    @staticmethod
+    def get_launcher(scenario):
+        """Return instance for interaction with simulation engine
+
+        :param powersimdata.Scenario scenario: a scenario object
+        """
+        mode = get_deployment_mode()
+        if mode == DeploymentMode.Server:
+            return SSHLauncher(scenario)
+        elif mode == DeploymentMode.Container:
+            return HttpLauncher(scenario)
+        return NativeLauncher(scenario)

--- a/powersimdata/data_access/context.py
+++ b/powersimdata/data_access/context.py
@@ -1,6 +1,6 @@
 from powersimdata.data_access.data_access import LocalDataAccess, SSHDataAccess
 from powersimdata.utility import server_setup
-from powersimdata.utility.server_setup import DeploymentMode, get_deployment_mode
+from powersimdata.utility.config import DeploymentMode, get_deployment_mode
 
 
 class Context:

--- a/powersimdata/data_access/context.py
+++ b/powersimdata/data_access/context.py
@@ -14,6 +14,8 @@ class Context:
 
         :param str data_loc: pass "disk" if using data from backup disk,
             otherwise leave the default.
+        :return: (:class:`powersimdata.data_access.data_access.DataAccess`) -- a data access
+            instance
         """
         if data_loc == "disk":
             root = server_setup.BACKUP_DATA_ROOT_DIR
@@ -29,7 +31,8 @@ class Context:
     def get_launcher(scenario):
         """Return instance for interaction with simulation engine
 
-        :param powersimdata.Scenario scenario: a scenario object
+        :param powersimdata.scenario.scenario.Scenario scenario: a scenario object
+        :return: (:class:`powersimdata.data_access.launcher.Launcher`) -- a launcher instance
         """
         mode = get_deployment_mode()
         if mode == DeploymentMode.Server:

--- a/powersimdata/data_access/data_access.py
+++ b/powersimdata/data_access/data_access.py
@@ -24,10 +24,12 @@ _dirs = {
 class DataAccess:
     """Interface to a local or remote data store."""
 
-    def __init__(self, root=None):
+    def __init__(self, root=None, backup_root=None):
         """Constructor"""
         self.root = server_setup.DATA_ROOT_DIR if root is None else root
-        self.backup_root = server_setup.BACKUP_DATA_ROOT_DIR
+        self.backup_root = (
+            server_setup.BACKUP_DATA_ROOT_DIR if backup_root is None else backup_root
+        )
         self.join = None
 
     def copy_from(self, file_name, from_dir):
@@ -291,9 +293,9 @@ class SSHDataAccess(DataAccess):
 
     _last_attempt = 0
 
-    def __init__(self, root=None):
+    def __init__(self, root=None, backup_root=None):
         """Constructor"""
-        super().__init__(root)
+        super().__init__(root, backup_root)
         self._ssh = None
         self._retry_after = 5
         self.local_root = server_setup.LOCAL_DIR

--- a/powersimdata/data_access/execute_list.py
+++ b/powersimdata/data_access/execute_list.py
@@ -18,7 +18,7 @@ class ExecuteListManager(CsvStore):
         """Return the status for the scenario
 
         :param str/int scenario_id: the scenario id
-        :raises Exception: if scenario not found in execute list on server.
+        :raises Exception: if scenario not found in execute list.
         :return: (*str*) -- scenario status
         """
         table = self.get_execute_table()
@@ -46,12 +46,12 @@ class ExecuteListManager(CsvStore):
         table = self.get_execute_table()
         table.loc[int(scenario_id), "status"] = status
 
-        print(f"-->  Setting status={status} in execute table on server")
+        print(f"--> Setting status={status} in execute list")
         return table
 
     @verify_hash
     def delete_entry(self, scenario_id):
-        """Deletes entry from execute list on server.
+        """Deletes entry from execute list.
 
         :param int/str scenario_id: the id of the scenario
         :return: (*pandas.DataFrame*) -- the updated data frame
@@ -59,5 +59,5 @@ class ExecuteListManager(CsvStore):
         table = self.get_execute_table()
         table.drop(int(scenario_id), inplace=True)
 
-        print("--> Deleting entry in execute table on server")
+        print("--> Deleting entry in %s" % self._FILE_NAME)
         return table

--- a/powersimdata/data_access/launcher.py
+++ b/powersimdata/data_access/launcher.py
@@ -45,7 +45,7 @@ class Launcher:
     def launch_simulation(self, threads=None, solver=None, extract_data=True):
         _check_threads(threads)
         _check_solver(solver)
-        self._launch(threads, solver, extract_data)
+        return self._launch(threads, solver, extract_data)
 
 
 class SSHLauncher(Launcher):
@@ -127,7 +127,8 @@ class HttpLauncher(Launcher):
         :param str solver: the solver used for optimization. This defaults to
             None, which translates to gurobi
         :param bool extract_data: always True
-        :return: (*requests.Response*) -- the http response object
+        :return: (*requests.Response*) -- http response from the engine, with a json
+            body as is returned by check_progress
         """
         scenario_id = self.scenario.scenario_id
         url = f"http://{server_setup.SERVER_ADDRESS}:5000/launch/{scenario_id}"
@@ -141,7 +142,8 @@ class HttpLauncher(Launcher):
     def check_progress(self):
         """Get the status of an ongoing simulation, if possible
 
-        :return: (*dict*) -- json response
+        :return: (*dict*) -- contains "output", "errors", "scenario_id", and "status"
+            keys which map to stdout, stderr, and the respective scenario attributes
         """
         scenario_id = self.scenario.scenario_id
         url = f"http://{server_setup.SERVER_ADDRESS}:5000/status/{scenario_id}"
@@ -158,7 +160,8 @@ class NativeLauncher(Launcher):
         :param str solver: the solver used for optimization. This defaults to
             None, which translates to gurobi
         :param bool extract_data: always True
-        :return: (*dict*) -- json response
+        :return: (*dict*) -- contains "output", "errors", "scenario_id", and "status"
+            keys which map to stdout, stderr, and the respective scenario attributes
         """
         sys.path.append(server_setup.ENGINE_DIR)
         from pyreisejl.utility import app
@@ -168,7 +171,8 @@ class NativeLauncher(Launcher):
     def check_progress(self):
         """Get the status of an ongoing simulation, if possible
 
-        :return: (*dict*) -- json response
+        :return: (*dict*) -- contains "output", "errors", "scenario_id", and "status"
+            keys which map to stdout, stderr, and the respective scenario attributes
         """
         sys.path.append(server_setup.ENGINE_DIR)
         from pyreisejl.utility import app

--- a/powersimdata/data_access/launcher.py
+++ b/powersimdata/data_access/launcher.py
@@ -32,6 +32,11 @@ def _check_solver(solver):
 
 
 class Launcher:
+    """Base class for interaction with simulation engine.
+
+    :param powrsimdata.scenario.scenario.Scenario scenario: scenario instance
+    """
+
     def __init__(self, scenario):
         self.scenario = scenario
 

--- a/powersimdata/data_access/launcher.py
+++ b/powersimdata/data_access/launcher.py
@@ -1,4 +1,5 @@
 import posixpath
+import sys
 
 import requests
 
@@ -159,11 +160,17 @@ class NativeLauncher(Launcher):
         :param bool extract_data: always True
         :return: (*dict*) -- json response
         """
-        pass
+        sys.path.append(server_setup.ENGINE_DIR)
+        from pyreisejl.utility import app
+
+        return app.launch_simulation(self.scenario.scenario_id, threads, solver)
 
     def check_progress(self):
         """Get the status of an ongoing simulation, if possible
 
         :return: (*dict*) -- json response
         """
-        pass
+        sys.path.append(server_setup.ENGINE_DIR)
+        from pyreisejl.utility import app
+
+        return app.check_progress()

--- a/powersimdata/data_access/launcher.py
+++ b/powersimdata/data_access/launcher.py
@@ -1,0 +1,139 @@
+import posixpath
+
+import requests
+
+from powersimdata.utility import server_setup
+
+
+def _check_threads(threads):
+    """Validate threads argument
+
+    :param int threads: the number of threads to be used
+    :raises TypeError: if threads is not an int
+    :raises ValueError: if threads is not a positive value
+    """
+    if threads:
+        if not isinstance(threads, int):
+            raise TypeError("threads must be an int")
+        if threads < 1:
+            raise ValueError("threads must be a positive value")
+
+
+def _check_solver(solver):
+    """Validate solver argument
+
+    :param str solver: the solver used for the optimization
+    :raises ValueError: if invalid solver provided
+    """
+    solvers = ("gurobi", "glpk")
+    if solver is not None and solver.lower() not in solvers:
+        raise ValueError(f"Invalid solver: options are {solvers}")
+
+
+# TODO - check_progress (just print a message for SSHLauncher)
+# TODO - extract_data
+class Launcher:
+    def __init__(self, scenario):
+        self.scenario = scenario
+
+    def _launch(self, threads=None, solver=None, extract_data=True):
+        raise NotImplementedError
+
+    def launch_simulation(self, threads=None, solver=None, extract_data=True):
+        _check_threads(threads)
+        _check_solver(solver)
+        self._launch(threads, solver, extract_data)
+
+
+class SSHLauncher(Launcher):
+    def _run_script(self, script, extra_args=None):
+        """Returns running process
+
+        :param str script: script to be used.
+        :param list extra_args: list of strings to be passed after scenario id.
+        :return: (*subprocess.Popen*) -- process used to run script
+        """
+        if extra_args is None:
+            extra_args = []
+
+        engine = self.scenario._scenario_info["engine"]
+        path_to_package = posixpath.join(server_setup.MODEL_DIR, engine)
+        folder = "pyreise" if engine == "REISE" else "pyreisejl"
+
+        path_to_script = posixpath.join(path_to_package, folder, "utility", script)
+        cmd_pythonpath = [f'export PYTHONPATH="{path_to_package}:$PYTHONPATH";']
+        cmd_pythoncall = [
+            "nohup",
+            "python3",
+            "-u",
+            path_to_script,
+            self.scenario.scenario_id,
+        ]
+        cmd_io_redirect = ["</dev/null >/dev/null 2>&1 &"]
+        cmd = cmd_pythonpath + cmd_pythoncall + extra_args + cmd_io_redirect
+        process = self.scenario._data_access.execute_command_async(cmd)
+        print("PID: %s" % process.pid)
+        return process
+
+    def _launch(self, threads=None, solver=None, extract_data=True):
+        """Launch simulation on server, via ssh.
+
+        :param int/None threads: the number of threads to be used. This defaults to None,
+            where None means auto.
+        :param str solver: the solver used for optimization. This defaults to
+            None, which translates to gurobi
+        :param bool extract_data: whether the results of the simulation engine should
+            automatically extracted after the simulation has run. This defaults to True.
+        :raises TypeError: if extract_data is not a boolean
+        :return: (*subprocess.Popen*) -- new process used to launch simulation.
+        """
+        extra_args = []
+
+        if threads:
+            # Use the -t flag as defined in call.py in REISE.jl
+            extra_args.append("--threads " + str(threads))
+
+        if solver:
+            extra_args.append("--solver " + solver)
+
+        if not isinstance(extract_data, bool):
+            raise TypeError("extract_data must be a boolean: 'True' or 'False'")
+        if extract_data:
+            extra_args.append("--extract-data")
+
+        return self._run_script("call.py", extra_args=extra_args)
+
+
+class HttpLauncher(Launcher):
+    def _launch(self, threads=None, solver=None, extract_data=True):
+        """Launches simulation in container via http call
+
+        :param int/None threads: the number of threads to be used. This defaults to None,
+            where None means auto.
+        :param str solver: the solver used for optimization. This defaults to
+            None, which translates to gurobi
+        :param bool extract_data: always True
+        :return: (*requests.Response*) -- the http response object
+        """
+        scenario_id = self.scenario.scenario_id
+        url = f"http://{server_setup.SERVER_ADDRESS}:5000/launch/{scenario_id}"
+        resp = requests.post(url, params={"threads": threads, "solver": solver})
+        if resp.status_code != 200:
+            print(
+                f"Failed to launch simulation: status={resp.status_code}. See response for details"
+            )
+        return resp
+
+
+class NativeLauncher(Launcher):
+    def _launch(self, threads=None, solver=None, extract_data=True):
+        """Launches simulation by importing from REISE.jl
+
+        :param int/None threads: the number of threads to be used. This defaults to None,
+            where None means auto.
+        :param str solver: the solver used for optimization. This defaults to
+            None, which translates to gurobi
+        :param bool extract_data: always True
+        :return: (*dict*) -- json response
+        """
+        pass

--- a/powersimdata/data_access/launcher.py
+++ b/powersimdata/data_access/launcher.py
@@ -36,6 +36,16 @@ class Launcher:
         self.scenario = scenario
 
     def _launch(self, threads=None, solver=None, extract_data=True):
+        """Launches simulation on target environment
+
+        :param int/None threads: the number of threads to be used. This defaults to None,
+            where None means auto.
+        :param str solver: the solver used for optimization. This defaults to
+            None, which translates to gurobi
+        :param bool extract_data: whether the results of the simulation engine should
+            automatically extracted after the simulation has run. This defaults to True.
+        :raises NotImplementedError: always - this must be implemented in a subclass
+        """
         raise NotImplementedError
 
     def extract_simulation_output(self):
@@ -43,6 +53,18 @@ class Launcher:
         pass
 
     def launch_simulation(self, threads=None, solver=None, extract_data=True):
+        """Launches simulation on target environment
+
+        :param int/None threads: the number of threads to be used. This defaults to None,
+            where None means auto.
+        :param str solver: the solver used for optimization. This defaults to
+            None, which translates to gurobi
+        :param bool extract_data: whether the results of the simulation engine should
+            automatically extracted after the simulation has run. This defaults to True.
+        :return: (*subprocess.Popen*) or (*requests.Response*) - either the
+            process (if using ssh to server) or http response (if run in container)
+            or (*dict*) (if run locally)
+        """
         _check_threads(threads)
         _check_solver(solver)
         return self._launch(threads, solver, extract_data)
@@ -99,7 +121,7 @@ class SSHLauncher(Launcher):
             extra_args.append("--solver " + solver)
 
         if not isinstance(extract_data, bool):
-            raise TypeError("extract_data must be a boolean: 'True' or 'False'")
+            raise TypeError("extract_data must be a bool")
         if extract_data:
             extra_args.append("--extract-data")
 

--- a/powersimdata/data_access/scenario_list.py
+++ b/powersimdata/data_access/scenario_list.py
@@ -64,7 +64,7 @@ class ScenarioListManager(CsvStore):
 
     @verify_hash
     def add_entry(self, scenario_info):
-        """Adds scenario to the scenario list file on server.
+        """Adds scenario to the scenario list file.
 
         :param collections.OrderedDict scenario_info: entry to add to scenario list.
         :return: (*pandas.DataFrame*) -- the updated data frame
@@ -78,7 +78,7 @@ class ScenarioListManager(CsvStore):
         table = table.append(entry)
         table.set_index("id", inplace=True)
 
-        print("--> Adding entry in %s on server" % self._FILE_NAME)
+        print("--> Adding entry in %s" % self._FILE_NAME)
         return table
 
     @verify_hash
@@ -91,5 +91,5 @@ class ScenarioListManager(CsvStore):
         table = self.get_scenario_table()
         table.drop(int(scenario_id), inplace=True)
 
-        print("--> Deleting entry in %s on server" % self._FILE_NAME)
+        print("--> Deleting entry in %s" % self._FILE_NAME)
         return table

--- a/powersimdata/data_access/tests/test_data_access.py
+++ b/powersimdata/data_access/tests/test_data_access.py
@@ -10,11 +10,12 @@ from powersimdata.tests.mock_ssh import MockConnection
 from powersimdata.utility import server_setup
 
 CONTENT = b"content"
+backup_root = "/mnt/backup_dir"
 
 
 @pytest.fixture
 def data_access():
-    data_access = SSHDataAccess()
+    data_access = SSHDataAccess(backup_root=backup_root)
     yield data_access
     data_access.close()
 
@@ -68,7 +69,6 @@ def _check_content(filepath):
 
 
 root_dir = server_setup.DATA_ROOT_DIR.rstrip("/")
-backup_root = server_setup.BACKUP_DATA_ROOT_DIR
 
 
 def test_base_dir(data_access):

--- a/powersimdata/scenario/analyze.py
+++ b/powersimdata/scenario/analyze.py
@@ -61,7 +61,9 @@ class Analyze(State):
     def _set_allowed_state(self):
         """Sets allowed state."""
         if self._scenario_status == "extracted":
-            self.allowed = ["delete", "move"]
+            self.allowed = ["delete"]
+            if self._data_access.backup_root is not None:
+                self.allowed.append("move")
 
     def _set_ct_and_grid(self):
         """Sets change table and grid."""

--- a/powersimdata/scenario/analyze.py
+++ b/powersimdata/scenario/analyze.py
@@ -39,17 +39,16 @@ class Analyze(State):
         "get_storage_pg",
         "get_wind",
         "print_infeasibilities",
-        "print_scenario_info",
     }
 
     def __init__(self, scenario):
         """Constructor."""
-        self._scenario_info = scenario.info
-        self._scenario_status = scenario.status
         super().__init__(scenario)
 
         self.data_loc = "disk" if scenario.status == "moved" else None
+        self.refresh(scenario)
 
+    def refresh(self, scenario):
         print(
             "SCENARIO: %s | %s\n"
             % (self._scenario_info["plan"], self._scenario_info["name"])
@@ -321,3 +320,8 @@ class Analyze(State):
         """
         profile = TransformProfile(self._scenario_info, self.get_grid(), self.get_ct())
         return profile.get_profile("wind")
+
+    def _leave(self):
+        """Cleans when leaving state."""
+        del self.grid
+        del self.ct

--- a/powersimdata/scenario/create.py
+++ b/powersimdata/scenario/create.py
@@ -174,6 +174,7 @@ class Create(State):
         self._scenario_info["interconnect"] = self.builder.interconnect
 
     def _leave(self):
+        """Cleans when leaving state."""
         del self.builder
 
 

--- a/powersimdata/scenario/create.py
+++ b/powersimdata/scenario/create.py
@@ -27,7 +27,6 @@ class Create(State):
     default_exported_methods = (
         "create_scenario",
         "get_bus_demand",
-        "print_scenario_info",
         "set_builder",
         "set_grid",
     )
@@ -37,8 +36,6 @@ class Create(State):
         self.builder = None
         self.grid = None
         self.ct = None
-        self._scenario_status = None
-        self._scenario_info = scenario.info
         self.exported_methods = set(self.default_exported_methods)
         super().__init__(scenario)
 
@@ -175,6 +172,9 @@ class Create(State):
 
         self._scenario_info["grid_model"] = self.builder.grid_model
         self._scenario_info["interconnect"] = self.builder.interconnect
+
+    def _leave(self):
+        del self.builder
 
 
 class _Builder(object):

--- a/powersimdata/scenario/delete.py
+++ b/powersimdata/scenario/delete.py
@@ -10,7 +10,6 @@ class Delete(State):
     allowed = []
     exported_methods = {
         "delete_scenario",
-        "print_scenario_info",
     }
 
     def print_scenario_info(self):

--- a/powersimdata/scenario/execute.py
+++ b/powersimdata/scenario/execute.py
@@ -167,9 +167,8 @@ class Execute(State):
             None, which translates to gurobi
         :param bool extract_data: whether the results of the simulation engine should
             automatically extracted after the simulation has run. This defaults to True.
-        :return: (*subprocess.Popen*) or (*requests.Response*) - either the
-            process (if using ssh to server) or http response (if run in container)
-            or (*dict*) (if run locally)
+        :return: (*subprocess.Popen*) or (*dict*) - the process, if using ssh to server,
+            otherwise a dict containing status information.
         """
         self._check_if_ready()
 
@@ -180,7 +179,9 @@ class Execute(State):
     def check_progress(self):
         """Get the status of an ongoing simulation, if possible
 
-        :return: (*dict*) -- progress information, or None
+        :return: (*dict*) -- either None if using ssh, or a dict which contains
+            "output", "errors", "scenario_id", and "status" keys which map to
+            stdout, stderr, and the respective scenario attributes
         """
         return self._launcher.check_progress()
 

--- a/powersimdata/scenario/execute.py
+++ b/powersimdata/scenario/execute.py
@@ -1,6 +1,5 @@
 import copy
 import os
-import posixpath
 
 from powersimdata.data_access.context import Context
 from powersimdata.input.case_mat import export_case_mat

--- a/powersimdata/scenario/execute.py
+++ b/powersimdata/scenario/execute.py
@@ -27,17 +27,20 @@ class Execute(State):
         "get_grid",
         "launch_simulation",
         "prepare_simulation_input",
-        "print_scenario_info",
         "print_scenario_status",
         "scenario_id",
     }
 
     def __init__(self, scenario):
         """Constructor."""
-        self._scenario_info = scenario.info
-        self._scenario_status = scenario.status
         super().__init__(scenario)
+        self.refresh(scenario)
 
+    @property
+    def scenario_id(self):
+        return self._scenario_info["id"]
+
+    def refresh(self, scenario):
         print(
             "SCENARIO: %s | %s\n"
             % (self._scenario_info["plan"], self._scenario_info["name"])
@@ -47,10 +50,6 @@ class Execute(State):
 
         self._set_ct_and_grid()
         self._launcher = Context.get_launcher(scenario)
-
-    @property
-    def scenario_id(self):
-        return self._scenario_info["id"]
 
     def _set_ct_and_grid(self):
         """Sets change table and grid."""
@@ -129,7 +128,9 @@ class Execute(State):
 
             si.prepare_mpc_file()
 
-            self._execute_list_manager.set_status(self.scenario_id, "prepared")
+            prepared = "prepared"
+            self._execute_list_manager.set_status(self.scenario_id, prepared)
+            self._scenario_status = prepared
         else:
             print("---------------------------")
             print("SCENARIO CANNOT BE PREPARED")

--- a/powersimdata/scenario/execute.py
+++ b/powersimdata/scenario/execute.py
@@ -149,15 +149,15 @@ class Execute(State):
                 f"Status must be one of {valid_status}, but got status={self._scenario_status}"
             )
 
-    def launch_simulation(self, threads=None, extract_data=True, solver=None):
+    def launch_simulation(self, threads=None, solver=None, extract_data=True):
         """Launches simulation on target environment (server or container)
 
         :param int/None threads: the number of threads to be used. This defaults to None,
             where None means auto.
-        :param bool extract_data: whether the results of the simulation engine should
-            automatically extracted after the simulation has run. This defaults to True.
         :param str solver: the solver used for optimization. This defaults to
             None, which translates to gurobi
+        :param bool extract_data: whether the results of the simulation engine should
+            automatically extracted after the simulation has run. This defaults to True.
         :return: (*subprocess.Popen*) or (*requests.Response*) - either the
             process (if using ssh to server) or http response (if run in container)
         """
@@ -165,7 +165,7 @@ class Execute(State):
 
         mode = get_deployment_mode()
         print(f"--> Launching simulation on {mode.lower()}")
-        self._launcher.launch_simulation(threads, extract_data, solver)
+        return self._launcher.launch_simulation(threads, solver, extract_data)
 
     def check_progress(self):
         """Get the status of an ongoing simulation, if possible

--- a/powersimdata/scenario/execute.py
+++ b/powersimdata/scenario/execute.py
@@ -11,7 +11,7 @@ from powersimdata.input.transform_grid import TransformGrid
 from powersimdata.input.transform_profile import TransformProfile
 from powersimdata.scenario.state import State
 from powersimdata.utility import server_setup
-from powersimdata.utility.server_setup import DeploymentMode, get_deployment_mode
+from powersimdata.utility.config import DeploymentMode, get_deployment_mode
 
 
 class Execute(State):

--- a/powersimdata/scenario/execute.py
+++ b/powersimdata/scenario/execute.py
@@ -38,9 +38,17 @@ class Execute(State):
 
     @property
     def scenario_id(self):
+        """Get the current scenario id
+
+        :return: (*str*) -- scenario id
+        """
         return self._scenario_info["id"]
 
     def refresh(self, scenario):
+        """Called during state changes to ensure instance is properly initialized
+
+        :param powrsimdata.scenario.scenario.Scenario scenario: scenario instance
+        """
         print(
             "SCENARIO: %s | %s\n"
             % (self._scenario_info["plan"], self._scenario_info["name"])

--- a/powersimdata/scenario/execute.py
+++ b/powersimdata/scenario/execute.py
@@ -151,7 +151,7 @@ class Execute(State):
             )
 
     def launch_simulation(self, threads=None, solver=None, extract_data=True):
-        """Launches simulation on target environment (server or container)
+        """Launches simulation on target environment
 
         :param int/None threads: the number of threads to be used. This defaults to None,
             where None means auto.
@@ -161,6 +161,7 @@ class Execute(State):
             automatically extracted after the simulation has run. This defaults to True.
         :return: (*subprocess.Popen*) or (*requests.Response*) - either the
             process (if using ssh to server) or http response (if run in container)
+            or (*dict*) (if run locally)
         """
         self._check_if_ready()
 

--- a/powersimdata/scenario/move.py
+++ b/powersimdata/scenario/move.py
@@ -11,7 +11,6 @@ class Move(State):
     allowed = []
     exported_methods = {
         "move_scenario",
-        "print_scenario_info",
     }
 
     def print_scenario_info(self):

--- a/powersimdata/scenario/scenario.py
+++ b/powersimdata/scenario/scenario.py
@@ -57,6 +57,7 @@ class Scenario(object):
 
         if not descriptor:
             self.info = OrderedDict(self._default_info)
+            self.status = None
             self.state = Create(self)
         else:
             self._set_info(descriptor)
@@ -68,7 +69,7 @@ class Scenario(object):
                 elif state == "analyze":
                     self.state = Analyze(self)
             except AttributeError:
-                return
+                pass
 
     def __getattr__(self, name):
         if name in self.state.exported_methods:

--- a/powersimdata/scenario/state.py
+++ b/powersimdata/scenario/state.py
@@ -1,7 +1,3 @@
-from powersimdata.data_access.execute_list import ExecuteListManager
-from powersimdata.data_access.scenario_list import ScenarioListManager
-
-
 class State(object):
     """Defines an interface for encapsulating the behavior associated with a
         particular state of the Scenario object.
@@ -18,9 +14,15 @@ class State(object):
         if type(self) == State:
             raise TypeError("Only subclasses of 'State' can be instantiated directly")
 
+        self._scenario = scenario
+        self._scenario_info = scenario.info
+        self._scenario_status = scenario.status
         self._data_access = scenario.data_access
-        self._scenario_list_manager = ScenarioListManager(self._data_access)
-        self._execute_list_manager = ExecuteListManager(self._data_access)
+        self._scenario_list_manager = scenario._scenario_list_manager
+        self._execute_list_manager = scenario._execute_list_manager
+
+    def refresh(self, scenario):
+        pass
 
     def switch(self, state):
         """Switches state.
@@ -33,6 +35,7 @@ class State(object):
             self._leave()
             self.__class__ = state
             self._enter(state)
+            self.refresh(self._scenario)
         else:
             raise Exception(
                 "State switching: %s --> %s not permitted" % (self, state.name)
@@ -47,11 +50,7 @@ class State(object):
 
     def _leave(self):
         """Cleans when leaving state."""
-        if self.name == "create":
-            del self.builder
-        elif self.name == "analyze":
-            del self.grid
-            del self.ct
+        pass
 
     def _enter(self, state):
         """Initializes when entering state."""

--- a/powersimdata/scenario/state.py
+++ b/powersimdata/scenario/state.py
@@ -1,6 +1,6 @@
 class State(object):
     """Defines an interface for encapsulating the behavior associated with a
-        particular state of the Scenario object.
+    particular state of the Scenario object.
 
     :param powrsimdata.scenario.scenario.Scenario scenario: scenario instance
     :raise TypeError: if not instantiated through a derived class
@@ -22,6 +22,10 @@ class State(object):
         self._execute_list_manager = scenario._execute_list_manager
 
     def refresh(self, scenario):
+        """Called during state changes to ensure instance is properly initialized
+
+        :param powrsimdata.scenario.scenario.Scenario scenario: scenario instance
+        """
         pass
 
     def switch(self, state):

--- a/powersimdata/utility/config.py
+++ b/powersimdata/utility/config.py
@@ -1,9 +1,17 @@
+import configparser
 import os
 import shutil
 from dataclasses import dataclass
 from pathlib import Path
 
 from powersimdata.utility import templates
+
+INI_FILE = "config.ini"
+if Path(INI_FILE).exists():
+    conf = configparser.ConfigParser()
+    conf.read(INI_FILE)
+    for k, v in conf["PowerSimData"].items():
+        os.environ[k.upper()] = v
 
 
 @dataclass(frozen=True)

--- a/powersimdata/utility/config.py
+++ b/powersimdata/utility/config.py
@@ -8,13 +8,13 @@ class Config:
     SERVER_ADDRESS = None
     SERVER_SSH_PORT = None
     BACKUP_DATA_ROOT_DIR = None
+    MODEL_DIR = None
     ENGINE_DIR = None
     DATA_ROOT_DIR = "/mnt/bes/pcm"
     EXECUTE_DIR = "tmp"
     INPUT_DIR = ("data", "input")
     OUTPUT_DIR = ("data", "output")
     LOCAL_DIR = os.path.join(Path.home(), "ScenarioData", "")
-    MODEL_DIR = "/home/bes/pcm"
 
 
 @dataclass(frozen=True)
@@ -22,6 +22,7 @@ class ServerConfig(Config):
     SERVER_ADDRESS = os.getenv("BE_SERVER_ADDRESS", "becompute01.gatesventures.com")
     SERVER_SSH_PORT = os.getenv("BE_SERVER_SSH_PORT", 22)
     BACKUP_DATA_ROOT_DIR = "/mnt/RE-Storage/v2"
+    MODEL_DIR = "/home/bes/pcm"
 
 
 @dataclass(frozen=True)
@@ -44,7 +45,6 @@ class DeploymentMode:
 
 
 def get_deployment_mode():
-    # TODO: consider auto detection
     mode = os.getenv("DEPLOYMENT_MODE")
     if mode is None:
         return DeploymentMode.Server

--- a/powersimdata/utility/config.py
+++ b/powersimdata/utility/config.py
@@ -21,7 +21,6 @@ class Config:
 class ServerConfig(Config):
     SERVER_ADDRESS = os.getenv("BE_SERVER_ADDRESS", "becompute01.gatesventures.com")
     SERVER_SSH_PORT = os.getenv("BE_SERVER_SSH_PORT", 22)
-    BACKUP_DATA_ROOT_DIR = "/mnt/RE-Storage/v2"
     MODEL_DIR = "/home/bes/pcm"
 
 

--- a/powersimdata/utility/config.py
+++ b/powersimdata/utility/config.py
@@ -1,0 +1,54 @@
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class Config:
+    DATA_ROOT_DIR = "/mnt/bes/pcm"
+    EXECUTE_DIR = "tmp"
+    INPUT_DIR = ("data", "input")
+    OUTPUT_DIR = ("data", "output")
+    LOCAL_DIR = os.path.join(Path.home(), "ScenarioData", "")
+    MODEL_DIR = "/home/bes/pcm"
+
+
+@dataclass(frozen=True)
+class ServerConfig(Config):
+    SERVER_ADDRESS = os.getenv("BE_SERVER_ADDRESS", "becompute01.gatesventures.com")
+    SERVER_SSH_PORT = os.getenv("BE_SERVER_SSH_PORT", 22)
+    BACKUP_DATA_ROOT_DIR = "/mnt/RE-Storage/v2"
+
+
+@dataclass(frozen=True)
+class ContainerConfig(Config):
+    SERVER_ADDRESS = os.getenv("BE_SERVER_ADDRESS", "reisejl")
+
+
+@dataclass(frozen=True)
+class LocalConfig(Config):
+    DATA_ROOT_DIR = Config.LOCAL_DIR
+
+
+class DeploymentMode:
+    Server = "SERVER"
+    Container = "CONTAINER"
+    Local = "LOCAL"
+
+    CONFIG_MAP = {Server: ServerConfig, Container: ContainerConfig, Local: LocalConfig}
+
+
+def get_deployment_mode():
+    # TODO: consider auto detection
+    mode = os.getenv("DEPLOYMENT_MODE")
+    if mode is None:
+        return DeploymentMode.Server
+    if mode == "1" or mode.lower() == "container":
+        return DeploymentMode.Container
+    if mode == "2" or mode.lower() == "local":
+        return DeploymentMode.Local
+
+
+def get_config():
+    mode = get_deployment_mode()
+    return DeploymentMode.CONFIG_MAP[mode]()

--- a/powersimdata/utility/config.py
+++ b/powersimdata/utility/config.py
@@ -5,6 +5,10 @@ from pathlib import Path
 
 @dataclass(frozen=True)
 class Config:
+    SERVER_ADDRESS = None
+    SERVER_SSH_PORT = None
+    BACKUP_DATA_ROOT_DIR = None
+    ENGINE_DIR = None
     DATA_ROOT_DIR = "/mnt/bes/pcm"
     EXECUTE_DIR = "tmp"
     INPUT_DIR = ("data", "input")
@@ -28,6 +32,7 @@ class ContainerConfig(Config):
 @dataclass(frozen=True)
 class LocalConfig(Config):
     DATA_ROOT_DIR = Config.LOCAL_DIR
+    ENGINE_DIR = os.getenv("ENGINE_DIR")
 
 
 class DeploymentMode:

--- a/powersimdata/utility/server_setup.py
+++ b/powersimdata/utility/server_setup.py
@@ -12,6 +12,7 @@ INPUT_DIR = config.INPUT_DIR
 OUTPUT_DIR = config.OUTPUT_DIR
 LOCAL_DIR = config.LOCAL_DIR
 MODEL_DIR = config.MODEL_DIR
+ENGINE_DIR = config.ENGINE_DIR
 
 
 def get_server_user():

--- a/powersimdata/utility/server_setup.py
+++ b/powersimdata/utility/server_setup.py
@@ -1,27 +1,17 @@
 import os
-from pathlib import Path
 
-SERVER_ADDRESS = os.getenv("BE_SERVER_ADDRESS", "becompute01.gatesventures.com")
-SERVER_SSH_PORT = os.getenv("BE_SERVER_SSH_PORT", 22)
-BACKUP_DATA_ROOT_DIR = "/mnt/RE-Storage/v2"
-DATA_ROOT_DIR = "/mnt/bes/pcm"
-EXECUTE_DIR = "tmp"
-INPUT_DIR = ("data", "input")
-OUTPUT_DIR = ("data", "output")
-LOCAL_DIR = os.path.join(Path.home(), "ScenarioData", "")
-MODEL_DIR = "/home/bes/pcm"
+from powersimdata.utility.config import get_config
 
-
-class DeploymentMode:
-    Server = "SERVER"
-    Container = "CONTAINER"
-
-
-def get_deployment_mode():
-    mode = os.getenv("DEPLOYMENT_MODE")
-    if mode is None:
-        return DeploymentMode.Server
-    return DeploymentMode.Container
+config = get_config()
+SERVER_ADDRESS = config.SERVER_ADDRESS
+SERVER_SSH_PORT = config.SERVER_SSH_PORT
+BACKUP_DATA_ROOT_DIR = config.BACKUP_DATA_ROOT_DIR
+DATA_ROOT_DIR = config.DATA_ROOT_DIR
+EXECUTE_DIR = config.EXECUTE_DIR
+INPUT_DIR = config.INPUT_DIR
+OUTPUT_DIR = config.OUTPUT_DIR
+LOCAL_DIR = config.LOCAL_DIR
+MODEL_DIR = config.MODEL_DIR
 
 
 def get_server_user():


### PR DESCRIPTION
### Purpose
Add the remaining code changes so that the framework can be used locally, outside docker, on any os, using a local REISE.jl installation.

### What the code is doing
* Factor out `launch_scenario` into subclasses for each use case, and similarly for extracting output.
* Add `State.refresh` method so state changes have up to date information without re-initializing the instance
* Split up configuration into classes, making it easy to override values specific to a given environment
* various cleanup


### Testing
* Ran a simulation end to end on windows. Ran into issues due to using julia 1.6 but upgrading PyCall and CSV packages fixed the issues. 
* Ran simulation on MacOS using julia 1.5 (there are issues with 1.6)
* Ran simulation in plug to verify no regressions

### Usage Example/Visuals
The PR for documentation is https://github.com/Breakthrough-Energy/docs/pull/62. For testing locally, I changed the name of the data directory to `ScenarioDataLocal` (in both PowerSimData and REISE.jl) so it won't collide with the existing data from the server. 

### Time estimate
40 mins
