### PR TITLE
refactor: add compare module, move Grid/Scenario check functions from PostREISE to PowerSimData

### DIFF
--- a/powersimdata/design/compare/generation.py
+++ b/powersimdata/design/compare/generation.py
@@ -1,0 +1,25 @@
+from powersimdata.design.compare.helpers import _reindex_as_necessary
+from powersimdata.input.check import _check_data_frame
+
+
+def calculate_plant_difference(plant1, plant2):
+    """Calculate the capacity differences between two plant data frames. If capacity in
+    ``plant2`` is larger than capacity in ``plant1``, the return will be positive.
+
+    :param pandas.DataFrame plant1: first plant data frame.
+    :param pandas.DataFrame plant2: second plant data frame.
+    :return: (*pandas.DataFrame*) -- merged data frames with a new 'diff' column.
+    """
+    _check_data_frame(plant1, "plant1")
+    _check_data_frame(plant2, "plant2")
+    # Reindex so that we don't get NaN when calculating upgrades for new generators
+    plant1, plant2 = _reindex_as_necessary(plant1, plant2, ["bus_id", "type"])
+    plant_merge = plant1.merge(
+        plant2, how="outer", right_index=True, left_index=True, suffixes=(None, "_2")
+    )
+    plant_merge["diff"] = plant_merge.Pmax_2.fillna(0) - plant_merge.Pmax.fillna(0)
+    # Ensure that lats & lons get filled in as necessary from plant2 entries
+    for l in ["lat", "lon"]:
+        plant_merge[l].fillna(plant_merge[f"{l}_2"], inplace=True)
+
+    return plant_merge

--- a/powersimdata/design/compare/helpers.py
+++ b/powersimdata/design/compare/helpers.py
@@ -1,0 +1,19 @@
+def _reindex_as_necessary(df1, df2, check_columns):
+    """Check for indices with mismatched entries in specified columns. If any entries
+    don't match, reindex based on these columns such that there are no shared indices
+    with mismatched entries in these columns.
+
+    :param pandas.DataFrame df1: data frame containing ``check_columns``.
+    :param pandas.DataFrame df2: data frame containing ``check_columns``.
+    :param iterable check_columns: column
+    :return: (*tuple*) -- data frames, reindexed as necessary.
+    """
+    # Coerce to list for safety, since pandas interprets lists and tuples differently
+    check_columns_list = list(check_columns)
+    shared_indices = set(df1.index) & set(df2.index)
+    check1 = df1.loc[shared_indices, check_columns_list]
+    check2 = df2.loc[shared_indices, check_columns_list]
+    if not check1.equals(check2):
+        df1 = df1.set_index(keys=check_columns_list, drop=False, append=True)
+        df2 = df2.set_index(keys=check_columns_list, drop=False, append=True)
+    return df1, df2

--- a/powersimdata/design/compare/transmission.py
+++ b/powersimdata/design/compare/transmission.py
@@ -1,0 +1,61 @@
+from powersimdata.design.compare.helpers import _reindex_as_necessary
+from powersimdata.input.check import _check_data_frame, _check_grid_type
+
+
+def calculate_branch_difference(branch1, branch2):
+    """Calculate the capacity differences between two branch data frames. If capacity in
+    ``branch2`` is larger than capacity in ``branch1``, the return will be positive.
+
+    :param pandas.DataFrame branch1: first branch data frame.
+    :param pandas.DataFrame branch2: second branch data frame.
+    :param float/int difference_threshold: drop any changes less than this value from
+        the returned Series.
+    :return: (*pandas.Series*) -- capacity difference between the two branch data
+        frames.
+    """
+    _check_data_frame(branch1, "branch1")
+    _check_data_frame(branch2, "branch2")
+    if not ("rateA" in branch1.columns) and ("rateA" in branch2.columns):
+        raise ValueError("branch1 and branch2 both must have 'rateA' columns")
+    branch1, branch2 = _reindex_as_necessary(
+        branch1, branch2, ["from_bus_id", "to_bus_id"]
+    )
+    branch_merge = branch1.merge(
+        branch2, how="outer", right_index=True, left_index=True, suffixes=(None, "_2")
+    )
+    branch_merge["diff"] = branch_merge.rateA_2.fillna(0) - branch_merge.rateA.fillna(0)
+    # Ensure that lats & lons get filled in as necessary from branch2 entries
+    for l in ["from_lat", "from_lon", "to_lat", "to_lon"]:
+        branch_merge[l].fillna(branch_merge[f"{l}_2"], inplace=True)
+
+    return branch_merge
+
+
+def calculate_dcline_differences(grid1, grid2):
+    """Calculate capacity differences between dcline tables, and add to/from lat/lon.
+
+    :param powersimdata.input.grid.Grid grid1: first grid instance.
+    :param powersimdata.input.grid.Grid grid2: second grid instance.
+    :return: (*pandas.DataFrame*) -- data frame with all indices, plus new columns:
+        diff, from_lat, from_lon, to_lat, to_lon.
+    """
+    _check_grid_type(grid1)
+    _check_grid_type(grid2)
+    dcline1, dcline2 = _reindex_as_necessary(
+        grid1.dcline, grid2.dcline, ["from_bus_id", "to_bus_id"]
+    )
+    # Get latitudes and longitudes for to & from buses
+    for dcline, grid in [(dcline1, grid1), (dcline2, grid2)]:
+        dcline["from_lat"] = grid.bus.loc[dcline.from_bus_id, "lat"].to_numpy()
+        dcline["from_lon"] = grid.bus.loc[dcline.from_bus_id, "lon"].to_numpy()
+        dcline["to_lat"] = grid.bus.loc[dcline.to_bus_id, "lat"].to_numpy()
+        dcline["to_lon"] = grid.bus.loc[dcline.to_bus_id, "lon"].to_numpy()
+    dc_merge = dcline1.merge(
+        dcline2, how="outer", right_index=True, left_index=True, suffixes=(None, "_2")
+    )
+    dc_merge["diff"] = dc_merge.Pmax_2.fillna(0) - dc_merge.Pmax.fillna(0)
+    # Ensure that lats & lons get filled in as necessary from grid2.dcline entries
+    for l in ["from_lat", "from_lon", "to_lat", "to_lon"]:
+        dc_merge[l].fillna(dc_merge[f"{l}_2"], inplace=True)
+
+    return dc_merge

--- a/powersimdata/input/check.py
+++ b/powersimdata/input/check.py
@@ -13,11 +13,9 @@ def check_grid(grid):
     """Check whether an object is an internally-consistent Grid object.
 
     :param powersimdata.input.grid.Grid grid: grid or grid-like object to check.
-    :raises TypeError: if ``grid`` is not a Grid object.
     :raises ValueError: if ``grid`` has any inconsistency
     """
-    if not isinstance(grid, Grid):
-        raise TypeError("grid must be a Grid object")
+    _check_grid_type(grid)
     error_messages = []
     # Run all checks which operate on a Grid object
     for check in [
@@ -44,7 +42,7 @@ def check_grid(grid):
         except Exception:
             error_messages.append(
                 f"Exception during {check.__name__} {gencost_key}: "
-                "{sys.exc_info()[1]!r}"
+                f"{sys.exc_info()[1]!r}"
             )
     if len(error_messages) > 0:
         collected = "\n".join(error_messages)
@@ -233,6 +231,8 @@ def _check_grid_models_match(grid1, grid2):
     :param powersimdata.input.grid.Grid grid2: second Grid instance.
     :raises ValueError: if the grid models don't match.
     """
+    _check_grid_type(grid1)
+    _check_grid_type(grid2)
     if not grid1.grid_model == grid2.grid_model:
         raise ValueError(
             f"Grid models don't match: {grid1.grid_model}, {grid2.grid_model}"

--- a/powersimdata/input/check.py
+++ b/powersimdata/input/check.py
@@ -1,8 +1,12 @@
+import datetime
 import sys
 
 import networkx as nx
+import numpy as np
+import pandas as pd
 
 from powersimdata.input.grid import Grid
+from powersimdata.network.model import ModelImmutables
 
 
 def check_grid(grid):
@@ -15,6 +19,7 @@ def check_grid(grid):
     if not isinstance(grid, Grid):
         raise TypeError("grid must be a Grid object")
     error_messages = []
+    # Run all checks which operate on a Grid object
     for check in [
         _check_attributes,
         _check_for_islanded_buses,
@@ -31,6 +36,15 @@ def check_grid(grid):
         except Exception:
             error_messages.append(
                 f"Exception during {check.__name__}: {sys.exc_info()[1]!r}"
+            )
+    # Run checks which operate on a pandas data frame
+    for gencost_key in ("before", "after"):
+        try:
+            _check_gencost(grid.gencost[gencost_key], error_messages)
+        except Exception:
+            error_messages.append(
+                f"Exception during {check.__name__} {gencost_key}: "
+                "{sys.exc_info()[1]!r}"
             )
     if len(error_messages) > 0:
         collected = "\n".join(error_messages)
@@ -223,3 +237,362 @@ def _check_grid_models_match(grid1, grid2):
         raise ValueError(
             f"Grid models don't match: {grid1.grid_model}, {grid2.grid_model}"
         )
+
+
+def _check_data_frame(df, label):
+    """Ensure that input is a pandas data frame.
+
+    :param pandas.DataFrame df: a data frame.
+    :param str label: name of data frame (used for error messages).
+    :raises TypeError: if df is not a data frame or label is not a str.
+    :raises ValueError: if data frame is empty.
+    """
+    if not isinstance(label, str):
+        raise TypeError("label must be a str")
+    if not isinstance(df, pd.DataFrame):
+        raise TypeError(label + " must be a pandas.DataFrame object")
+    if not df.shape[0] > 0:
+        raise ValueError(label + " must have at least one row")
+    if not df.shape[1] > 0:
+        raise ValueError(label + " must have at least one column")
+
+
+def _check_time_series(ts, label):
+    """Check that a time series is specified properly.
+
+    :param pandas.DataFrame/pandas.Series ts: time series to check.
+    :param str label: name of time series (used for error messages).
+    :raises TypeError: if ts is not a data frame/time series or label is not a str.
+    :raises ValueError: if indices are not timestamps.
+    """
+    if not isinstance(label, str):
+        raise TypeError("label must be a str")
+    if not isinstance(ts, (pd.DataFrame, pd.Series)):
+        raise TypeError(label + " must be a pandas.DataFrame or pandas.Series object")
+    if not ts.shape[0] > 0:
+        raise ValueError(label + " must have at least one row")
+    if not isinstance(ts.index, pd.DatetimeIndex):
+        raise ValueError(label + " must be a time series")
+
+
+def _check_grid_type(grid):
+    """Ensure that ``grid`` is a Grid object.
+
+    :param powersimdata.input.grid.Grid grid: a Grid instance.
+    :raises TypeError: if input is not a Grid instance.
+    """
+    if not isinstance(grid, Grid):
+        raise TypeError(f"grid must be a {Grid} object")
+
+
+def _check_areas_and_format(areas, grid_model="usa_tamu"):
+    """Ensure that areas are valid. Duplicates are removed and state abbreviations are
+    converted to their actual name.
+
+    :param str/list/tuple/set areas: areas(s) to check. Could be load zone name(s),
+        state name(s)/abbreviation(s) or interconnect(s).
+    :param str grid_model: grid model.
+    :raises TypeError: if areas is not a list/tuple/set of str.
+    :raises ValueError: if areas is empty or not valid.
+    :return: (*set*) -- areas as a set. State abbreviations are converted to state
+        names.
+    """
+    mi = ModelImmutables(grid_model)
+    if isinstance(areas, str):
+        areas = {areas}
+    elif isinstance(areas, (list, set, tuple)):
+        if not all([isinstance(z, str) for z in areas]):
+            raise TypeError("all areas must be str")
+        areas = set(areas)
+    else:
+        raise TypeError("areas must be a str or a list/tuple/set of str")
+    if len(areas) == 0:
+        raise ValueError("areas must be non-empty")
+    all_areas = (
+        mi.zones["loadzone"]
+        | mi.zones["abv"]
+        | mi.zones["state"]
+        | mi.zones["interconnect"]
+    )
+    if not areas <= all_areas:
+        diff = areas - all_areas
+        raise ValueError("invalid area(s): %s" % " | ".join(diff))
+
+    abv_in_areas = [z for z in areas if z in mi.zones["abv"]]
+    for a in abv_in_areas:
+        areas.remove(a)
+        areas.add(mi.zones["abv2state"][a])
+
+    return areas
+
+
+def _check_resources_and_format(resources, grid_model="usa_tamu"):
+    """Ensure that resources are valid and convert variable to a set.
+
+    :param str/list/tuple/set resources: resource(s) to check.
+    :param str grid_model: grid model.
+    :raises TypeError: if resources is not a list/tuple/set of str.
+    :raises ValueError: if resources is empty or not valid.
+    :return: (*set*) -- resources as a set.
+    """
+    mi = ModelImmutables(grid_model)
+    if isinstance(resources, str):
+        resources = {resources}
+    elif isinstance(resources, (list, set, tuple)):
+        if not all([isinstance(r, str) for r in resources]):
+            raise TypeError("all resources must be str")
+        resources = set(resources)
+    else:
+        raise TypeError("resources must be a str or a list/tuple/set of str")
+    if len(resources) == 0:
+        raise ValueError("resources must be non-empty")
+    if not resources <= mi.plants["all_resources"]:
+        diff = resources - mi.plants["all_resources"]
+        raise ValueError("invalid resource(s): %s" % " | ".join(diff))
+    return resources
+
+
+def _check_resources_are_renewable_and_format(resources, grid_model="usa_tamu"):
+    """Ensure that resources are valid renewable resources and convert variable to
+    a set.
+
+    :param str/list/tuple/set resources: resource(s) to analyze.
+    :param str grid_model: grid model.
+    :raises ValueError: if resources are not renewables.
+    return: (*set*) -- resources as a set
+    """
+    mi = ModelImmutables(grid_model)
+    resources = _check_resources_and_format(resources, grid_model=grid_model)
+    if not resources <= mi.plants["renewable_resources"]:
+        diff = resources - mi.plants["all_resources"]
+        raise ValueError("invalid renewable resource(s): %s" % " | ".join(diff))
+    return resources
+
+
+def _check_areas_are_in_grid_and_format(areas, grid):
+    """Ensure that list of areas are in grid.
+
+    :param dict areas: keys are area types: '*loadzone*', '*state*' or '*interconnect*'.
+        Values are str/list/tuple/set of areas.
+    :param powersimdata.input.grid.Grid grid: Grid instance.
+    :return: (*dict*) -- modified areas dictionary. Keys are area types ('*loadzone*',
+        '*state*' or '*interconnect*'). State abbreviations, if present, are converted
+        to state names. Values are areas as a set.
+    :raises TypeError: if areas is not a dict or its keys are not str.
+    :raises ValueError: if area type is invalid, an area in not in grid or an
+        invalid loadzone/state/interconnect is passed.
+    """
+    _check_grid_type(grid)
+    if not isinstance(areas, dict):
+        raise TypeError("areas must be a dict")
+
+    mi = grid.model_immutables
+    areas_formatted = {}
+    for a in areas.keys():
+        if a in ["loadzone", "state", "interconnect"]:
+            areas_formatted[a] = set()
+
+    all_loadzones = set()
+    for k, v in areas.items():
+        if not isinstance(k, str):
+            raise TypeError("area type must be a str")
+        elif k == "interconnect":
+            interconnects = _check_areas_and_format(v)
+            for i in interconnects:
+                try:
+                    all_loadzones.update(mi.zones["interconnect2loadzone"][i])
+                except KeyError:
+                    raise ValueError("invalid interconnect: %s" % i)
+            areas_formatted["interconnect"].update(interconnects)
+        elif k == "state":
+            states = _check_areas_and_format(v)
+            for s in states:
+                try:
+                    all_loadzones.update(mi.zones["state2loadzone"][s])
+                except KeyError:
+                    raise ValueError("invalid state: %s" % s)
+            areas_formatted["state"].update(states)
+        elif k == "loadzone":
+            loadzones = _check_areas_and_format(v)
+            for l in loadzones:
+                if l not in mi.zones["loadzone"]:
+                    raise ValueError("invalid load zone: %s" % l)
+            all_loadzones.update(loadzones)
+            areas_formatted["loadzone"].update(loadzones)
+        else:
+            raise ValueError("invalid area type")
+
+    valid_loadzones = set(grid.plant["zone_name"].unique())
+    if not all_loadzones <= valid_loadzones:
+        diff = all_loadzones - valid_loadzones
+        raise ValueError("%s not in in grid" % " | ".join(diff))
+
+    return areas_formatted
+
+
+def _check_resources_are_in_grid_and_format(resources, grid):
+    """Ensure that resource(s) is represented in at least one generator in the grid
+    used for the scenario.
+
+    :param str/list/tuple/set resources: resource(s) to analyze.
+    :param powersimdata.input.grid.Grid grid: a Grid instance.
+    :return: (*set*) -- resources as a set.
+    :raises ValueError: if resources is not used in scenario.
+    """
+    _check_grid_type(grid)
+    resources = _check_resources_and_format(resources)
+    valid_resources = set(grid.plant["type"].unique())
+    if not resources <= valid_resources:
+        diff = resources - valid_resources
+        raise ValueError("%s not in in grid" % " | ".join(diff))
+    return resources
+
+
+def _check_plants_are_in_grid(plant_id, grid):
+    """Ensure that list of plant id are in grid.
+
+    :param list/tuple/set plant_id: list of plant id.
+    :param powersimdata.input.grid.Grid grid: Grid instance.
+    :raises TypeError: if plant_id is not a list of int or str.
+    :raises ValueError: if plant id is not in network.
+    """
+    _check_grid_type(grid)
+    if not (
+        isinstance(plant_id, (list, tuple, set))
+        and all([isinstance(p, (int, str)) for p in plant_id])
+    ):
+        raise TypeError("plant_id must be a a list/tuple/set of int or str")
+    if not set([str(p) for p in plant_id]) <= set([str(i) for i in grid.plant.index]):
+        raise ValueError("plant_id must be subset of plant index")
+
+
+def _check_number_hours_to_analyze(scenario, hours):
+    """Ensure that number of hours is greater than simulation length.
+
+    :param powersimdata.scenario.scenario.Scenario scenario: scenario instance.
+    :param int hours: number of hours to analyze.
+    :raises TypeError: if hours is not int.
+    :raises ValueError: if hours is negative or greater than simulation length
+    """
+    start_date = pd.Timestamp(scenario.info["start_date"])
+    end_date = pd.Timestamp(scenario.info["end_date"])
+    if not isinstance(hours, int):
+        raise TypeError("hours must be an int")
+    if hours < 1:
+        raise ValueError("hours must be positive")
+    if hours > (end_date - start_date).total_seconds() / 3600 + 1:
+        raise ValueError("hours must not be greater than simulation length")
+
+
+def _check_date(date):
+    """Check date is valid.
+
+    :param pandas.Timestamp/numpy.datetime64/datetime.datetime date: timestamp.
+    :raises TypeError: if date is improperly formatted.
+    """
+    if not isinstance(date, (pd.Timestamp, np.datetime64, datetime.datetime)):
+        raise TypeError(
+            "date must be a pandas.Timestamp, a numpy.datetime64 or a datetime.datetime object"
+        )
+
+
+def _check_date_range_in_scenario(scenario, start, end):
+    """Check if start time and end time define a valid time range of the given scenario.
+
+    :param powersimdata.scenario.scenario.Scenario scenario: scenario instance.
+    :param pandas.Timestamp/numpy.datetime64/datetime.datetime start: start date.
+    :param pandas.Timestamp/numpy.datetime64/datetime.datetime end: end date.
+    :raises ValueError: if the date range is invalid.
+    """
+    _check_date(start)
+    _check_date(end)
+    scenario_start = pd.Timestamp(scenario.info["start_date"])
+    scenario_end = pd.Timestamp(scenario.info["end_date"])
+
+    if not scenario_start <= start <= end <= scenario_end:
+        raise ValueError("Must have scenario_start <= start <= end <= scenario_end")
+
+
+def _check_date_range_in_time_series(ts, start, end):
+    """Check if start time and end time define a valid time range of the time series.
+
+    :param pandas.DataFrame/pandas.Series ts: a time series with timestamp as indices.
+    :param pandas.Timestamp/numpy.datetime64/datetime.datetime start: start date.
+    :param pandas.Timestamp/numpy.datetime64/datetime.datetime end: end date.
+    :raises ValueError: if the date range is invalid.
+    """
+    _check_time_series(ts, "time series")
+    _check_date(start)
+    _check_date(end)
+
+    if not ts.index[0] <= start <= end <= ts.index[-1]:
+        raise ValueError(
+            "Must have time_series_start <= start <= end <= time_series_end"
+        )
+
+
+def _check_epsilon(epsilon):
+    """Ensure epsilon is valid.
+
+    :param float/int epsilon: precision for binding constraints.
+    :raises TypeError: if epsilon is not a float or an int.
+    :raises ValueError: if epsilon is negative.
+    """
+    if not isinstance(epsilon, (float, int)):
+        raise TypeError("epsilon must be numeric")
+    if epsilon < 0:
+        raise ValueError("epsilon must be non-negative")
+
+
+def _check_gencost(gencost, error_messages=None):
+    """Check that gencost is valid.
+
+    :param pandas.DataFrame gencost: cost curve polynomials.
+    :param list error_messages: list to append error messages to. If `error_messages``
+        is None and an error is encountered, an Exception will be raised instead.
+    :raises TypeError: if ``error_messages`` is None and: gencost is not a data frame,
+        or polynomial degree is not an int.
+    :raises ValueError: if data frame has no rows, does not have the required columns,
+        curves are not polynomials and have not the appropriate coefficients.
+    """
+
+    try:
+        # check for nonempty dataframe
+        if isinstance(gencost, pd.DataFrame):
+            _check_data_frame(gencost, "gencost")
+        else:
+            print(gencost)
+            raise TypeError("gencost must be a pandas.DataFrame object")
+
+        # check for proper columns
+        required_columns = ("type", "n")
+        for r in required_columns:
+            if r not in gencost.columns:
+                raise ValueError("gencost must have column " + r)
+
+        # check that gencosts are all specified as type 2 (polynomial)
+        cost_type = gencost["type"]
+        if not cost_type.where(cost_type == 2).equals(cost_type):
+            raise ValueError("each gencost must be type 2 (polynomial)")
+
+        # check that all gencosts are specified as same order polynomial
+        if not (gencost["n"].nunique() == 1):
+            raise ValueError("all polynomials must be of same order")
+
+        # check that this order is an integer > 0
+        n = gencost["n"].iloc[0]
+        if not isinstance(n, (int, np.integer)):
+            raise TypeError("polynomial degree must be specified as an int")
+        if n < 1:
+            raise ValueError("polynomial must be at least of order 1 (constant)")
+
+        # check that the right columns are here for this dataframe
+        coef_columns = ["c" + str(i) for i in range(n)]
+        for c in coef_columns:
+            if c not in gencost.columns:
+                raise ValueError(f"gencost of order {n} must have column {c}")
+    except Exception:
+        if error_messages is not None:
+            error_messages.append(repr(sys.exc_info()[1]))
+        else:
+            raise

--- a/powersimdata/input/tests/test_check.py
+++ b/powersimdata/input/tests/test_check.py
@@ -1,7 +1,115 @@
+import datetime
+
+import numpy as np
+import pandas as pd
 import pytest
 
 from powersimdata import Grid
-from powersimdata.input.check import _check_grid_models_match, check_grid
+from powersimdata.input.check import (
+    _check_areas_and_format,
+    _check_areas_are_in_grid_and_format,
+    _check_data_frame,
+    _check_date,
+    _check_date_range_in_scenario,
+    _check_date_range_in_time_series,
+    _check_epsilon,
+    _check_gencost,
+    _check_grid_models_match,
+    _check_grid_type,
+    _check_number_hours_to_analyze,
+    _check_plants_are_in_grid,
+    _check_resources_and_format,
+    _check_resources_are_in_grid_and_format,
+    _check_resources_are_renewable_and_format,
+    _check_time_series,
+    check_grid,
+)
+from powersimdata.tests.mock_scenario import MockScenario
+
+
+@pytest.fixture
+def mock_plant():
+    return {
+        "plant_id": range(15),
+        "type": [
+            "solar",
+            "nuclear",
+            "wind",
+            "wind_offshore",
+            "coal",
+            "ng",
+            "coal",
+            "coal",
+            "geothermal",
+            "wind",
+            "solar",
+            "hydro",
+            "coal",
+            "ng",
+            "solar",
+        ],
+        "interconnect": ["Western"] * 3 + ["Texas"] * 8 + ["Eastern"] * 4,
+        "zone_name": [
+            "Washington",
+            "El Paso",
+            "Bay Area",
+        ]
+        + [
+            "Far West",
+            "North",
+            "West",
+            "South",
+            "North Central",
+            "South Central",
+            "Coast",
+            "East",
+        ]
+        + ["Kentucky", "Nebraska", "East Texas", "Texas Panhandle"],
+    }
+
+
+@pytest.fixture
+def mock_gencost():
+    return {
+        "plant_id": range(15),
+        "type": [2] * 15,
+        "startup": [0] * 15,
+        "shutdown": [0] * 15,
+        "n": [3] * 15,
+        "c2": [
+            0,
+            0.00021,
+            0,
+            0,
+            0.00125,
+            0.0015,
+            0.00085,
+            0.0009,
+            0,
+            0,
+            0,
+            0,
+            0.0013,
+            0.0011,
+            0,
+        ],
+        "c1": [0, 20, 0, 0, 25, 32, 18, 29, 0, 0, 0, 0, 35, 27, 0],
+        "c0": [0, 888, 0, 0, 750, 633, 599, 933, 0, 0, 0, 0, 1247, 1111, 0],
+        "interconnect": ["Western"] * 15,
+    }
+
+
+@pytest.fixture
+def mock_scenario(mock_plant, mock_gencost):
+    mock_scenario = MockScenario({"plant": mock_plant, "gencost_after": mock_gencost})
+    mock_scenario.info["start_date"] = "2016-01-01 00:00:00"
+    mock_scenario.info["end_date"] = "2016-01-10 23:00:00"
+    return mock_scenario
+
+
+@pytest.fixture
+def mock_grid(mock_scenario):
+    return mock_scenario.get_grid()
 
 
 def test_error_handling():
@@ -29,3 +137,314 @@ def check_grid_models_match_failure():
     grid2.grid_model == "foo"
     with pytest.raises(ValueError):
         _check_grid_models_match(grid1, grid2)
+
+
+def test_check_data_frame_argument_type():
+    arg = (
+        (1, "int"),
+        ("homer", "str"),
+        ({"homer", "marge", "bart", "lida"}, "set"),
+        (pd.DataFrame({"California": [1, 2, 3], "Texas": [4, 5, 6]}), 123456),
+    )
+    for a in arg:
+        with pytest.raises(TypeError):
+            _check_data_frame(a[0], a[1])
+
+
+def test_check_data_frame_argument_value():
+    arg = (
+        (pd.DataFrame({"California": [], "Texas": []}), "row"),
+        (pd.DataFrame({}), "col"),
+    )
+    for a in arg:
+        with pytest.raises(ValueError):
+            _check_data_frame(a[0], a[1])
+
+
+def test_check_data_frame():
+    _check_data_frame(
+        pd.DataFrame({"California": [1, 2, 3], "Texas": [4, 5, 6]}), "pandas.DataFrame"
+    )
+
+
+def test_check_time_series_argument_value():
+    ts = pd.DataFrame({"demand": [200, 100, 10, 75, 150]})
+    with pytest.raises(ValueError):
+        _check_time_series(ts, "demand")
+
+
+def test_check_time_series():
+    ts = pd.DataFrame(
+        {"demand": [200, 100, 10, 75, 150]},
+        index=pd.date_range("2018-01-01", periods=5, freq="H"),
+    )
+    _check_time_series(ts, "demand")
+
+    ts = pd.Series(
+        [200, 100, 10, 75, 150],
+        index=pd.date_range("2018-01-01", periods=5, freq="H"),
+    )
+    _check_time_series(ts, "demand")
+
+
+def test_check_grid_type_failure():
+    arg = (1, pd.DataFrame({"California": [1, 2, 3], "Texas": [4, 5, 6]}))
+    for a in arg:
+        with pytest.raises(TypeError):
+            _check_grid_type(a)
+
+
+def test_check_grid_type_success(mock_grid):
+    _check_grid_type(mock_grid)
+
+
+def test_check_areas_and_format_argument_type():
+    arg = (
+        1,
+        {"California": [1, 2, 3], "Texas": [4, 5, 6]},
+        [1, 2, 3, 4],
+        (1, 2, 3, 4),
+        ("a", "b", "c", 4),
+    )
+    for a in arg:
+        with pytest.raises(TypeError):
+            _check_areas_and_format()
+
+
+def test_check_areas_and_format_argument_value():
+    arg = ([], {"Texas", "Louisane", "Florida", "Canada"}, {"France"})
+    for a in arg:
+        with pytest.raises(ValueError):
+            _check_areas_and_format(a)
+
+
+def test_check_areas_and_format():
+    _check_areas_and_format(["Western", "NY", "El Paso", "Arizona"])
+    areas = _check_areas_and_format(["California", "CA", "NY", "TX", "MT", "WA"])
+    assert areas == {"Washington", "Texas", "Montana", "California", "New York"}
+
+
+def test_check_resources_and_format_argument_type():
+    arg = (
+        1,
+        {"coal": [1, 2, 3], "htdro": [4, 5, 6]},
+        [1, 2, 3, 4],
+        (1, 2, 3, 4),
+        {1, 2, 3, 4},
+        ("a", "b", "c", 4),
+    )
+    for a in arg:
+        with pytest.raises(TypeError):
+            _check_resources_and_format(a)
+
+
+def test_check_resources_and_format_argument_value():
+    arg = ((), {"solar", "nuclear", "ng", "battery"}, {"geo-thermal"})
+    for a in arg:
+        with pytest.raises(ValueError):
+            _check_resources_and_format(a)
+
+
+def test_check_resources_and_format():
+    _check_resources_and_format(["dfo", "wind", "solar", "ng"])
+    _check_resources_and_format("wind_offshore")
+    _check_resources_and_format({"nuclear"})
+
+
+def test_check_resources_are_renewable_and_format_argument_value():
+    with pytest.raises(ValueError):
+        _check_resources_are_renewable_and_format({"solar", "nuclear"})
+
+
+def test_check_resources_are_renewable_and_format():
+    _check_resources_are_renewable_and_format(["wind_offshore", "wind"])
+    _check_resources_are_renewable_and_format("solar")
+    _check_resources_are_renewable_and_format({"wind"})
+
+
+def test_check_areas_are_in_grid_and_format_argument_type(mock_grid):
+    arg = (({"Texas", "El Paso"}, mock_grid), ({123: "Nebraska"}, mock_grid))
+    for a in arg:
+        with pytest.raises(TypeError):
+            _check_areas_are_in_grid_and_format(a[0], a[1])
+
+
+def test_check_areas_are_in_grid_and_format_argument_value(mock_grid):
+    arg = (
+        ({"county": "Kentucky"}, mock_grid),
+        ({"state": "California"}, mock_grid),
+        ({"loadzone": "Texas"}, mock_grid),
+        ({"state": "El Paso"}, mock_grid),
+        ({"interconnect": "Nebraska"}, mock_grid),
+    )
+    for a in arg:
+        with pytest.raises(ValueError):
+            _check_areas_are_in_grid_and_format(a[0], a[1])
+
+
+def test_check_areas_are_in_grid_and_format(mock_grid):
+    assert _check_areas_are_in_grid_and_format(
+        {
+            "state": {"Washington", "Kentucky", "NE", "TX", "WA"},
+            "loadzone": ["Washington", "East", "El Paso", "Bay Area"],
+            "interconnect": "Texas",
+        },
+        mock_grid,
+    ) == {
+        "interconnect": {"Texas"},
+        "state": {"Washington", "Kentucky", "Nebraska", "Texas"},
+        "loadzone": {"Washington", "East", "El Paso", "Bay Area"},
+    }
+
+
+def test_check_resources_are_in_grid_and_format_argument_value(mock_grid):
+    arg = (({"solar", "dfo"}, mock_grid), ({"uranium"}, mock_grid))
+    for a in arg:
+        with pytest.raises(ValueError):
+            _check_resources_are_in_grid_and_format(a[0], a[1])
+
+
+def test_check_resources_are_in_grid_and_format(mock_grid):
+    _check_resources_are_in_grid_and_format({"solar", "coal", "hydro"}, mock_grid)
+    _check_resources_are_in_grid_and_format(
+        ["solar", "ng", "hydro", "nuclear"], mock_grid
+    )
+
+
+def test_check_plants_are_in_grid_argument_type(mock_grid):
+    arg = (
+        (str(mock_grid.plant.index[1]), mock_grid),
+        (mock_grid.plant.index[:3], mock_grid),
+        (mock_grid.plant.index[0], mock_grid.plant),
+    )
+    for a in arg:
+        with pytest.raises(TypeError):
+            _check_plants_are_in_grid(a[0], a[1])
+
+
+def test_check_plants_are_in_grid_argument_value(mock_grid):
+    with pytest.raises(ValueError):
+        _check_plants_are_in_grid(
+            [p + 100 for p in mock_grid.plant.index[-5:]], mock_grid
+        )
+
+
+def test_check_plants_are_in_grid(mock_grid):
+    _check_plants_are_in_grid([p for p in mock_grid.plant.index[:5]], mock_grid)
+    _check_plants_are_in_grid([str(p) for p in mock_grid.plant.index[:5]], mock_grid)
+    _check_plants_are_in_grid(set([p for p in mock_grid.plant.index[:5]]), mock_grid)
+    _check_plants_are_in_grid(tuple([p for p in mock_grid.plant.index[:5]]), mock_grid)
+
+
+def test_check_number_hours_to_analyze_argument_type(mock_scenario):
+    arg = ((mock_scenario, "100"), (mock_scenario, [100]), (mock_scenario, {100, 50}))
+    for a in arg:
+        with pytest.raises(TypeError):
+            _check_number_hours_to_analyze(a[0], a[1])
+
+
+def test_check_number_hours_to_analyze_argument_value(mock_scenario):
+    arg = ((mock_scenario, -10), (mock_scenario, 15 * 24))
+    for a in arg:
+        with pytest.raises(ValueError):
+            _check_number_hours_to_analyze(a[0], a[1])
+
+
+def test_check_number_hours_to_analyze(mock_scenario):
+    _check_number_hours_to_analyze(mock_scenario, 24)
+
+
+def test_check_date_argument_type():
+    with pytest.raises(TypeError):
+        _check_date("2016-02-01 00:00:00")
+
+
+def test_check_date():
+    _check_date(datetime.datetime(2020, 9, 9))
+    _check_date(np.datetime64("1981-06-21"))
+    _check_date(pd.Timestamp(2016, 2, 1))
+
+
+def test_check_date_range_in_scenario_argument_value(mock_scenario):
+    arg = (
+        (mock_scenario, pd.Timestamp(2016, 1, 5), pd.Timestamp(2016, 1, 2)),
+        (mock_scenario, pd.Timestamp(2015, 12, 1), pd.Timestamp(2016, 1, 8)),
+        (mock_scenario, pd.Timestamp(2016, 1, 2), pd.Timestamp(2016, 2, 15)),
+    )
+    for a in arg:
+        with pytest.raises(ValueError):
+            _check_date_range_in_scenario(a[0], a[1], a[2])
+
+
+def test_check_date_range_in_scenario(mock_scenario):
+    _check_date_range_in_scenario(
+        mock_scenario, pd.Timestamp(2016, 1, 2), pd.Timestamp(2016, 1, 7)
+    )
+
+
+def test_check_date_range_in_time_series_argument_value():
+    data = {
+        "A": np.random.randint(0, high=1000, size=366 * 24),
+        "B": np.random.randn(366 * 24),
+    }
+
+    ts = pd.DataFrame(
+        data, index=pd.date_range("2016-01-01", periods=366 * 24, freq="H")
+    )
+
+    arg = (
+        (ts, pd.Timestamp(2016, 5, 5), pd.Timestamp(2016, 3, 28)),
+        (ts, pd.Timestamp(2015, 12, 1), pd.Timestamp(2016, 8, 8)),
+        (ts, pd.Timestamp(2016, 3, 2), pd.Timestamp(2017, 2, 15)),
+    )
+    for a in arg:
+        with pytest.raises(ValueError):
+            _check_date_range_in_time_series(a[0], a[1], a[2])
+
+
+def test_check_epsilon_argument_type():
+    arg = ("1e-3", [0.0001])
+    for a in arg:
+        with pytest.raises(TypeError):
+            _check_epsilon()
+
+
+def test_check_epsilon_argument_value():
+    with pytest.raises(ValueError):
+        _check_epsilon(-0.00001)
+
+
+def test_check_epsilon():
+    _check_epsilon(1e-2)
+    _check_epsilon(0.001)
+
+
+def test_check_gencost_argument_type(mock_grid):
+    gencost_n = mock_grid.gencost["after"].copy()
+    gencost_n.n = gencost_n.n.astype(float)
+    arg = (1, gencost_n)
+    for a in arg:
+        with pytest.raises(TypeError):
+            _check_gencost(a)
+
+
+def test_check_gencost_argument_value(mock_grid):
+    gencost = mock_grid.gencost["after"]
+    gencost_n = mock_grid.gencost["after"].copy()
+    gencost_n.loc[0, "n"] = 10
+    gencost_type = mock_grid.gencost["after"].copy()
+    gencost_type.loc[3, "type"] = 3
+    arg = (
+        gencost.drop(columns=["type"]),
+        gencost.drop(columns=["n"]),
+        gencost_type,
+        gencost_n,
+    )
+    for a in arg:
+        with pytest.raises(ValueError):
+            _check_gencost(a)
+
+
+def test_check_gencost(mock_grid):
+    gencost = mock_grid.gencost["after"]
+    _check_gencost(gencost)

--- a/powersimdata/scenario/check.py
+++ b/powersimdata/scenario/check.py
@@ -1,0 +1,15 @@
+from powersimdata.scenario.analyze import Analyze
+from powersimdata.scenario.scenario import Scenario
+
+
+def _check_scenario_is_in_analyze_state(scenario):
+    """Ensure that scenario is a Scenario object in the analyze state.
+
+    :param powersimdata.scenario.scenario.Scenario scenario: scenario instance.
+    :raises TypeError: if scenario is not a Scenario instance.
+    :raises ValueError: if Scenario object is not in analyze state.
+    """
+    if not isinstance(scenario, Scenario):
+        raise TypeError(f"scenario must be a {Scenario} object")
+    if not isinstance(scenario.state, Analyze):
+        raise ValueError("scenario must in analyze state")

--- a/powersimdata/scenario/tests/test_check.py
+++ b/powersimdata/scenario/tests/test_check.py
@@ -1,0 +1,27 @@
+import pytest
+
+from powersimdata.scenario.check import _check_scenario_is_in_analyze_state
+from powersimdata.tests.mock_scenario import MockScenario
+
+
+@pytest.fixture
+def mock_scenario():
+    return MockScenario()
+
+
+def test_check_scenario_is_in_analyze_state_argument_type():
+    arg = (1, "foo")
+    for a in arg:
+        with pytest.raises(TypeError):
+            _check_scenario_is_in_analyze_state(a)
+
+
+def test_check_scenario_is_in_analyze_state_argument_value():
+    input = MockScenario()
+    input.state = "Create"
+    with pytest.raises(ValueError):
+        _check_scenario_is_in_analyze_state(input)
+
+
+def test_check_scenario_is_in_analyze(mock_scenario):
+    _check_scenario_is_in_analyze_state(mock_scenario)


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
- Add a new module, `powersimdata.design.compare`, to consolidate code which compares Grid data tables.
- In the process of moving code from PostREISE to PowerSimData, move associated check functions which do not depend on PCM outputs.

### What the code is doing
- `powersimdata.design.compare` gets comparison logic that had been performed elsewhere in PowerSimData or PostREISE.
- `powersimdata.design.investment` uses the newly consolidated comparison logic.
- `powersimdata.input.check` and `powersimdata.scenario.check` get the Grid and Scenario check functions (with associated tests).

### Testing
Existing unit tests still pass. The existing comparison logic in PowerSimData was untested, but now has a path to getting tests, since it is separated from the broader investment cost calculations.

### Where to look
The only real new code is in `powersimdata.design.compare.generation`, since it is more robust than what we had before in `calculate_gen_inv_costs`. Everything else is just moved from elsewhere, with references updated.

### Time estimate
15-30 minutes. 
