### PR TITLE
Fix TypeError raised when using using default solver

### DIFF
--- a/powersimdata/data_access/launcher.py
+++ b/powersimdata/data_access/launcher.py
@@ -13,11 +13,12 @@ def _check_threads(threads):
     :raises TypeError: if threads is not an int
     :raises ValueError: if threads is not a positive value
     """
-    if threads is not None:
-        if not isinstance(threads, int):
-            raise TypeError("threads must be an int")
-        if threads < 1:
-            raise ValueError("threads must be a positive value")
+    if threads is None:
+        return
+    if not isinstance(threads, int):
+        raise TypeError("threads must be an int")
+    if threads < 1:
+        raise ValueError("threads must be a positive value")
 
 
 def _check_solver(solver):
@@ -27,10 +28,12 @@ def _check_solver(solver):
     :raises TypeError: if solver is not a str
     :raises ValueError: if invalid solver provided
     """
+    if solver is None:
+        return
     if not isinstance(solver, str):
         raise TypeError("solver must be a str")
     solvers = ("gurobi", "glpk")
-    if solver is not None and solver.lower() not in solvers:
+    if solver.lower() not in solvers:
         raise ValueError(f"Invalid solver: options are {solvers}")
 
 

--- a/powersimdata/data_access/tests/test_launcher.py
+++ b/powersimdata/data_access/tests/test_launcher.py
@@ -1,0 +1,23 @@
+import pytest
+
+from powersimdata.data_access.launcher import _check_solver, _check_threads
+
+
+def test_check_solver():
+    _check_solver(None)
+    _check_solver("gurobi")
+    _check_solver("GLPK")
+    with pytest.raises(TypeError):
+        _check_solver(123)
+    with pytest.raises(ValueError):
+        _check_solver("not-a-real-solver")
+
+
+def test_check_threads():
+    _check_threads(None)
+    _check_threads(1)
+    _check_threads(8)
+    with pytest.raises(TypeError):
+        _check_threads("4")
+    with pytest.raises(ValueError):
+        _check_threads(0)


### PR DESCRIPTION
### Purpose
If no solver is provided we should use the default which is determined in REISE.jl. I think I introduced this bug by adding the validation after having tested the code, and it was not re-tested (d'oh). 

### What the code is doing
Fix validation and add tests.

### Testing
New unit tests

### Time estimate
3 min
