### PR TITLE
fix: access column values instead of DataFrame method

### DIFF
--- a/powersimdata/design/investment/investment_costs.py
+++ b/powersimdata/design/investment/investment_costs.py
@@ -74,7 +74,7 @@ def calculate_ac_inv_costs(
         base_grid.branch, grid_differences.branch
     )
     grid_differences.branch = grid_differences.branch.assign(
-        rateA=capacity_difference.diff
+        rateA=capacity_difference["diff"].to_numpy()
     )
     grid_differences.branch = grid_differences.branch.query("rateA != 0.0")
     if exclude_branches is not None:
@@ -297,7 +297,7 @@ def calculate_dc_inv_costs(scenario, sum_results=True, base_grid=None):
         base_grid.dcline, grid_differences.dcline
     )
     grid_differences.dcline = grid_differences.dcline.assign(
-        Pmax=capacity_difference.diff
+        Pmax=capacity_difference["diff"].to_numpy()
     )
     grid_differences.dcline = grid_differences.dcline.query("Pmax != 0.0")
 
@@ -391,7 +391,7 @@ def calculate_gen_inv_costs(
         base_grid.plant, grid_differences.plant
     )
     grid_differences.plant = grid_differences.plant.assign(
-        Pmax=capacity_difference.diff
+        Pmax=capacity_difference["diff"].to_numpy()
     )
     grid_differences.plant = grid_differences.plant.query("Pmax >= 0.01")
     # Find change in storage capacity


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
Correct a bug introduced in #507.

### What the code is doing
We had meant to access the `"diff"` column of a DataFrame, but we're instead accessing the `.diff()` method. This fixes that.

### Testing
Tested manually. Before:
```python
>>> from powersimdata import Scenario
>>> from powersimdata.design.investment.investment_costs import (
...     calculate_ac_inv_costs,
...     calculate_gen_inv_costs,
... )
>>> scenario = Scenario(1705)
>>> calculate_ac_inv_costs(scenario)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\Users\DanielOlsen\repos\bes\PowerSimData\powersimdata\design\investment\investment_costs.py", line 76, in calculate_ac_inv_costs
    grid_differences.branch = grid_differences.branch.assign(
  File "C:\Python39\lib\site-packages\pandas\core\frame.py", line 3699, in assign
    data[k] = com.apply_if_callable(v, data)
  File "C:\Python39\lib\site-packages\pandas\core\common.py", line 341, in apply_if_callable
    return maybe_callable(obj, **kwargs)
  File "C:\Python39\lib\site-packages\pandas\core\frame.py", line 7260, in diff
    new_data = self._mgr.diff(n=periods, axis=bm_axis)
  File "C:\Python39\lib\site-packages\pandas\core\internals\managers.py", line 567, in diff
    return self.apply("diff", n=n, axis=axis)
  File "C:\Python39\lib\site-packages\pandas\core\internals\managers.py", line 409, in apply
    applied = getattr(b, f)(**kwargs)
  File "C:\Python39\lib\site-packages\pandas\core\internals\blocks.py", line 1272, in diff
    new_values = algos.diff(self.values, n, axis=axis, stacklevel=7)
  File "C:\Python39\lib\site-packages\pandas\core\algorithms.py", line 1918, in diff
    n = int(n)
TypeError: int() argument must be a string, a bytes-like object or a number, not 'DataFrame'
>>> calculate_gen_inv_costs(scenario, 2025, "Moderate")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\Users\DanielOlsen\repos\bes\PowerSimData\powersimdata\design\investment\investment_costs.py", line 393, in calculate_gen_inv_costs
    grid_differences.plant = grid_differences.plant.assign(
  File "C:\Python39\lib\site-packages\pandas\core\frame.py", line 3699, in assign
    data[k] = com.apply_if_callable(v, data)
  File "C:\Python39\lib\site-packages\pandas\core\common.py", line 341, in apply_if_callable
    return maybe_callable(obj, **kwargs)
  File "C:\Python39\lib\site-packages\pandas\core\frame.py", line 7260, in diff
    new_data = self._mgr.diff(n=periods, axis=bm_axis)
  File "C:\Python39\lib\site-packages\pandas\core\internals\managers.py", line 567, in diff
    return self.apply("diff", n=n, axis=axis)
  File "C:\Python39\lib\site-packages\pandas\core\internals\managers.py", line 409, in apply
    applied = getattr(b, f)(**kwargs)
  File "C:\Python39\lib\site-packages\pandas\core\internals\blocks.py", line 1272, in diff
    new_values = algos.diff(self.values, n, axis=axis, stacklevel=7)
  File "C:\Python39\lib\site-packages\pandas\core\algorithms.py", line 1918, in diff
    n = int(n)
TypeError: int() argument must be a string, a bytes-like object or a number, not 'DataFrame'
```
After:
```python
>>> from powersimdata import Scenario
>>> from powersimdata.design.investment.investment_costs import (
...     calculate_ac_inv_costs,
...     calculate_gen_inv_costs,
... )
>>> scenario = Scenario(1705)
>>> calculate_ac_inv_costs(scenario)
{'line_cost': 292542221726.4701, 'transformer_cost': 7594541147.697944}
>>> calculate_gen_inv_costs(scenario, 2025, "Moderate")
Technology
coal          2.750677e+10
geothermal    7.362562e+08
hydro         1.492064e+10
ng            5.826340e+10
nuclear       1.592516e+10
solar         5.741915e+11
wind          7.455055e+11
Name: cost, dtype: float64
```

### Time estimate
2 minutes.
