### PR TITLE
feat: deduplicate interconnect passed to grid constructor

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,2 @@
 [run]
 branch = True
-omit =
-    **/test_*.py
-    **/__init__.py
-

--- a/powersimdata/input/grid.py
+++ b/powersimdata/input/grid.py
@@ -14,7 +14,7 @@ _cache = MemoryCache()
 class Grid:
     """Grid
 
-    :param str/list/set interconnect: geographical region covered. Either *'USA'*, one of
+    :param str/iterable interconnect: geographical region covered. Either *'USA'*, one of
         the three interconnections, i.e., *'Eastern'*, *'Western'* or *'Texas'* or a
         combination of two interconnections.
     :param str source: model used to build the network.

--- a/powersimdata/input/grid.py
+++ b/powersimdata/input/grid.py
@@ -14,7 +14,7 @@ _cache = MemoryCache()
 class Grid:
     """Grid
 
-    :param str/list interconnect: geographical region covered. Either *'USA'*, one of
+    :param str/list/set interconnect: geographical region covered. Either *'USA'*, one of
         the three interconnections, i.e., *'Eastern'*, *'Western'* or *'Texas'* or a
         combination of two interconnections.
     :param str source: model used to build the network.

--- a/powersimdata/network/usa_tamu/model.py
+++ b/powersimdata/network/usa_tamu/model.py
@@ -77,7 +77,7 @@ class TAMU(AbstractGrid):
 def check_and_format_interconnect(interconnect):
     """Checks interconnect.
 
-    :param str/list/set interconnect: interconnect name(s).
+    :param str/iterable interconnect: interconnect name(s).
     :return: (*list*) -- interconnect(s)
     :raises TypeError: if parameter has wrong type.
     :raises ValueError: if interconnect not found or combination of interconnect is not
@@ -85,10 +85,11 @@ def check_and_format_interconnect(interconnect):
     """
     if isinstance(interconnect, str):
         interconnect = [interconnect]
-    if not isinstance(interconnect, (set, list)):
-        raise TypeError("interconnect must be one of str/list/set")
+    try:
+        interconnect = sorted(set(interconnect))
+    except:  # noqa
+        raise TypeError("interconnect must be either str or an iterable of str")
 
-    interconnect = list(set(interconnect))
     possible = ["Eastern", "Texas", "Western", "USA"]
     if any(i for i in interconnect if i not in possible):
         raise ValueError("Wrong interconnect. Choose from %s" % " | ".join(possible))

--- a/powersimdata/network/usa_tamu/model.py
+++ b/powersimdata/network/usa_tamu/model.py
@@ -77,7 +77,7 @@ class TAMU(AbstractGrid):
 def check_and_format_interconnect(interconnect):
     """Checks interconnect.
 
-    :param str/list interconnect: interconnect name(s).
+    :param str/list/set interconnect: interconnect name(s).
     :return: (*list*) -- interconnect(s)
     :raises TypeError: if parameter has wrong type.
     :raises ValueError: if interconnect not found or combination of interconnect is not
@@ -85,18 +85,14 @@ def check_and_format_interconnect(interconnect):
     """
     if isinstance(interconnect, str):
         interconnect = [interconnect]
-    if not isinstance(interconnect, list):
-        raise TypeError("interconnect must be a str or list of str")
+    if not isinstance(interconnect, (set, list)):
+        raise TypeError("interconnect must be one of str/list/set")
 
+    interconnect = list(set(interconnect))
     possible = ["Eastern", "Texas", "Western", "USA"]
-    for i in interconnect:
-        if i not in possible:
-            raise ValueError(
-                "Wrong interconnect. Choose from %s" % " | ".join(possible)
-            )
+    if any(i for i in interconnect if i not in possible):
+        raise ValueError("Wrong interconnect. Choose from %s" % " | ".join(possible))
     n = len(interconnect)
-    if n > len(set(interconnect)):
-        raise ValueError("List of interconnects contains duplicate values")
     if "USA" in interconnect and n > 1:
         raise ValueError("USA cannot be paired")
     if n == 3:

--- a/powersimdata/network/usa_tamu/tests/test_model.py
+++ b/powersimdata/network/usa_tamu/tests/test_model.py
@@ -3,8 +3,12 @@ import pytest
 from powersimdata.network.usa_tamu.model import TAMU, check_and_format_interconnect
 
 
+def _assert_lists_equal(a, b):
+    assert sorted(a) == sorted(b)
+
+
 def test_interconnect_type():
-    interconnect = {"Western", "Texas"}
+    interconnect = 42
     with pytest.raises(TypeError):
         check_and_format_interconnect(interconnect)
 
@@ -17,10 +21,8 @@ def test_interconnect_value():
 
 def test_interconnect_duplicate_value():
     interconnect = ["Western", "Western", "Texas"]
-    with pytest.raises(
-        ValueError, match="List of interconnects contains duplicate values"
-    ):
-        check_and_format_interconnect(interconnect)
+    result = check_and_format_interconnect(interconnect)
+    _assert_lists_equal(["Western", "Texas"], result)
 
 
 def test_interconnect_usa_is_unique():
@@ -29,37 +31,38 @@ def test_interconnect_usa_is_unique():
         check_and_format_interconnect(interconnect)
 
 
+def test_interconnect_set():
+    result = check_and_format_interconnect({"Texas", "Eastern"})
+    _assert_lists_equal(["Eastern", "Texas"], result)
+
+
 def test_interconnect():
     arg = ("Western", ["Eastern", "Western"])
     expected = (["Western"], ["Eastern", "Western"])
     for a, e in zip(arg, expected):
-        assert check_and_format_interconnect(a) == e
+        _assert_lists_equal(check_and_format_interconnect(a), e)
+
+
+def _assert_interconnect_missing(interconnect, model):
+    assert interconnect not in model.sub.interconnect.unique()
+    assert interconnect not in model.bus2sub.interconnect.unique()
+    assert interconnect not in model.bus.interconnect.unique()
+    assert interconnect not in model.plant.interconnect.unique()
+    assert interconnect not in model.branch.interconnect.unique()
+    assert interconnect not in model.gencost["before"].interconnect.unique()
+    assert interconnect not in model.gencost["after"].interconnect.unique()
+    assert interconnect not in model.dcline.from_interconnect.unique()
+    assert interconnect not in model.dcline.to_interconnect.unique()
 
 
 def test_drop_one_interconnect():
     model = TAMU(["Western", "Texas"])
-    assert model.interconnect == ["Western", "Texas"]
-    assert "eastern" not in model.sub.interconnect.unique()
-    assert "eastern" not in model.bus2sub.interconnect.unique()
-    assert "eastern" not in model.bus.interconnect.unique()
-    assert "eastern" not in model.plant.interconnect.unique()
-    assert "eastern" not in model.branch.interconnect.unique()
-    assert "eastern" not in model.gencost["before"].interconnect.unique()
-    assert "eastern" not in model.gencost["after"].interconnect.unique()
-    assert "eastern" not in model.dcline.from_interconnect.unique()
-    assert "eastern" not in model.dcline.to_interconnect.unique()
+    _assert_lists_equal(["Western", "Texas"], model.interconnect)
+    _assert_interconnect_missing("Eastern", model)
 
 
 def test_drop_two_interconnect():
     model = TAMU(["Western"])
-    assert model.interconnect == ["Western"]
+    _assert_lists_equal(["Western"], model.interconnect)
     for interconnect in ["Eastern", "Texas"]:
-        assert interconnect not in model.sub.interconnect.unique()
-        assert interconnect not in model.bus2sub.interconnect.unique()
-        assert interconnect not in model.bus.interconnect.unique()
-        assert interconnect not in model.plant.interconnect.unique()
-        assert interconnect not in model.branch.interconnect.unique()
-        assert interconnect not in model.gencost["before"].interconnect.unique()
-        assert interconnect not in model.gencost["after"].interconnect.unique()
-        assert interconnect not in model.dcline.from_interconnect.unique()
-        assert interconnect not in model.dcline.to_interconnect.unique()
+        _assert_interconnect_missing(interconnect, model)

--- a/powersimdata/network/usa_tamu/tests/test_model.py
+++ b/powersimdata/network/usa_tamu/tests/test_model.py
@@ -31,8 +31,11 @@ def test_interconnect_usa_is_unique():
         check_and_format_interconnect(interconnect)
 
 
-def test_interconnect_set():
+def test_interconnect_iterable():
     result = check_and_format_interconnect({"Texas", "Eastern"})
+    _assert_lists_equal(["Eastern", "Texas"], result)
+
+    result = check_and_format_interconnect(("Texas", "Eastern"))
     _assert_lists_equal(["Eastern", "Texas"], result)
 
 


### PR DESCRIPTION
### Purpose
Improve experience of using the grid object by allowing users to provide interconnects as a `set`, and removing duplicates if a `list` is provided. Basically, eliminating the requirement of calling code to do `Grid(list(set(interconnect)))`.

### What the code is doing
Described above, and some test updates. Also, include tests in code coverage report.

### Testing
There are good unit tests already, just modified as needed.

### Usage Example/Visuals
```
In [1]: from powersimdata import Grid

In [2]: Grid({'Eastern', 'Texas'})
Reading bus.csv
Reading plant.csv
Reading gencost.csv
Reading branch.csv
Reading dcline.csv
Reading sub.csv
Reading bus2sub.csv
Reading zone.csv
Out[2]: <powersimdata.input.grid.Grid at 0x10f376cd0>

In [3]: Grid(['Texas', 'Texas'])
Reading bus.csv
Reading plant.csv
Reading gencost.csv
Reading branch.csv
Reading dcline.csv
Reading sub.csv
Reading bus2sub.csv
Reading zone.csv
Out[3]: <powersimdata.input.grid.Grid at 0x10f376df0>

In [4]: grid = _

In [5]: grid.interconnect
Out[5]: ['Texas']
```

### Time estimate
10 min
