### PR TITLE
Rename module and move function

### DIFF
--- a/powersimdata/input/export_data.py
+++ b/powersimdata/input/export_data.py
@@ -3,6 +3,8 @@ import copy
 import numpy as np
 from scipy.io import savemat
 
+from powersimdata.input.transform_profile import TransformProfile
+
 
 def export_case_mat(grid, filepath, storage_filepath=None):
     """Export a grid to a format suitable for loading into simulation engine.
@@ -120,3 +122,19 @@ def export_case_mat(grid, filepath, storage_filepath=None):
         savemat(storage_filepath, mpc_storage, appendmat=False)
 
     savemat(filepath, mpc, appendmat=False)
+
+
+def export_transformed_profile(kind, scenario_info, grid, ct, filepath):
+    """Apply transformation to the given kind of profile and save the result locally.
+
+    :param dict scenario_info: a dict containing the profile version, with
+        key in the form base_{kind}
+    :param powersimdata.input.grid.Grid grid: a Grid object previously
+        transformed.
+    :param dict ct: change table.
+    :param str filepath: path to save the result, including the filename
+    """
+    tp = TransformProfile(scenario_info, grid, ct)
+    profile = tp.get_profile(kind)
+    print(f"Writing scaled {kind} profile to {filepath} on local machine")
+    profile.to_csv(filepath)

--- a/powersimdata/input/transform_profile.py
+++ b/powersimdata/input/transform_profile.py
@@ -3,22 +3,6 @@ import copy
 from powersimdata.input.input_data import InputData
 
 
-def export_scaled_profile(kind, scenario_info, grid, ct, filepath):
-    """Apply transformation to the given kind of profile and save the result locally.
-
-    :param dict scenario_info: a dict containing the profile version, with
-        key in the form base_{kind}
-    :param powersimdata.input.grid.Grid grid: a Grid object previously
-        transformed.
-    :param dict ct: change table.
-    :param str filepath: path to save the result, including the filename
-    """
-    tp = TransformProfile(scenario_info, grid, ct)
-    profile = tp.get_profile(kind)
-    print(f"Writing scaled {kind} profile to {filepath} on local machine")
-    profile.to_csv(filepath)
-
-
 class TransformProfile:
     """Transform profile according to operations listed in change table."""
 

--- a/powersimdata/scenario/execute.py
+++ b/powersimdata/scenario/execute.py
@@ -2,11 +2,10 @@ import copy
 import os
 
 from powersimdata.data_access.context import Context
-from powersimdata.input.case_mat import export_case_mat
+from powersimdata.input.export_data import export_case_mat, export_transformed_profile
 from powersimdata.input.grid import Grid
 from powersimdata.input.input_data import InputData
 from powersimdata.input.transform_grid import TransformGrid
-from powersimdata.input.transform_profile import export_scaled_profile
 from powersimdata.scenario.state import State
 from powersimdata.utility import server_setup
 from powersimdata.utility.config import get_deployment_mode
@@ -256,7 +255,7 @@ class SimulationInput:
         if profile_as is None:
             file_name = "%s_%s.csv" % (self.scenario_id, kind)
             filepath = os.path.join(server_setup.LOCAL_DIR, file_name)
-            export_scaled_profile(
+            export_transformed_profile(
                 kind, self._scenario_info, self.grid, self.ct, filepath
             )
 


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
Gather functions that export the grid and the profiles into a single module

### What the code is doing
* The `powersimdata/input/case_mat` module is renamed to `powersimdata/input/export_data`.
* The `export_scaled_profile` function is moved from the ` powersimdata/input/transform_profile` module to the `powersimdata/input/export_data` module
* The `export_scaled_profile` function is renamed to `export_transformed_profile` to reflect both scaling and adding operations.

### Testing
N/A

### Where to look
Check that I handled correctly the import statement

### Usage Example/Visuals
N/A

### Time estimate
5min
