### PR TITLE
refactor: set grid_model property on grid

### DIFF
--- a/powersimdata/design/generation/clean_capacity_scaling.py
+++ b/powersimdata/design/generation/clean_capacity_scaling.py
@@ -101,7 +101,7 @@ def _make_zonename2target(grid, targets):
     :raises ValueError: if a zone is not present in any target areas, or
         if a zone is present in more than one target area.
     """
-    grid_model = grid.get_grid_model()
+    grid_model = grid.grid_model
     target_zones = {
         target_name: area_to_loadzone(grid_model, target_name)
         if pd.isnull(targets.loc[target_name, "area_type"])

--- a/powersimdata/design/generation/cost_curves.py
+++ b/powersimdata/design/generation/cost_curves.py
@@ -228,7 +228,7 @@ def build_supply_curve(grid, num_segments, area, gen_type, area_type=None, plot=
         raise ValueError(f"{gen_type} is not a valid generation type.")
 
     # Identify the load zones that correspond to the specified area and area_type
-    returned_zones = area_to_loadzone(grid.get_grid_model(), area, area_type)
+    returned_zones = area_to_loadzone(grid.grid_model, area, area_type)
 
     # Trim the DataFrame to only be of the desired area and generation type
     supply_data = supply_data.loc[supply_data.zone_name.isin(returned_zones)]
@@ -467,7 +467,7 @@ def plot_linear_vs_quadratic_terms(
         raise ValueError(f"{gen_type} is not a valid generation type.")
 
     # Identify the load zones that correspond to the specified area and area_type
-    returned_zones = area_to_loadzone(grid.get_grid_model(), area, area_type)
+    returned_zones = area_to_loadzone(grid.grid_model, area, area_type)
 
     # Trim the DataFrame to only be of the desired area and generation type
     supply_data = supply_data.loc[supply_data.zone_name.isin(returned_zones)]
@@ -574,7 +574,7 @@ def plot_capacity_vs_price(
         raise ValueError(f"{gen_type} is not a valid generation type.")
 
     # Identify the load zones that correspond to the specified area and area_type
-    returned_zones = area_to_loadzone(grid.get_grid_model(), area, area_type)
+    returned_zones = area_to_loadzone(grid.grid_model, area, area_type)
 
     # Trim the DataFrame to only be of the desired area and generation type
     supply_data = supply_data.loc[supply_data.zone_name.isin(returned_zones)]

--- a/powersimdata/design/generation/tests/test_cost_curves.py
+++ b/powersimdata/design/generation/tests/test_cost_curves.py
@@ -140,7 +140,6 @@ grid_attrs = {"plant": mock_plant, "gencost_before": mock_gencost}
 grid = MockGrid(grid_attrs)
 grid.interconnect = "Western"
 grid.zone2id = {"Utah": 210, "Colorado": 212, "Washington": 201}
-grid.get_grid_model = lambda: "usa_tamu"
 
 
 def test_get_supply_data():

--- a/powersimdata/design/scenario_info.py
+++ b/powersimdata/design/scenario_info.py
@@ -27,7 +27,7 @@ class ScenarioInfo:
         self.pg = scenario.state.get_pg()
         self.grid = scenario.state.get_grid()
         self.demand = scenario.state.get_demand()
-        self.grid_model = self.grid.get_grid_model()
+        self.grid_model = self.grid.grid_model
         solar = scenario.state.get_solar()
         wind = scenario.state.get_wind()
         hydro = scenario.state.get_hydro()

--- a/powersimdata/design/tests/test_scenario_info.py
+++ b/powersimdata/design/tests/test_scenario_info.py
@@ -128,7 +128,6 @@ class TestScenarioInfo(unittest.TestCase):
             wind=mock_wind,
             hydro=mock_hydro,
         )
-        scenario.state.grid.get_grid_model = lambda: "usa_tamu"
         scenario.state.grid.zone2id = {"Oregon": 202, "Arizona": 209}
         self.scenario_info = ScenarioInfo(scenario)
 

--- a/powersimdata/design/tests/test_scenario_info.py
+++ b/powersimdata/design/tests/test_scenario_info.py
@@ -79,36 +79,21 @@ zone2_plant_id = [
     if mock_plant["zone_name"][i] == "Arizona"
 ]
 
-solar_plant_id = [
-    plant_id
-    for i, plant_id in enumerate(mock_plant["plant_id"])
-    if mock_plant["type"][i] == "solar"
-]
-wind_plant_id = [
-    plant_id
-    for i, plant_id in enumerate(mock_plant["plant_id"])
-    if mock_plant["type"][i] == "wind"
-]
-ng_plant_id = [
-    plant_id
-    for i, plant_id in enumerate(mock_plant["plant_id"])
-    if mock_plant["type"][i] == "ng"
-]
-coal_plant_id = [
-    plant_id
-    for i, plant_id in enumerate(mock_plant["plant_id"])
-    if mock_plant["type"][i] == "coal"
-]
-dfo_plant_id = [
-    plant_id
-    for i, plant_id in enumerate(mock_plant["plant_id"])
-    if mock_plant["type"][i] == "dfo"
-]
-hydro_plant_id = [
-    plant_id
-    for i, plant_id in enumerate(mock_plant["plant_id"])
-    if mock_plant["type"][i] == "hydro"
-]
+
+def _select_plant_id(type):
+    return [
+        plant_id
+        for i, plant_id in enumerate(mock_plant["plant_id"])
+        if mock_plant["type"][i] == type
+    ]
+
+
+solar_plant_id = _select_plant_id("solar")
+wind_plant_id = _select_plant_id("wind")
+ng_plant_id = _select_plant_id("ng")
+coal_plant_id = _select_plant_id("coal")
+dfo_plant_id = _select_plant_id("dfo")
+hydro_plant_id = _select_plant_id("hydro")
 
 mock_solar = mock_pg[solar_plant_id] * 2
 mock_wind = mock_pg[wind_plant_id] * 4

--- a/powersimdata/design/transmission/tests/test_upgrade.py
+++ b/powersimdata/design/transmission/tests/test_upgrade.py
@@ -61,7 +61,6 @@ mock_plant = {
 mock_grid = MockGrid(
     grid_attrs={"branch": mock_branch, "bus": mock_bus, "plant": mock_plant}
 )
-mock_grid.get_grid_model = lambda: "usa_tamu"
 
 
 class TestStubTopologyHelpers(unittest.TestCase):

--- a/powersimdata/design/transmission/upgrade.py
+++ b/powersimdata/design/transmission/upgrade.py
@@ -176,9 +176,8 @@ def get_branches_by_area(grid, area_names, method="either"):
 
     branch = grid.branch
     selected_branches = set()
-    grid_model = grid.grid_model
     for a in area_names:
-        load_zone_names = area_to_loadzone(grid_model, a)
+        load_zone_names = area_to_loadzone(grid.grid_model, a)
         to_bus_in_area = branch.to_zone_name.isin(load_zone_names)
         from_bus_in_area = branch.from_zone_name.isin(load_zone_names)
         if method in ("internal", "either"):

--- a/powersimdata/design/transmission/upgrade.py
+++ b/powersimdata/design/transmission/upgrade.py
@@ -176,7 +176,7 @@ def get_branches_by_area(grid, area_names, method="either"):
 
     branch = grid.branch
     selected_branches = set()
-    grid_model = grid.get_grid_model()
+    grid_model = grid.grid_model
     for a in area_names:
         load_zone_names = area_to_loadzone(grid_model, a)
         to_bus_in_area = branch.to_zone_name.isin(load_zone_names)

--- a/powersimdata/input/grid.py
+++ b/powersimdata/input/grid.py
@@ -31,13 +31,6 @@ class Grid:
         if engine not in supported_engines:
             raise ValueError(f"Engine must be one of {','.join(supported_engines)}")
 
-        try:
-            self.model_immutables = ModelImmutables(source)
-        except ValueError:
-            self.model_immutables = ModelImmutables(
-                _get_grid_model_from_scenario_list(source)
-            )
-
         key = cache_key(interconnect, source)
         cached = _cache.get(key)
         if cached is not None:
@@ -65,7 +58,10 @@ class Grid:
 
         _cache.put(key, self)
 
-    def get_grid_model(self):
+        self.grid_model = self._get_grid_model()
+        self.model_immutables = ModelImmutables(self.grid_model)
+
+    def _get_grid_model(self):
         """Get the grid model.
 
         :return: (*str*).

--- a/powersimdata/tests/mock_grid.py
+++ b/powersimdata/tests/mock_grid.py
@@ -196,6 +196,7 @@ class MockGrid:
         if len(extra_keys) > 0:
             raise ValueError("Got unknown key(s):" + str(extra_keys))
 
+        self.grid_model = model
         self.model_immutables = ModelImmutables(model)
 
         cols = {

--- a/powersimdata/tests/mock_scenario_info.py
+++ b/powersimdata/tests/mock_scenario_info.py
@@ -6,7 +6,6 @@ class MockScenarioInfo(ScenarioInfo):
     def __init__(self, scenario=None):
         self._DEFAULT_FLOAT = 42
         scenario = MockScenario() if scenario is None else scenario
-        scenario.state.grid.get_grid_model = lambda: "mock_grid"
         super().__init__(scenario)
 
     def area_to_loadzone(self, area, area_type=None):


### PR DESCRIPTION
### Purpose
Add the property to grid and mock grid classes as it's commonly used and set at init time.

### What the code is doing
Simplify the grid constructor by adding `self.grid_model` as an instance variable - no need to try/catch to set `ModelImmutables`. Also set the property in `MockGrid` since it's already available. 

### Testing
Existing unit tests

### Time estimate
5 min
