### PR TITLE
feat: enable retrieval of pf and dcline_pf from MockAnalyze

### DIFF
--- a/powersimdata/tests/mock_analyze.py
+++ b/powersimdata/tests/mock_analyze.py
@@ -33,6 +33,7 @@ class MockAnalyze:
         lmp=None,
         pf=None,
         pg=None,
+        dcline_pf=None,
         storage_pg=None,
         solar=None,
         wind=None,
@@ -60,6 +61,7 @@ class MockAnalyze:
         self.demand = _ensure_ts_index(demand)
         self.lmp = _ensure_ts_index(lmp)
         self.pf = _ensure_ts_index(pf)
+        self.dcline_pf = _ensure_ts_index(dcline_pf)
         self.pg = _ensure_ts_index(pg)
         self.storage_pg = _ensure_ts_index(storage_pg)
         self.solar = _ensure_ts_index(solar)
@@ -102,6 +104,18 @@ class MockAnalyze:
         :return: (pandas.DataFrame) -- dummy lmp
         """
         return self.lmp
+
+    def get_pf(self):
+        """Get PF.
+        :return: (pandas.DataFrame) -- dummy pf
+        """
+        return self.pf
+
+    def get_dcline_pf(self):
+        """Get PF_DCLINE.
+        :return: (pandas.DataFrame) -- dummy pf_dcline
+        """
+        return self.dcline_pf
 
     def get_pg(self):
         """Get PG.


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
Enable retrieval of pf and dcline_pf from MockAnalyze. This is a follow-up to #501.

### Time estimate
2 minutes.
