### PR TITLE
chore: fix N818 warning from pep8-naming

### DIFF
--- a/powersimdata/data_access/sql_store.py
+++ b/powersimdata/data_access/sql_store.py
@@ -7,7 +7,7 @@ import psycopg2.extras
 from psycopg2.sql import SQL, Identifier, Placeholder
 
 
-class SqlException(Exception):
+class SqlError(Exception):
     """To be raised by sql layer, enabling handling of data access errors."""
 
     pass
@@ -157,4 +157,4 @@ class SqlStore:
         self.conn.close()
 
         if exc_type:
-            raise SqlException("Exception during sql transaction.") from exc_value
+            raise SqlError("Exception during sql transaction.") from exc_value

--- a/powersimdata/data_access/tests/test_execute_table.py
+++ b/powersimdata/data_access/tests/test_execute_table.py
@@ -3,7 +3,7 @@ from collections import OrderedDict
 import pytest
 
 from powersimdata.data_access.execute_table import ExecuteTable
-from powersimdata.data_access.sql_store import SqlException
+from powersimdata.data_access.sql_store import SqlError
 
 row_id = 9000
 
@@ -34,7 +34,7 @@ def store():
 @pytest.mark.integration
 @pytest.mark.db
 def test_err_handle():
-    with pytest.raises(SqlException):
+    with pytest.raises(SqlError):
         with RaiseErrorSqlStore() as store:
             store.add_entry(None)
 

--- a/powersimdata/data_access/tests/test_scenario_table.py
+++ b/powersimdata/data_access/tests/test_scenario_table.py
@@ -3,7 +3,7 @@ from collections import OrderedDict
 import pytest
 
 from powersimdata.data_access.scenario_table import ScenarioTable
-from powersimdata.data_access.sql_store import SqlException
+from powersimdata.data_access.sql_store import SqlError
 
 # uncomment to enable logging queries to stdout
 # os.environ["DEBUG_MODE"] = "1"
@@ -85,7 +85,7 @@ def test_add_entry(store):
 def test_add_entry_missing_required_raises():
     info = _get_test_row()
     del info["plan"]
-    with pytest.raises(SqlException):
+    with pytest.raises(SqlError):
         # create explicitly since yield loses exception context
         with NoEffectSqlStore() as store:
             store.add_entry(info)


### PR DESCRIPTION
### Purpose
The latest release of pep8-naming now includes N818 which checks the naming of `Exception` subclasses.

### What the code is doing
Fix the one existing violation .

### Testing
`tox -e flake8`

### Time estimate
1 min
