### PR TITLE
feat: allow state method passthrough in MockScenario objects

### DIFF
--- a/powersimdata/tests/mock_analyze.py
+++ b/powersimdata/tests/mock_analyze.py
@@ -23,6 +23,39 @@ def _ensure_ts_index(df):
 
 
 class MockAnalyze:
+    """A mock of a powersimdata.scenario.analyze.Analyze object.
+
+    :param dict grid_attrs: fields to be added to grid.
+    :param pandas.DataFrame congl: dummy congl
+    :param pandas.DataFrame congu: dummy congu
+    :param dict ct: dummy ct
+    :param pandas.DataFrame demand: dummy demand
+    :param pandas.DataFrame lmp: dummy lmp
+    :param pandas.DataFrame pf: dummy pf
+    :param pandas.DataFrame pg: dummy pg
+    :param pandas.DataFrame storage_pg: dummy storage_pg
+    :param pandas.DataFrame solar: dummy solar
+    :param pandas.DataFrame wind: dummy wind
+    :param pandas.DataFrame hydro: dummy hydro
+    """
+
+    exported_methods = [
+        "get_congl",
+        "get_congu",
+        "get_ct",
+        "get_demand",
+        "get_grid",
+        "get_lmp",
+        "get_pf",
+        "gt_dcline_pf",
+        "get_pg",
+        "get_storage_pg",
+        "get_storage_e",
+        "get_solar",
+        "get_wind",
+        "get_hydro",
+    ]
+
     def __init__(
         self,
         grid_attrs=None,
@@ -40,21 +73,7 @@ class MockAnalyze:
         wind=None,
         hydro=None,
     ):
-        """Constructor.
-
-        :param dict grid_attrs: fields to be added to grid.
-        :param pandas.DataFrame congl: dummy congl
-        :param pandas.DataFrame congu: dummy congu
-        :param dict ct: dummy ct
-        :param pandas.DataFrame demand: dummy demand
-        :param pandas.DataFrame lmp: dummy lmp
-        :param pandas.DataFrame pf: dummy pf
-        :param pandas.DataFrame pg: dummy pg
-        :param pandas.DataFrame storage_pg: dummy storage_pg
-        :param pandas.DataFrame solar: dummy solar
-        :param pandas.DataFrame wind: dummy wind
-        :param pandas.DataFrame hydro: dummy hydro
-        """
+        """Constructor."""
         self.grid = MockGrid(grid_attrs)
         self.congl = _ensure_ts_index(congl)
         self.congu = _ensure_ts_index(congu)

--- a/powersimdata/tests/mock_analyze.py
+++ b/powersimdata/tests/mock_analyze.py
@@ -34,6 +34,7 @@ class MockAnalyze:
         pf=None,
         pg=None,
         dcline_pf=None,
+        storage_e=None,
         storage_pg=None,
         solar=None,
         wind=None,
@@ -63,6 +64,7 @@ class MockAnalyze:
         self.pf = _ensure_ts_index(pf)
         self.dcline_pf = _ensure_ts_index(dcline_pf)
         self.pg = _ensure_ts_index(pg)
+        self.storage_e = _ensure_ts_index(storage_e)
         self.storage_pg = _ensure_ts_index(storage_pg)
         self.solar = _ensure_ts_index(solar)
         self.wind = _ensure_ts_index(wind)
@@ -122,6 +124,12 @@ class MockAnalyze:
         :return: (pandas.DataFrame) -- dummy pg
         """
         return self.pg
+
+    def get_storage_e(self):
+        """Get storage E.
+        :return: (pandas.DataFrame) -- dummy storage_e
+        """
+        return self.storage_e
 
     def get_storage_pg(self):
         """Get storage PG.

--- a/powersimdata/tests/mock_scenario.py
+++ b/powersimdata/tests/mock_scenario.py
@@ -3,12 +3,16 @@ from powersimdata.tests.mock_analyze import MockAnalyze
 
 
 class MockScenario:
-    def __init__(self, grid_attrs=None, **kwargs):
-        """Constructor.
+    """
+    :param dict grid_attrs: fields to be added to grid.
+    :param \\*\\*kwargs: collected keyword arguments to be passed to
+        MockAnalyze init.
+    """
 
-        :param dict grid_attrs: fields to be added to grid.
-        :param pandas.DataFrame pg: dummy pg
-        """
+    _setattr_allowlist = {"state", "info"}
+
+    def __init__(self, grid_attrs=None, **kwargs):
+        """Constructor."""
         self.state = MockAnalyze(grid_attrs, **kwargs)
         self.info = {
             "id": "111",
@@ -34,3 +38,26 @@ class MockScenario:
     def __class__(self):
         """If anyone asks, I'm a Scenario object!"""
         return Scenario
+
+    def __dir__(self):
+        return sorted(super().__dir__() + list(self.state.exported_methods))
+
+    def __getattr__(self, name):
+        if name in self.state.exported_methods:
+            return getattr(self.state, name)
+        elif hasattr(self.state, "__getattr__"):
+            return self.state.__getattr__(name)
+        else:
+            raise AttributeError(
+                f"Scenario object in {self.state.name} state "
+                f"has no attribute {name}"
+            )
+
+    def __setattr__(self, name, value):
+        if name in self._setattr_allowlist:
+            super().__setattr__(name, value)
+        elif name in self.state.exported_methods:
+            raise AttributeError(
+                f"{name} is exported from Scenario.state, edit it there if necessary"
+            )
+        super().__setattr__(name, value)


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
Allow state method passthrough in MockScenario objects. Closes #434.

### What the code is doing
- in **mock_analyze.py**:
  - we add an `exported_methods` class attribute, which will be accessed by the logic in the `MockScenario` class.
  - we also add logic to accept and return `storage_e` data.
- in **mock_scenario.py**:
  - we copy the passthrough logic from the Scenario object. See #420 for more details.

### Testing
Manual.

### Usage Example/Visuals
```python
>>> from powersimdata.tests.mock_scenario import MockScenario
>>> from powersimdata import Scenario
>>> demand = Scenario(599).get_demand()
>>> mock_scenario = MockScenario(demand=demand)
>>> mock_scenario.get_demand()
                         201      202      203  ...      214      215      216
UTC Time                                        ...
2016-01-01 00:00:00  14957.1  6735.53  4364.43  ...  4239.74  1766.76  606.157
2016-01-01 01:00:00  16112.7  7123.50  4546.56  ...  4599.10  1893.96  677.637
2016-01-01 02:00:00  17131.5  7689.84  4905.41  ...  4729.24  1900.99  706.230
2016-01-01 03:00:00  16985.6  7625.47  5225.50  ...  4580.75  1861.18  685.500
2016-01-01 04:00:00  16498.0  7366.67  5187.20  ...  4585.80  1816.51  664.056
...                      ...      ...      ...  ...      ...      ...      ...
2016-12-31 19:00:00  16357.0  7042.57  4447.70  ...  4391.56  1772.38  573.275
2016-12-31 20:00:00  16186.3  6958.31  4454.60  ...  4291.82  1731.52  574.705
2016-12-31 21:00:00  15841.4  6784.84  4369.54  ...  4180.42  1694.26  563.983
2016-12-31 22:00:00  15514.9  6573.87  4297.82  ...  4122.95  1663.71  563.983
2016-12-31 23:00:00  15422.6  6501.24  4244.10  ...  4157.27  1670.22  555.405

[8784 rows x 16 columns]
```

### Time estimate
15 minutes.
