### PR TITLE
feat: add substation transmission capacity calculation

### DIFF
--- a/powersimdata/design/transmission/substations.py
+++ b/powersimdata/design/transmission/substations.py
@@ -1,0 +1,19 @@
+def calculate_substation_capacity(grid):
+    """For each substation in a grid, calculate the total substation transmission
+    capacity (in a transport model, ignoring power flow).
+
+    :param powersimdata.input.grid.Grid grid: a grid instance.
+    :return: (*pandas.Series*) -- index is substation IDs, value are total transmission
+        capacity (MW).
+    """
+    # Get new branch data frame with 'from_sub' and 'to_sub' columns
+    branch = grid.branch.assign(
+        from_sub_id=grid.branch.from_bus_id.map(grid.bus2sub.sub_id),
+        to_sub_id=grid.branch.to_bus_id.map(grid.bus2sub.sub_id),
+    )
+    # Calculate total substation capacity for matching 'from_sub' branches
+    filtered_branch = branch.query("from_sub_id != to_sub_id")
+    from_cap = filtered_branch.groupby("from_sub_id").sum()["rateA"]
+    to_cap = filtered_branch.groupby("to_sub_id").sum()["rateA"]
+    total_capacities = from_cap.combine(to_cap, lambda x, y: x + y, fill_value=0)
+    return total_capacities

--- a/powersimdata/design/transmission/tests/test_substations.py
+++ b/powersimdata/design/transmission/tests/test_substations.py
@@ -1,0 +1,32 @@
+import pandas as pd
+
+from powersimdata.design.transmission.substations import calculate_substation_capacity
+from powersimdata.tests.mock_grid import MockGrid
+
+
+def test_calculate_substation_capacity():
+    mock_sub = {"sub_id": [1, 2, 3, 4]}
+    mock_bus2sub = {"bus_id": [10, 20, 21, 30, 40], "sub_id": [1, 2, 2, 3, 4]}
+    mock_branch = {
+        "branch_id": [200, 400, 420, 600, 601, 1200],
+        "from_bus_id": [10, 40, 20, 20, 30, 30],
+        "to_bus_id": [20, 10, 21, 30, 20, 40],
+        "rateA": [1, 2, 4, 8, 16, 32],
+    }
+
+    mock_grid_data = {
+        "sub": mock_sub,
+        "bus2sub": mock_bus2sub,
+        "branch": mock_branch,
+    }
+    mock_grid = MockGrid(grid_attrs=mock_grid_data)
+    substation_capacity = calculate_substation_capacity(mock_grid)
+    expected_return = pd.Series(
+        {
+            1: 3,
+            2: 25,
+            3: 56,
+            4: 34,
+        }
+    )
+    assert substation_capacity.equals(expected_return)


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
Add a feature to calculate the maximum transmission capacity into or out of a substation. This can be helpful e.g. when working to troubleshoot feasibility for a new grid model, when designing a Grid for a new scenario, or when investigating capacity expansion candidates.

### What the code is doing
In **substations.py**:
- We create a copy of the `grid.branch` data frame which has additional columns for `from_sub` and `to_sub`.
- We group on these `from_sub` and `to_sub` columns, and sum the branch capacities for branches 'from' and 'to' each substation, excluding branches which are 'from' and 'to' the same substation.
- We reindex so that all substation IDs are present in each of the 'from' and 'to' summations.
- Now that the indices are aligned, we sum the 'from' and 'to' summations and return.

### Testing
New unit test added. It features branches which have opposite to/from bus IDs (summed appropriately), and one branch with to/from buses within the same substation (not counted in any substation's capacity).

### Usage Example/Visuals
```python
>>> from powersimdata.design.transmission.substations import calculate_substation_capacity
>>> from powersimdata import Grid
>>> grid = Grid("Western")
Reading bus.csv
Reading plant.csv
Reading gencost.csv
Reading branch.csv
Reading dcline.csv
Reading sub.csv
Reading bus2sub.csv
Reading zone.csv
>>> calculate_substation_capacity(grid)
sub_id
35000    453.21
35001    492.76
35002    584.01
35003    465.77
35004    662.52
          ...
41078    100.00
41079    100.00
41080    100.00
41081    100.00
41082    100.00
Length: 4786, dtype: float64
```

### Time estimate
15 minutes.
