### PR TITLE
feat: list available profiles directly

### DIFF
--- a/powersimdata/data_access/profile_helper.py
+++ b/powersimdata/data_access/profile_helper.py
@@ -1,6 +1,6 @@
-import json
 import os
 
+import fs
 import requests
 from tqdm.auto import tqdm
 
@@ -87,10 +87,7 @@ class ProfileHelper:
         :param str kind: *'demand'*, *'hydro'*, *'solar'* or *'wind'*.
         :return: (*list*) -- available profile version.
         """
-
-        version_file = os.path.join(server_setup.LOCAL_DIR, "version.json")
-        if not os.path.exists(version_file):
-            return []
-        with open(version_file) as f:
-            version = json.load(f)
-            return ProfileHelper.parse_version(grid_model, kind, version)
+        profile_dir = fs.path.join(server_setup.LOCAL_DIR, "raw", grid_model)
+        lfs = fs.open_fs(profile_dir)
+        matching = [f for f in lfs.listdir(".") if kind in f]
+        return [f.lstrip(f"{kind}_").rstrip(".csv") for f in matching]


### PR DESCRIPTION
### Purpose
Simplify the process to use a custom profile - instead of requiring a local version.json, we can just list the existing files.

### What the code is doing
Extracts the profile version from the filename, for files in the `raw/{grid_model}` folder. We currently assume this folder exists, and the files conform to the current naming convention.

### Testing
Ran it locally, added a new profile, got expected result:
```
In [17]: ProfileHelper.get_profile_version_local("usa_tamu", "demand")
Out[17]: ['vJan2021', 'vFeb2021']
```

### Time estimate
10 min
