### PR TITLE
ci: code coverage reporting

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,36 @@
+name: Code coverage
+
+on:
+  push:
+    branches:
+      - 'develop'
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    env:
+      python-version: 3.9
+
+    name: Python ${{ env.python-version }}
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python ${{ env.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ env.python-version }}
+
+      - name: Start postgres container
+        run: |
+          docker-compose -f stack.yml up -d
+          while ! nc -z localhost 5432; do sleep 1; done;
+        working-directory: powersimdata/data_access
+
+      - run: python -m pip install --upgrade pip tox
+      - run: tox -e pytest-ci -- --cov-report=xml
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v1
+        with:
+          name: codecov-powersimdata
+          fail_ci_if_error: true

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ deps =
     flake8: pep8-naming
 commands =
     pytest: pipenv sync --dev
-    ci: pytest -m 'not ssh'
+    ci: pytest -m 'not ssh' {posargs}
     local: pytest -m 'not integration'
     integration: pytest
     format: black .


### PR DESCRIPTION
### Purpose
Upload code coverage report to [codecov.io](https://about.codecov.io/) for each merge to develop branch.

### What the code is doing
Created a separate workflow which is partly duplicated from the test.yml rather than make that more complicated with various conditionals. This keeps the stdout report for per-commit tests but uses the xml report required for uploading to codecov. 

### Testing
Ran the workflow on this branch, and got a report uploaded, which is available [here](https://codecov.io/gh/Breakthrough-Energy/PowerSimData/commit/434a083c7fcf6e75c64cae84a40850ce8ccede73/). The files and graphs tabs are probably the best place to explore.

### Time estimate
10 mins
