### PR TITLE
feat: add base_grid input to investment cost calculation functions

### DIFF
--- a/powersimdata/input/check.py
+++ b/powersimdata/input/check.py
@@ -210,3 +210,16 @@ def _check_connected_components(grid, error_messages):
             f"but is specified as having {num_interconnects} interconnects: "
             f"{grid.interconnect}."
         )
+
+
+def _check_grid_models_match(grid1, grid2):
+    """Check whether an object is an internally-consistent Grid object.
+
+    :param powersimdata.input.grid.Grid grid1: first Grid instance.
+    :param powersimdata.input.grid.Grid grid2: second Grid instance.
+    :raises ValueError: if the grid models don't match.
+    """
+    if not grid1.grid_model == grid2.grid_model:
+        raise ValueError(
+            f"Grid models don't match: {grid1.grid_model}, {grid2.grid_model}"
+        )

--- a/powersimdata/input/tests/test_check.py
+++ b/powersimdata/input/tests/test_check.py
@@ -1,7 +1,7 @@
 import pytest
 
 from powersimdata import Grid
-from powersimdata.input.check import check_grid
+from powersimdata.input.check import _check_grid_models_match, check_grid
 
 
 def test_error_handling():
@@ -17,3 +17,15 @@ def test_error_handling():
 def test_check_grid(interconnect):
     grid = Grid(interconnect)
     check_grid(grid)
+
+
+def check_grid_models_match_success():
+    _check_grid_models_match(Grid("Western"), Grid("Texas"))
+
+
+def check_grid_models_match_failure():
+    grid1 = Grid("Western")
+    grid2 = Grid("Texas")
+    grid2.grid_model == "foo"
+    with pytest.raises(ValueError):
+        _check_grid_models_match(grid1, grid2)


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
Currently, the user-facing functions to calculate investment cost for each of {ac branches, dc branches, generation/storage} automatically compare against the base Grid in the repository. This PR adds a new parameter `base_grid` to each of these functions, so that another Grid can be passed instead.

This is useful because the base Grid in the repository does not correspond to any particular point in time, so calculating investment costs between for example a 2021 scenario and a 2030 scenario currently involves calculating the investment costs of each of them compared to the base grid in the repository, and then comparing those differences against each other. If instead the user can say that the 2021 scenario is the 'base' grid to compare against, then all of the implementation details of comparing the two deltas is avoided.

### What the code is doing
If a `base_grid` is provided to any of the functions, this object is used to calculate investment costs. If this parameter is not specified, then the code proceeds as currently by spinning up a new base Grid.

### Testing
No tests were performed. Currently, this instantiation of a base Grid limits the testability of the user-facing functions, since we can't pass a MockScenario with a MockGrid. This refactor improves this testability by enabling tests which avoid instantiating a Grid.

### Time estimate
10 minutes.
