### PR TITLE
refactor: move PostREISE helper functions to PowerSimData

### DIFF
--- a/powersimdata/input/check.py
+++ b/powersimdata/input/check.py
@@ -5,7 +5,8 @@ import networkx as nx
 import numpy as np
 import pandas as pd
 
-from powersimdata.input.grid import Grid
+# Importing the module, not anything in it, to avid a circular import
+import powersimdata.input.grid as _grid
 from powersimdata.network.model import ModelImmutables
 
 
@@ -281,8 +282,8 @@ def _check_grid_type(grid):
     :param powersimdata.input.grid.Grid grid: a Grid instance.
     :raises TypeError: if input is not a Grid instance.
     """
-    if not isinstance(grid, Grid):
-        raise TypeError(f"grid must be a {Grid} object")
+    if not isinstance(grid, _grid.Grid):
+        raise TypeError(f"grid must be a {_grid.Grid} object")
 
 
 def _check_areas_and_format(areas, grid_model="usa_tamu"):

--- a/powersimdata/input/check.py
+++ b/powersimdata/input/check.py
@@ -41,7 +41,7 @@ def check_grid(grid):
             _check_gencost(grid.gencost[gencost_key], error_messages)
         except Exception:
             error_messages.append(
-                f"Exception during {check.__name__} {gencost_key}: "
+                f"Exception during _check_gencost: {gencost_key}: "
                 f"{sys.exc_info()[1]!r}"
             )
     if len(error_messages) > 0:

--- a/powersimdata/input/helpers.py
+++ b/powersimdata/input/helpers.py
@@ -1,6 +1,16 @@
 import os
+from collections import defaultdict
 
 import pandas as pd
+
+from powersimdata.input.check import (
+    _check_areas_are_in_grid_and_format,
+    _check_data_frame,
+    _check_grid_type,
+    _check_plants_are_in_grid,
+    _check_resources_are_in_grid_and_format,
+)
+from powersimdata.network.model import area_to_loadzone
 
 
 def csv_to_data_frame(data_loc, filename):
@@ -120,3 +130,322 @@ def add_interconnect_to_grid_data_frames(grid):
         "to_interconnect": get_interconnect(grid.dcline.to_bus_id),
     }
     add_column_to_data_frame(grid.dcline, extra_col_dcline)
+
+
+def get_resources_in_grid(grid):
+    """Get resources in grid.
+
+    :param powersimdata.input.grid.Grid grid: a Grid instance.
+    :return: (*set*) -- name of all resources in grid.
+    """
+    _check_grid_type(grid)
+    resources = set(grid.plant["type"].unique())
+    return resources
+
+
+def get_active_resources_in_grid(grid):
+    """Get active resources in grid.
+
+    :param powersimdata.input.grid.Grid grid: a Grid instance.
+    :return: (*set*) -- name of active resources in grid.
+    """
+    _check_grid_type(grid)
+    active_resources = set(grid.plant.loc[grid.plant["Pmax"] > 0].type.unique())
+    return active_resources
+
+
+def get_plant_id_for_resources(resources, grid):
+    """Get plant id for plants fueled by resource(s).
+
+    :param str/list/tuple/set resources: name of resource(s).
+    :param powersimdata.input.grid.Grid grid: Grid instance.
+    :return: (*set*) -- list of plant id.
+    """
+    resources = _check_resources_are_in_grid_and_format(resources, grid)
+    plant = grid.plant
+    plant_id = plant[(plant.type.isin(resources))].index
+    return set(plant_id)
+
+
+def get_plant_id_in_loadzones(loadzones, grid):
+    """Get plant id for plants in loadzone(s).
+
+    :param str/list/tuple/set loadzones: name of load zone(s).
+    :param powersimdata.input.grid.Grid grid: Grid instance.
+    :return: (*set*) -- list of plant id.
+    """
+    areas = _check_areas_are_in_grid_and_format({"loadzone": loadzones}, grid)
+    plant = grid.plant
+    plant_id = plant[(plant.zone_name.isin(areas["loadzone"]))].index
+    return set(plant_id)
+
+
+def get_plant_id_in_interconnects(interconnects, grid):
+    """Get plant id for plants in interconnect(s).
+
+    :param str/list/tuple/set interconnects: name of interconnect(s).
+    :param powersimdata.input.grid.Grid grid: Grid instance.
+    :return: (*set*) -- list of plant id
+    """
+    areas = _check_areas_are_in_grid_and_format({"interconnect": interconnects}, grid)
+    loadzones = set.union(
+        *(
+            grid.model_immutables.zones["interconnect2loadzone"][i]
+            for i in areas["interconnect"]
+        )
+    )
+
+    plant = grid.plant
+    plant_id = plant[(plant.zone_name.isin(loadzones))].index
+    return set(plant_id)
+
+
+def get_plant_id_in_states(states, grid):
+    """Get plant id for plants in state(s).
+
+    :param str/list/tuple/set states: states(s) name or abbreviation(s).
+    :param powersimdata.input.grid.Grid grid: Grid instance.
+    :return: (*set*) -- list of plant id.
+    """
+    areas = _check_areas_are_in_grid_and_format({"state": states}, grid)
+    loadzones = set.union(
+        *(grid.model_immutables.zones["state2loadzone"][i] for i in areas["state"])
+    )
+
+    plant = grid.plant
+    plant_id = plant[(plant.zone_name.isin(loadzones))].index
+    return set(plant_id)
+
+
+def get_plant_id_for_resources_in_loadzones(resources, loadzones, grid):
+    """Get plant id for plants fueled by resource(s) in load zone(s).
+
+    :param str/list/tuple/set resources: name of resource(s).
+    :param str/list/tuple/set loadzones: name of load zone(s).
+    :param powersimdata.input.grid.Grid grid: a Grid instance.
+    :return: (*set*) -- list of plant id.
+    """
+    plant_id = get_plant_id_for_resources(resources, grid) & get_plant_id_in_loadzones(
+        loadzones, grid
+    )
+    return set(plant_id)
+
+
+def get_plant_id_for_resources_in_interconnects(resources, interconnects, grid):
+    """Get plant id for for plants fueled by resource(s) in interconnect(s).
+
+    :param str/list/tuple/set resources: name of resource(s).
+    :param str/list/tuple/set interconnects: name of interconnect(s).
+    :param powersimdata.input.grid.Grid grid: a Grid instance.
+    :return: (*set*) -- list of plant id.
+    """
+    plant_id = get_plant_id_for_resources(
+        resources, grid
+    ) & get_plant_id_in_interconnects(interconnects, grid)
+    return set(plant_id)
+
+
+def get_plant_id_for_resources_in_states(resources, states, grid):
+    """Get plant id for for plants fueled by resource(s) in state(s).
+
+    :param str/list/tuple/set resources: name of resource(s).
+    :param str/list/tuple/set states: state(s) name or abbreviation.
+    :param powersimdata.input.grid.Grid grid: a Grid instance.
+    :return: (*set*) -- list of plant id
+    """
+    plant_id = get_plant_id_for_resources(resources, grid) & get_plant_id_in_states(
+        states, grid
+    )
+    return set(plant_id)
+
+
+def decompose_plant_data_frame_into_resources(df, resources, grid):
+    """Take a plant-column data frame and decompose it into plant-column data frames
+    for each resource.
+
+    :param pandas.DataFrame df: data frame, columns are plant id in grid.
+    :param str/list/tuple/set resources: resource(s) to use for decomposition.
+    :param powersimdata.input.grid.Grid grid: Grid instance.
+    :return: (*dict*) -- keys are resources, values are plant-column data frames.
+    """
+    _check_data_frame(df, "PG")
+    plant_id = set(df.columns)
+    _check_plants_are_in_grid(plant_id, grid)
+    resources = _check_resources_are_in_grid_and_format(resources, grid)
+
+    df_resources = {
+        r: df[get_plant_id_for_resources(r, grid) & plant_id].sort_index(axis=1)
+        for r in resources
+    }
+    return df_resources
+
+
+def decompose_plant_data_frame_into_areas(df, areas, grid):
+    """Take a plant-column data frame and decompose it into plant-column data frames
+    for areas.
+
+    :param pandas.DataFrame df: data frame, columns are plant id in grid.
+    :param dict areas: areas to use for decomposition. Keys are area types
+        ('*loadzone*', '*state*', or '*interconnect*'), values are
+        str/list/tuple/set of areas.
+    :param powersimdata.input.grid.Grid grid: Grid instance.
+    :return: (*dict*) -- keys are areas, values are plant-column data frames.
+    """
+    _check_data_frame(df, "PG")
+    plant_id = set(df.columns)
+    _check_plants_are_in_grid(plant_id, grid)
+    areas = _check_areas_are_in_grid_and_format(areas, grid)
+
+    df_areas = {}
+    for k, v in areas.items():
+        if k == "interconnect":
+            for i in v:
+                name = "%s interconnect" % " - ".join(i.split("_"))
+                df_areas[name] = df[get_plant_id_in_interconnects(i, grid) & plant_id]
+        elif k == "state":
+            for s in v:
+                df_areas[s] = df[get_plant_id_in_states(s, grid) & plant_id]
+        elif k == "loadzone":
+            for l in v:
+                df_areas[l] = df[get_plant_id_in_loadzones(l, grid) & plant_id]
+
+    return df_areas
+
+
+def decompose_plant_data_frame_into_areas_and_resources(df, areas, resources, grid):
+    """Take a plant-column data frame and decompose it into plant-column data frames
+    for each resources-areas combinations.
+
+    :param pandas.DataFrame df: data frame, columns are plant id in grid.
+    :param dict areas: areas to use for decomposition. Keys are area types
+        ('*loadzone*', '*state*' or '*interconnect*'), values are
+        str/list/tuple/set of areas.
+    :param str/list/tuple/set resources: resource(s) to use for decomposition.
+    :param powersimdata.input.grid.Grid grid: Grid instance.
+    :return: (*dict*) -- keys are areas, values are dictionaries whose keys are
+        resources and values are data frames indexed by (datetime, plant) where plant
+        include only plants of matching type and located in area.
+    """
+    resources = _check_resources_are_in_grid_and_format(resources, grid)
+    df_areas_resources = {
+        a: decompose_plant_data_frame_into_resources(df_a, resources, grid)
+        for a, df_a in decompose_plant_data_frame_into_areas(df, areas, grid).items()
+    }
+
+    return df_areas_resources
+
+
+def decompose_plant_data_frame_into_resources_and_areas(df, resources, areas, grid):
+    """Take a plant-column data frame and decompose it into plant-column data frames
+    for each resources-areas combinations.
+
+    :param pandas.DataFrame df: data frame, columns are plant id in grid.
+    :param str/list/tuple/set resources: resource(s) to use for decomposition.
+    :param dict areas: areas to use for decomposition. Keys are area types
+        ('*loadzone*', '*state*', '*state_abv*' or '*interconnect*'), values are
+        str/list/tuple/set of areas.
+    :param powersimdata.input.grid.Grid grid: Grid instance.
+    :return: (*dict*) -- keys are resources, values are dictionaries whose keys are
+        areas and values are data frames indexed by (datetime, plant) where plant
+        include only plants of matching type and located in area.
+    """
+    resources_areas = defaultdict(dict)
+
+    areas_resources = decompose_plant_data_frame_into_areas_and_resources(
+        df, areas, resources, grid
+    )
+    for a in areas_resources.keys():
+        for r in areas_resources[a].keys():
+            resources_areas[r].update({a: areas_resources[a][r]})
+
+    return resources_areas
+
+
+def summarize_plant_to_bus(df, grid, all_buses=False):
+    """Take a plant-column data frame and sum to a bus-column data frame.
+
+    :param pandas.DataFrame df: dataframe, columns are plant id in grid.
+    :param powersimdata.input.grid.Grid grid: Grid instance.
+    :param boolean all_buses: return all buses in grid, not just plant buses.
+    :return: (*pandas.DataFrame*) -- index as df input, columns are buses.
+    """
+    _check_data_frame(df, "PG")
+    _check_grid_type(grid)
+    _check_plants_are_in_grid(df.columns.to_list(), grid)
+
+    all_buses_in_grid = grid.plant["bus_id"]
+    buses_in_df = all_buses_in_grid.loc[df.columns]
+    bus_data = df.T.groupby(buses_in_df).sum().T
+    if all_buses:
+        bus_data = pd.DataFrame(
+            bus_data, columns=grid.bus.index, index=df.index
+        ).fillna(0.0)
+
+    return bus_data
+
+
+def summarize_plant_to_location(df, grid):
+    """Take a plant-column data frame and sum to a location-column data frame.
+
+    :param pandas.DataFrame df: dataframe, columns are plant id in grid.
+    :param powersimdata.input.grid.Grid grid: Grid instance.
+    :return: (*pandas.DataFrame*) -- index: df index, columns: location tuples.
+    """
+    _check_data_frame(df, "PG")
+    _check_grid_type(grid)
+    _check_plants_are_in_grid(df.columns.to_list(), grid)
+
+    all_locations = grid.plant[["lat", "lon"]]
+    locations_in_df = all_locations.loc[df.columns].to_records(index=False)
+    location_data = df.groupby(locations_in_df, axis=1).sum()
+
+    return location_data
+
+
+def get_plant_id_for_resources_in_area(scenario, area, resources, area_type=None):
+    """Get the list of plant ids of certain resources in the specific area of a
+    scenario.
+
+    :param powersimdata.scenario.scenario.Scenario scenario: scenario instance
+    :param str area: one of *loadzone*, *state*, *state abbreviation*,
+        *interconnect*, *'all'*
+    :param str/list resources: one or a list of resources
+    :param str area_type: one of *'loadzone'*, *'state'*, *'state_abbr'*,
+        *'interconnect'*
+    :return: (*list*) -- list of plant id
+    """
+    resource_set = set([resources]) if isinstance(resources, str) else set(resources)
+    grid = scenario.state.get_grid()
+    loadzone_set = area_to_loadzone(
+        scenario.info["grid_model"], area, area_type=area_type
+    )
+    plant_id = grid.plant[
+        (grid.plant["zone_name"].isin(loadzone_set))
+        & (grid.plant["type"].isin(resource_set))
+    ].index.tolist()
+
+    return plant_id
+
+
+def get_storage_id_in_area(scenario, area, area_type=None):
+    """Get the list of storage ids in the specific area of a scenario
+
+    :param powersimdata.scenario.scenario.Scenario scenario: scenario instance
+    :param str area: one of *loadzone*, *state*, *state abbreviation*,
+        *interconnect*, *'all'*
+    :param str area_type: one of *'loadzone'*, *'state'*, *'state_abbr'*,
+        *'interconnect'*
+    :return: (*list*) -- list of storage id
+    """
+    grid = scenario.state.get_grid()
+    loadzone_set = area_to_loadzone(
+        scenario.info["grid_model"], area, area_type=area_type
+    )
+    loadzone_id_set = {grid.zone2id[lz] for lz in loadzone_set if lz in grid.zone2id}
+
+    gen = grid.storage["gen"]
+    storage_id = gen.loc[
+        gen["bus_id"].apply(lambda x: grid.bus.loc[x, "zone_id"]).isin(loadzone_id_set)
+    ].index.tolist()
+
+    return storage_id

--- a/powersimdata/input/tests/test_helpers.py
+++ b/powersimdata/input/tests/test_helpers.py
@@ -1,0 +1,377 @@
+import unittest
+
+import pandas as pd
+import pytest
+from numpy.testing import assert_array_almost_equal, assert_array_equal
+
+from powersimdata.input.grid import Grid
+from powersimdata.input.helpers import (
+    get_active_resources_in_grid,
+    get_plant_id_for_resources,
+    get_plant_id_for_resources_in_area,
+    get_plant_id_for_resources_in_interconnects,
+    get_plant_id_for_resources_in_loadzones,
+    get_plant_id_for_resources_in_states,
+    get_plant_id_in_interconnects,
+    get_plant_id_in_loadzones,
+    get_plant_id_in_states,
+    get_resources_in_grid,
+    get_storage_id_in_area,
+    summarize_plant_to_bus,
+    summarize_plant_to_location,
+)
+from powersimdata.tests.mock_grid import MockGrid
+from powersimdata.tests.mock_scenario import MockScenario
+
+# plant_id is the index
+mock_plant = {
+    "plant_id": ["A", "B", "C", "D"],
+    "bus_id": [1, 1, 2, 3],
+    "lat": [47.6, 47.6, 37.8, 37.8],
+    "lon": [-122.3, -122.3, -122.4, -122.4],
+    "type": ["coal", "ng", "coal", "solar"],
+    "Pmin": [0, 50, 0, 0],
+    "Pmax": [0, 300, 0, 50],
+    "zone_name": ["Washington", "Washington", "Bay Area", "Bay Area"],
+}
+
+# bus_id is the index
+mock_bus = {
+    "bus_id": [1, 2, 3, 4],
+    "lat": [47.6, 37.8, 37.8, 40.7],
+    "lon": [-122.3, -122.4, -122.4, -74],
+    "zone_id": [201, 204, 204, 7],
+}
+
+mock_pg = pd.DataFrame(
+    {
+        "A": [1, 2, 3, 4],
+        "B": [1, 2, 4, 8],
+        "C": [1, 1, 2, 3],
+        "D": [1, 3, 5, 7],
+    }
+)
+
+mock_storage = {
+    "bus_id": [1, 2, 3],
+    "Pmax": [10, 10, 10],
+}
+
+grid_attrs = {"plant": mock_plant, "bus": mock_bus, "storage_gen": mock_storage}
+scenario = MockScenario(grid_attrs)
+scenario.state.grid.zone2id = {
+    "Washington": 201,
+    "Bay Area": 204,
+    "New York City": 7,
+}
+
+
+def check_dataframe_matches(received_return, expected_return):
+    assert isinstance(received_return, pd.DataFrame)
+    assert_array_equal(
+        received_return.index.to_numpy(), expected_return.index.to_numpy()
+    )
+    assert_array_equal(
+        received_return.columns.to_numpy(), expected_return.columns.to_numpy()
+    )
+    assert_array_almost_equal(received_return.to_numpy(), expected_return.to_numpy())
+
+
+class TestSummarizePlantToBus(unittest.TestCase):
+    def setUp(self):
+        self.grid = MockGrid(grid_attrs)
+
+    def test_summarize_default(self):
+        expected_return = pd.DataFrame(
+            {
+                1: [2, 4, 7, 12],
+                2: [1, 1, 2, 3],
+                3: [1, 3, 5, 7],
+            }
+        )
+        bus_data = summarize_plant_to_bus(mock_pg, self.grid)
+        check_dataframe_matches(bus_data, expected_return)
+
+    def test_summarize_all_buses_false(self):
+        expected_return = pd.DataFrame(
+            {
+                1: [2, 4, 7, 12],
+                2: [1, 1, 2, 3],
+                3: [1, 3, 5, 7],
+            }
+        )
+        bus_data = summarize_plant_to_bus(mock_pg, self.grid, all_buses=False)
+        check_dataframe_matches(bus_data, expected_return)
+
+    def test_summarize_all_buses_true(self):
+        expected_return = pd.DataFrame(
+            {
+                1: [2, 4, 7, 12],
+                2: [1, 1, 2, 3],
+                3: [1, 3, 5, 7],
+                4: [0, 0, 0, 0],
+            }
+        )
+        bus_data = summarize_plant_to_bus(mock_pg, self.grid, all_buses=True)
+        check_dataframe_matches(bus_data, expected_return)
+
+
+class TestSummarizePlantToLocation(unittest.TestCase):
+    def setUp(self):
+        self.grid = MockGrid(grid_attrs)
+
+    def _check_dataframe_matches(self, loc_data, expected_return):
+        self.assertIsInstance(loc_data, pd.DataFrame)
+        assert_array_equal(loc_data.index.to_numpy(), expected_return.index.to_numpy())
+        self.assertEqual(
+            set(loc_data.columns.to_numpy()), set(expected_return.columns.to_numpy())
+        )
+        for c in loc_data.columns:
+            assert_array_almost_equal(
+                loc_data[c].to_numpy(), expected_return[c].to_numpy()
+            )
+
+    def test_summarize_location(self):
+        expected_return = pd.DataFrame(
+            {
+                (47.6, -122.3): [2, 4, 7, 12],
+                (37.8, -122.4): [2, 4, 7, 10],
+            }
+        )
+        loc_data = summarize_plant_to_location(mock_pg, self.grid)
+        self._check_dataframe_matches(loc_data, expected_return)
+
+
+class TestResourcesInGrid(unittest.TestCase):
+    def setUp(self):
+        self.grid = MockGrid(grid_attrs)
+
+    def test_get_resources_in_grid(self):
+        assert get_resources_in_grid(self.grid) == {"ng", "coal", "solar"}
+
+    def test_get_active_resources_in_grid(self):
+        assert get_active_resources_in_grid(self.grid) == {"ng", "solar"}
+
+
+@pytest.fixture(scope="module")
+def grid():
+    return Grid(["USA"])
+
+
+def test_get_plant_id_for_resources_argument_type(grid):
+    arg = ((1, grid), ([1, 2, 3], grid), ("nuclear", 1))
+    for a in arg:
+        with pytest.raises(TypeError):
+            get_plant_id_for_resources(a[0], a[1])
+
+
+def test_get_plant_id_for_resources_argument_value(grid):
+    arg = (("uranium", grid), (["uranium", "plutonium"], grid))
+    for a in arg:
+        with pytest.raises(ValueError):
+            get_plant_id_for_resources(a[0], a[1])
+
+
+def test_get_plant_id_for_resources(grid):
+    arg = (("nuclear", grid), (["solar", "ng"], grid))
+    expected = (["nuclear"], ["solar", "ng"])
+    for a, e in zip(arg, expected):
+        plant_id = get_plant_id_for_resources(a[0], a[1])
+        assert set(grid.plant.loc[plant_id].type) == set(e)
+
+
+def test_get_plant_id_in_loadzones_argument_type(grid):
+    arg = ((1, grid), ([1, 2, 3], grid), ("Nevada", 1), ("Far West", 1))
+    for a in arg:
+        with pytest.raises(TypeError):
+            get_plant_id_in_loadzones(a[0], a[1])
+
+
+def test_get_plant_id_in_loadzones_argument_value(grid):
+    arg = (("France", grid), (["Alberta", "British Columbia"], grid))
+    for a in arg:
+        with pytest.raises(ValueError):
+            get_plant_id_in_loadzones(a[0], a[1])
+
+
+def test_get_plant_id_in_loadzones(grid):
+    arg = (("Oregon", grid), (["Kentucky", "Montana Western", "El Paso"], grid))
+    expected = (["Oregon"], ["Kentucky", "Montana Western", "El Paso"])
+    for a, e in zip(arg, expected):
+        plant_id = get_plant_id_in_loadzones(a[0], a[1])
+        assert set(grid.plant.loc[plant_id].zone_name) == set(e)
+
+
+def test_get_plant_id_in_interconnects_argument_type(grid):
+    arg = ((1, grid), ([1, 2, 3], grid), ("Eastern", 1))
+    for a in arg:
+        with pytest.raises(TypeError):
+            get_plant_id_in_interconnects(a[0], a[1])
+
+
+def test_get_plant_id_in_interconnects_argument_value(grid):
+    arg = (("ERCOT", grid), (["CAISO", "Western"], grid))
+    for a in arg:
+        with pytest.raises(ValueError):
+            get_plant_id_in_interconnects(a[0], a[1])
+
+
+def test_get_plant_id_in_interconnects(grid):
+    arg = (("Western", grid), (["Texas_Western", "Eastern"], grid))
+    expected = (["Western"], ["Texas", "Western", "Eastern"])
+    for a, e in zip(arg, expected):
+        plant_id = get_plant_id_in_interconnects(a[0], a[1])
+        assert set(grid.plant.loc[plant_id].interconnect) == set(e)
+
+
+def test_get_plant_id_in_states_argument_type(grid):
+    arg = ((1, grid), ([1, 2, 3], grid), ("California", 1))
+    for a in arg:
+        with pytest.raises(TypeError):
+            get_plant_id_in_states(a[0], a[1])
+
+
+def test_get_plant_id_in_states_argument_value(grid):
+    arg = (("Western", grid), (["Far West", "New Mexico Eastern"], grid))
+    for a in arg:
+        with pytest.raises(ValueError):
+            get_plant_id_in_states(a[0], a[1])
+
+
+def test_get_plant_id_in_states(grid):
+    arg = (("TX", grid), (["Washington", "OR", "Idaho"], grid))
+    expected = (({44, 45, 216} | set(range(301, 309))), {201, 202, 214})
+    for a, e in zip(arg, expected):
+        plant_id = get_plant_id_in_states(a[0], a[1])
+        assert set(grid.plant.loc[plant_id].zone_id) == e
+
+
+def test_get_plant_id_for_resources_in_loadzones_argument_type(grid):
+    arg = ((1, 1, grid), ([1, 2, 3], {4, 5, 5}, grid), ("solar", "Utah", 1))
+    for a in arg:
+        with pytest.raises(TypeError):
+            get_plant_id_for_resources_in_loadzones(a[0], a[1], a[2])
+
+
+def test_get_plant_id_for_resources_in_loadzones_argument_value(grid):
+    arg = (
+        (["solar", "hydro", "wind"], "Western", grid),
+        ("plutonium", "Kentucky", grid),
+    )
+    for a in arg:
+        with pytest.raises(ValueError):
+            get_plant_id_for_resources_in_loadzones(a[0], a[1], a[2])
+
+
+def test_get_plant_id_for_resources_in_loadzones(grid):
+    arg = (
+        ("solar", ["Utah", "Montana Western"], grid),
+        (["nuclear", "wind"], ["Colorado", "El Paso"], grid),
+        (["wind", "solar"], "Oregon", grid),
+        (["coal", "ng"], ["South Carolina", "Ohio River", "Maine"], grid),
+    )
+    expected = (
+        (["solar"], ["Utah"]),
+        (["wind"], ["Colorado"]),
+        (["wind", "solar"], ["Oregon"]),
+        (["coal", "ng"], ["South Carolina", "Ohio River", "Maine"]),
+    )
+    for a, e in zip(arg, expected):
+        plant_id = get_plant_id_for_resources_in_loadzones(a[0], a[1], a[2])
+        assert set(grid.plant.loc[plant_id].type) == set(e[0])
+        assert set(grid.plant.loc[plant_id].zone_name) == set(e[1])
+
+
+def test_get_plant_id_for_resources_in_interconnects_argument_type(grid):
+    arg = (
+        (1, 1, grid),
+        ([1, 2, 3], {4, 5, 5}, grid),
+        (["solar", "ng", "gothermal"], "Texas_Western", 1),
+    )
+    for a in arg:
+        with pytest.raises(TypeError):
+            get_plant_id_for_resources_in_interconnects(a[0], a[1], a[2])
+
+
+def test_get_plant_id_for_resources_in_interconnects_argument_value(grid):
+    arg = (
+        (["nuclear", "hydro"], "coal", grid),
+        (["plutonium", "coal"], ["Eastern", "Texas"], grid),
+    )
+    for a in arg:
+        with pytest.raises(ValueError):
+            get_plant_id_for_resources_in_interconnects(a[0], a[1], a[2])
+
+
+def test_get_plant_id_for_resources_in_interconnects(grid):
+    arg = (
+        ("solar", ["Western"], grid),
+        (["nuclear", "wind"], ["Texas_Western"], grid),
+        (["geothermal"], ["Western", "Eastern"], grid),
+    )
+    expected = (
+        (["solar"], ["Western"]),
+        (["nuclear", "wind"], ["Texas", "Western"]),
+        (["geothermal"], ["Western"]),
+    )
+    for a, e in zip(arg, expected):
+        plant_id = get_plant_id_for_resources_in_interconnects(a[0], a[1], a[2])
+        assert set(grid.plant.loc[plant_id].type) == set(e[0])
+        assert set(grid.plant.loc[plant_id].interconnect) == set(e[1])
+
+
+def test_get_plant_id_for_resources_in_states_argument_type(grid):
+    arg = (
+        (1, 1, grid),
+        ([1, 2, 3], {4, 5, 5}, grid),
+        (["solar", "ng", "gothermal"], ["New Mexico", "California"], 1),
+    )
+    for a in arg:
+        with pytest.raises(TypeError):
+            get_plant_id_for_resources_in_states(a[0], a[1], a[2])
+
+
+def test_get_plant_id_for_resources_in_states_argument_value(grid):
+    arg = (
+        (["nuclear", "hydro"], "Eastern", grid),
+        (["plutonium", "coal"], ["Illinois", "FL"], grid),
+    )
+    for a in arg:
+        with pytest.raises(ValueError):
+            get_plant_id_for_resources_in_states(a[0], a[1], a[2])
+
+
+def test_get_plant_id_for_resources_in_states(grid):
+    arg = (
+        (["solar", "wind", "nuclear"], ["California", "TX"], grid),
+        (["nuclear", "wind"], ["Washington"], grid),
+        (["geothermal"], ["Nevada", "Massachusetts", "Mississippi"], grid),
+    )
+    expected = (
+        (
+            ["solar", "wind", "nuclear"],
+            set(range(203, 208)) | {44, 45, 216} | set(range(301, 309)),
+        ),
+        (["nuclear", "wind"], [201]),
+        (["geothermal"], [208]),
+    )
+    for a, e in zip(arg, expected):
+        plant_id = get_plant_id_for_resources_in_states(a[0], a[1], a[2])
+        assert set(grid.plant.loc[plant_id].type) == set(e[0])
+        assert set(grid.plant.loc[plant_id].zone_id) == set(e[1])
+
+
+def test_get_plant_id_for_resources_in_area():
+    arg = [(scenario, "Washington", "coal"), (scenario, "all", "coal")]
+    expected = [["A"], ["A", "C"]]
+    for a, e in zip(arg, expected):
+        plant_id = get_plant_id_for_resources_in_area(*a)
+        assert e == plant_id
+
+
+def test_get_storage_id_in_area():
+    arg = [(scenario, "Bay Area"), (scenario, "all")]
+    expected = [[1, 2], [0, 1, 2]]
+    for a, e in zip(arg, expected):
+        storage_id = get_storage_id_in_area(*a)
+        assert e == storage_id


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
We are moving helper functions from PostREISE to PowerSimData. This is motivated by conversation in https://github.com/Breakthrough-Energy/PostREISE/pull/310; we were discussing the companion PR to #507, which did the same thing for check functions, and we noticed that there is another module that doesn't need to be PostREISE-specific.

### What the code is doing
Most of the changes are straight copy/paste from `postreise.analyze.helpers`. The exception is in **powersimdata/input/check.py**, in which we move the import of the Grid object into the `_check_grid_type` function to avoid a circular import (since the `powersimdata.input.grid` module imports `powersimdata.input.helpers` which now imports `powersimdata.input.check`).

### Testing
All unit tests, including the ones copied from PostREISE, still pass.

### Time estimate
15 minutes.