### PR TITLE
ci: add workflow to build and upload package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+name: Publish Python 🐍 package 📦 to PyPI and TestPyPI
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - v*.*.*
+
+jobs:
+  release:
+    name: Publish python package
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - run: python -m pip install --upgrade build
+      - run: python -m build
+
+      - name: Publish to Test PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          repository_url: https://test.pypi.org/legacy/
+
+      - name: Publish to PyPI
+        if: startsWith(github.ref, 'refs/tags')
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
### Purpose
New workflow to handle building and uploading the package to PyPI whenever we push a new git tag with the specified version scheme. It can also be run manually, so we can test it out on the existing `v0.4.3` release.

### What the code is doing
Usual workflow stuff. We install the `build` package to create the `dist/` folder which will be uploaded subsequently using the github action provided by pypa.

### Testing
Tested the release to [TestPyPI](https://test.pypi.org/project/powersimdata/) initially by omitting the tags filter in the `on:` section. Once this is merged I will run the workflow on our latest release, which should also upload to the real PyPI.

### Time estimate
10 min
