### PR TITLE
Josephine/calculate interzone capacity

### DIFF
--- a/powersimdata/design/transmission/zones.py
+++ b/powersimdata/design/transmission/zones.py
@@ -1,0 +1,19 @@
+def calculate_interzone_capacity(grid):
+    """For each zone in a grid, calculate the aggreagte zone transmission
+    capacity (in a transport model, ignoring power flow).
+
+    :param powersimdata.input.grid.Grid grid: a grid instance.
+    :return: (*pandas.Series*) -- index is zone IDs, values are total transmission
+        capacity (MW).
+    """
+    # Get new branch data frame with 'from_zone' and 'to_zone' columns
+    branch = grid.branch.assign(
+        from_zone_id=grid.branch.from_bus_id.map(grid.bus["zone_id"]),
+        to_zone_id=grid.branch.to_bus_id.map(grid.bus["zone_id"]),
+    )
+    # Calculate total substation capacity for matching 'from_zone' branches
+    filtered_branch = branch.query("from_zone_id != to_zone_id")
+    from_cap = filtered_branch.groupby("from_zone_id").sum()["rateA"]
+    to_cap = filtered_branch.groupby("to_zone_id").sum()["rateA"]
+    total_capacities = from_cap.combine(to_cap, lambda x, y: x + y, fill_value=0)
+    return total_capacities


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
The method calculates the aggregate transmission capacity (from + to) at zone level for each zone id. It is implemented in a similar way as "calculate_substation_capacity" method, but mapping for zone level.

### What the code is doing

- assign corresponding zone_id to the ends of each branch according to 'from_bus_id' and 'to'_bus_id'

- filter branches: exclude those branches from and to the same zone

- calculate the marginal transmission capacities by each unique 'from_zone_id" and by each unique 'to_zone_id' from filtered branches 

- calculate total transmission capacity for each zone by adding up 'from capacity' and 'to capacity' by each zone id

### Value -> Values
grid->total transmission capacity by each zone for the grid

### Testing
from powersimdata.design.transmission.substations import calculate_zone_capacity
from powersimdata.input.grid import Grid
grid = Grid("Western")
calculate_interzone_capacity(grid)

<img width="167" alt="Screen Shot 2021-06-16 at 12 16 19 PM" src="https://user-images.githubusercontent.com/60896029/122256067-b31a5700-ce9c-11eb-925d-8544a3dab3dc.png">

