### PR TITLE
feat: access onshore and offshore wind profiles

### DIFF
--- a/powersimdata/scenario/analyze.py
+++ b/powersimdata/scenario/analyze.py
@@ -323,6 +323,36 @@ class Analyze(State):
         profile = TransformProfile(self._scenario_info, self.get_grid(), self.get_ct())
         return profile.get_profile("wind")
 
+    def get_wind_onshore(self):
+        """Returns wind onshore profile
+
+        :return: (*pandas.DataFrame*) -- data frame of wind energy output for onshore
+            turbines
+        """
+        profile = TransformProfile(self._scenario_info, self.get_grid(), self.get_ct())
+        wind = profile.get_profile("wind")
+
+        grid = self.get_grid()
+        onshore_id = grid.plant.groupby(["type"]).get_group("wind").index
+        return wind[onshore_id]
+
+    def get_wind_offshore(self):
+        """Returns wind offshore profile
+
+        :return: (*pandas.DataFrame*) -- data frame of wind energy output for offshore
+            turbines
+        :raises ValueError: if no offshore wind turbines in grid
+        """
+        profile = TransformProfile(self._scenario_info, self.get_grid(), self.get_ct())
+        wind = profile.get_profile("wind")
+
+        grid = self.get_grid()
+        if "wind_offshore" in grid.plant["type"].unique():
+            offshore_id = grid.plant.groupby(["type"]).get_group("wind_offshore").index
+            return wind[offshore_id]
+        else:
+            raise ValueError("No offshore wind turbines in grid")
+
     def _leave(self):
         """Cleans when leaving state."""
         del self.grid


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
Retrieve onshore and offshore wind profile for a scenario 

### What the code is doing
Two functions are implemented:
* plant ID are retrieved for each type of turbines 
* wind profile is queried
* an error is raised if no offshore wind profiles id found in the grid

### Testing
Manual testing for scenario.
Please propose potential test.

### Where to look
Check the `powersimdata.scenario.analyze` module

### Usage Example/Visuals
```
from powersimdata import Scenario

scenario = Scenario(600)

offshore_wind = scenario.get_wind_offshore()
onshore_wind = scenario.get_wind_onshore()
```

### Time estimate
10 min
