### PR TITLE
chore: use setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,38 @@
+[metadata]
+name = powersimdata
+version = 0.4.3
+author = Kaspar Mueller
+author_email = kaspar@breakthroughenergy.org
+description = Power Simulation Data
+long_description = file: README.md
+long_description_content_type = text/markdown
+url = https://github.com/Breakthrough-Energy/PowerSimData
+project_urls =
+    Bug Tracker = https://github.com/Breakthrough-Energy/PowerSimData/issues
+classifiers =
+    License :: OSI Approved :: MIT License
+    Operating System :: OS Independent
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+
+[options]
+zip_safe = False
+packages = find:
+python_requires = >=3.7
+install_requires =
+    networkx
+    numpy
+    pandas
+    paramiko
+    scipy
+    tqdm
+    requests
+
+[options.package_data]
+powersimdata = 
+    network/*/data/*.csv
+    design/investment/data/*.csv
+    design/investment/data/*/*
+    utility/templates/*.csv

--- a/setup.py
+++ b/setup.py
@@ -1,31 +1,3 @@
-from setuptools import find_packages, setup
+from setuptools import setup
 
-install_requires = [
-    "networkx",
-    "numpy",
-    "pandas",
-    "paramiko",
-    "scipy",
-    "tqdm",
-    "requests",
-]
-
-setup(
-    name="powersimdata",
-    version="0.4.3",
-    description="Power Simulation Data",
-    url="https://github.com/Breakthrough-Energy/powersimdata",
-    author="Kaspar Mueller",
-    author_email="kaspar@breakthroughenergy.org",
-    packages=find_packages(),
-    package_data={
-        "powersimdata": [
-            "network/*/data/*.csv",
-            "design/investment/data/*.csv",
-            "design/investment/data/*/*",
-            "utility/templates/*.csv",
-        ]
-    },
-    zip_safe=False,
-    install_requires=install_requires,
-)
+setup()


### PR DESCRIPTION
### Purpose
Switch to setup.cfg for package metadata since it's the [recommended](https://packaging.python.org/tutorials/packaging-projects/#configuring-metadata) approach. 

### What the code is doing
The details are the same as in setup.py, but this also adds some classifiers, project urls, and sets the readme as the `long_description` which will appear on the PyPI page once we publish.

### Testing
First ran `pip install build`, followed by `python -m build`, which creates a `dist/` folder with `.whl` package file. I installed this in a new environment and checked that I can still import stuff and instantiate a grid (to verify the `package_data` is included).

Also published to the test pypi server, check it out [here](https://test.pypi.org/project/powersimdata/)

### Time estimate
5 min
