### PR TITLE
fix: create copy of bus table before modifying within get_bus_demand function

### DIFF
--- a/powersimdata/input/input_data.py
+++ b/powersimdata/input/input_data.py
@@ -149,7 +149,7 @@ def get_bus_demand(scenario_info, grid):
     :param powersimdata.input.grid.Grid grid: grid to construct bus demand for.
     :return: (*pandas.DataFrame*) -- data frame of demand.
     """
-    bus = grid.bus
+    bus = grid.bus.copy()
     demand = InputData().get_data(scenario_info, "demand")[bus.zone_id.unique()]
     bus["zone_Pd"] = bus.groupby("zone_id")["Pd"].transform("sum")
     bus["zone_share"] = bus["Pd"] / bus["zone_Pd"]


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
When performing the `get_bus_demand` function, avoid modifying the bus table of the Grid that is passed as input. This is not a problem when we call `scenario.get_bus_demand()` on a Scenario in Analyze state, since that method passes a fresh copy of the grid so the grid associated with the scenario doesn't change, but it's still an unintuitive behavior in case anyone uses the lower-level function.

### Testing
Before:
```python
>>> from powersimdata import Scenario
>>> from powersimdata.input.input_data import get_bus_demand
>>> scenario = Scenario(599)
>>> grid = scenario.get_grid()
>>> len(grid.bus.columns)
19
>>> get_bus_demand(scenario.info, grid)
>>> len(grid.bus.columns)
21
```

After:
```python
>>> from powersimdata import Scenario
>>> from powersimdata.input.input_data import get_bus_demand
>>> scenario = Scenario(599)
>>> grid = scenario.get_grid()
>>> len(grid.bus.columns)
19
>>> get_bus_demand(scenario.info, grid)
>>> len(grid.bus.columns)
19
```

### Time estimate
2 minutes.
