### PR TITLE
More error handling for grid validation

### DIFF
--- a/powersimdata/input/check.py
+++ b/powersimdata/input/check.py
@@ -1,3 +1,5 @@
+import sys
+
 import networkx as nx
 
 from powersimdata.input.grid import Grid
@@ -13,15 +15,23 @@ def check_grid(grid):
     if not isinstance(grid, Grid):
         raise TypeError("grid must be a Grid object")
     error_messages = []
-    _check_attributes(grid, error_messages)
-    _check_for_islanded_buses(grid, error_messages)
-    _check_for_undescribed_buses(grid, error_messages)
-    _check_bus_against_bus2sub(grid, error_messages)
-    _check_ac_interconnects(grid, error_messages)
-    _check_transformer_substations(grid, error_messages)
-    _check_line_voltages(grid, error_messages)
-    _check_plant_against_gencost(grid, error_messages)
-    _check_connected_components(grid, error_messages)
+    for check in [
+        _check_attributes,
+        _check_for_islanded_buses,
+        _check_for_undescribed_buses,
+        _check_bus_against_bus2sub,
+        _check_ac_interconnects,
+        _check_transformer_substations,
+        _check_line_voltages,
+        _check_plant_against_gencost,
+        _check_connected_components,
+    ]:
+        try:
+            check(grid, error_messages)
+        except Exception:
+            error_messages.append(
+                f"Exception during {check.__name__}: {sys.exc_info()}"
+            )
     if len(error_messages) > 0:
         collected = "\n".join(error_messages)
         raise ValueError(f"Problem(s) found with grid:\n{collected}")

--- a/powersimdata/input/check.py
+++ b/powersimdata/input/check.py
@@ -30,7 +30,7 @@ def check_grid(grid):
             check(grid, error_messages)
         except Exception:
             error_messages.append(
-                f"Exception during {check.__name__}: {sys.exc_info()}"
+                f"Exception during {check.__name__}: {sys.exc_info()[1]!r}"
             )
     if len(error_messages) > 0:
         collected = "\n".join(error_messages)

--- a/powersimdata/input/check.py
+++ b/powersimdata/input/check.py
@@ -8,10 +8,11 @@ def check_grid(grid):
 
     :param powersimdata.input.grid.Grid grid: grid or grid-like object to check.
     :raises TypeError: if ``grid`` is not a Grid object.
+    :raises ValueError: if ``grid`` has any inconsistency
     """
-    error_messages = []
     if not isinstance(grid, Grid):
-        error_messages.append("grid must be a Grid object")
+        raise TypeError("grid must be a Grid object")
+    error_messages = []
     _check_attributes(grid, error_messages)
     _check_for_islanded_buses(grid, error_messages)
     _check_for_undescribed_buses(grid, error_messages)

--- a/powersimdata/input/tests/test_check.py
+++ b/powersimdata/input/tests/test_check.py
@@ -11,26 +11,9 @@ def test_error_handling():
         check_grid(grid)
 
 
-def test_check_eastern():
-    grid = Grid("Eastern")
-    check_grid(grid)
-
-
-def test_check_western():
-    grid = Grid("Western")
-    check_grid(grid)
-
-
-def test_check_texas():
-    grid = Grid("Texas")
-    check_grid(grid)
-
-
-def test_check_western_texas():
-    grid = Grid(["Western", "Texas"])
-    check_grid(grid)
-
-
-def test_check_usa():
-    grid = Grid(["USA"])
+@pytest.mark.parametrize(
+    "interconnect", ["Eastern", "Western", "Texas", ["Western", "Texas"], "USA"]
+)
+def test_check_grid(interconnect):
+    grid = Grid(interconnect)
     check_grid(grid)

--- a/powersimdata/input/tests/test_check.py
+++ b/powersimdata/input/tests/test_check.py
@@ -1,5 +1,14 @@
+import pytest
+
 from powersimdata import Grid
 from powersimdata.input.check import check_grid
+
+
+def test_error_handling():
+    grid = Grid("Western")
+    del grid.dcline
+    with pytest.raises(ValueError):
+        check_grid(grid)
 
 
 def test_check_eastern():


### PR DESCRIPTION
### Purpose
I assume we would want not proceed with the consistency checks unless it's a `Grid` object. Thought I commented on the original PR but evidently it wasn't submitted since only I can see it (something about "pending").  

### What the code is doing
Update the docstring and raise separate error for type check. Also added try/except around each check.

### Testing
tox

### Time estimate
5 min
