### PR TITLE
Add function to export profiles

### DIFF
--- a/powersimdata/input/abstract_grid.py
+++ b/powersimdata/input/abstract_grid.py
@@ -1,7 +1,7 @@
 import pandas as pd
 
 
-class AbstractGrid(object):
+class AbstractGrid:
     """Grid Builder."""
 
     def __init__(self):

--- a/powersimdata/input/change_table.py
+++ b/powersimdata/input/change_table.py
@@ -37,7 +37,7 @@ def ordinal(n):
     return str(n + 1) + ord_dict.get((n + 1) if (n + 1) < 20 else (n + 1) % 10, "th")
 
 
-class ChangeTable(object):
+class ChangeTable:
     """Create change table for changes that need to be applied to the original
     grid as well as to the original demand, hydro, solar and wind profiles.
     A pickle file enclosing the change table in form of a dictionary can be

--- a/powersimdata/input/grid.py
+++ b/powersimdata/input/grid.py
@@ -11,7 +11,7 @@ from powersimdata.utility.helpers import MemoryCache, cache_key
 _cache = MemoryCache()
 
 
-class Grid(object):
+class Grid:
     """Grid
 
     :param str/list interconnect: geographical region covered. Either *'USA'*, one of

--- a/powersimdata/input/input_data.py
+++ b/powersimdata/input/input_data.py
@@ -57,7 +57,7 @@ def _check_field(field_name):
         raise ValueError("Only %s data can be loaded" % " | ".join(possible))
 
 
-class InputData(object):
+class InputData:
     """Load input data.
 
     :param str data_loc: data location.

--- a/powersimdata/input/transform_grid.py
+++ b/powersimdata/input/transform_grid.py
@@ -6,7 +6,7 @@ import pandas as pd
 from powersimdata.utility.distance import haversine
 
 
-class TransformGrid(object):
+class TransformGrid:
     """Transforms grid according to operations listed in change table."""
 
     def __init__(self, grid, ct):

--- a/powersimdata/input/transform_profile.py
+++ b/powersimdata/input/transform_profile.py
@@ -3,6 +3,22 @@ import copy
 from powersimdata.input.input_data import InputData
 
 
+def export_scaled_profile(kind, scenario_info, grid, ct, filepath):
+    """Apply transformation to the given kind of profile and save the result locally.
+
+    :param dict scenario_info: a dict containing the profile version, with
+        key in the form base_{kind}
+    :param powersimdata.input.grid.Grid grid: a Grid object previously
+        transformed.
+    :param dict ct: change table.
+    :param str filepath: path to save the result, including the filename
+    """
+    tp = TransformProfile(scenario_info, grid, ct)
+    profile = tp.get_profile(kind)
+    print(f"Writing scaled {kind} profile to {filepath} on local machine")
+    profile.to_csv(filepath)
+
+
 class TransformProfile(object):
     """Transform profile according to operations listed in change table."""
 

--- a/powersimdata/input/transform_profile.py
+++ b/powersimdata/input/transform_profile.py
@@ -19,7 +19,7 @@ def export_scaled_profile(kind, scenario_info, grid, ct, filepath):
     profile.to_csv(filepath)
 
 
-class TransformProfile(object):
+class TransformProfile:
     """Transform profile according to operations listed in change table."""
 
     def __init__(self, scenario_info, grid, ct):

--- a/powersimdata/network/csv_reader.py
+++ b/powersimdata/network/csv_reader.py
@@ -1,7 +1,7 @@
 from powersimdata.input.helpers import csv_to_data_frame
 
 
-class CSVReader(object):
+class CSVReader:
     """MPC files reader.
 
     :param str data_loc: path to data.

--- a/powersimdata/output/output_data.py
+++ b/powersimdata/output/output_data.py
@@ -10,7 +10,7 @@ from powersimdata.input.input_data import get_bus_demand
 from powersimdata.utility import server_setup
 
 
-class OutputData(object):
+class OutputData:
     """Load output data.
 
     :param str data_loc: data location.

--- a/powersimdata/scenario/create.py
+++ b/powersimdata/scenario/create.py
@@ -178,7 +178,7 @@ class Create(State):
         del self.builder
 
 
-class _Builder(object):
+class _Builder:
     """Scenario Builder.
 
     :param str grid_model: grid model.

--- a/powersimdata/scenario/execute.py
+++ b/powersimdata/scenario/execute.py
@@ -202,7 +202,7 @@ class Execute(State):
             return
 
 
-class SimulationInput(object):
+class SimulationInput:
     """Prepares scenario for execution.
 
     :param powersimdata.data_access.data_access.DataAccess data_access:

--- a/powersimdata/scenario/execute.py
+++ b/powersimdata/scenario/execute.py
@@ -6,7 +6,7 @@ from powersimdata.input.case_mat import export_case_mat
 from powersimdata.input.grid import Grid
 from powersimdata.input.input_data import InputData
 from powersimdata.input.transform_grid import TransformGrid
-from powersimdata.input.transform_profile import TransformProfile
+from powersimdata.input.transform_profile import export_scaled_profile
 from powersimdata.scenario.state import State
 from powersimdata.utility import server_setup
 from powersimdata.utility.config import get_deployment_mode
@@ -254,13 +254,11 @@ class SimulationInput(object):
         :param int/str profile_as: if given, copy profile from this scenario.
         """
         if profile_as is None:
-            tp = TransformProfile(self._scenario_info, self.grid, self.ct)
-            profile = tp.get_profile(kind)
-            print(
-                f"Writing scaled {kind} profile in {server_setup.LOCAL_DIR} on local machine"
-            )
             file_name = "%s_%s.csv" % (self.scenario_id, kind)
-            profile.to_csv(os.path.join(server_setup.LOCAL_DIR, file_name))
+            filepath = os.path.join(server_setup.LOCAL_DIR, file_name)
+            export_scaled_profile(
+                kind, self._scenario_info, self.grid, self.ct, filepath
+            )
 
             self._data_access.move_to(
                 file_name, self.REL_TMP_DIR, change_name_to=f"{kind}.csv"

--- a/powersimdata/scenario/move.py
+++ b/powersimdata/scenario/move.py
@@ -52,7 +52,7 @@ class Move(State):
         self._data_access.close()
 
 
-class BackUpDisk(object):
+class BackUpDisk:
     """Back up scenario data to backup disk mounted on server.
 
     :param powersimdata.data_access.data_access.DataAccess data_access:

--- a/powersimdata/scenario/scenario.py
+++ b/powersimdata/scenario/scenario.py
@@ -12,7 +12,7 @@ from powersimdata.scenario.execute import Execute
 pd.set_option("display.max_colwidth", None)
 
 
-class Scenario(object):
+class Scenario:
     """Handles scenario.
 
     :param int/str descriptor: scenario name or index. If None, default to a Scenario

--- a/powersimdata/scenario/state.py
+++ b/powersimdata/scenario/state.py
@@ -1,4 +1,4 @@
-class State(object):
+class State:
     """Defines an interface for encapsulating the behavior associated with a
     particular state of the Scenario object.
 

--- a/powersimdata/tests/mock_grid.py
+++ b/powersimdata/tests/mock_grid.py
@@ -170,7 +170,7 @@ storage_columns = {
 }
 
 
-class MockGrid(object):
+class MockGrid:
     def __init__(self, grid_attrs=None, model="usa_tamu"):
         """Constructor.
 

--- a/powersimdata/utility/helpers.py
+++ b/powersimdata/utility/helpers.py
@@ -111,7 +111,7 @@ class CacheKeyBuilder:
         raise ValueError(f"unsupported type for cache key = {type(arg)}")
 
 
-class PrintManager(object):
+class PrintManager:
     """Manages print messages."""
 
     def __init__(self):


### PR DESCRIPTION
### Purpose
Address #482 

### What the code is doing
Define `export_scaled_profile` function which can be called given a profile kind/version, grid, change table, and destination path. We now call this function from `SimulationInput.prepare_profile`, but it could be called independent of a scenario.

### Testing
Prepared a scenario in a container with a change table and it worked as expected.

### Time estimate
10 min
