### PR TITLE
feat: allow the user to remove lines, buses, plants, and DC lines

### DIFF
--- a/powersimdata/input/tests/test_change_table.py
+++ b/powersimdata/input/tests/test_change_table.py
@@ -467,3 +467,28 @@ def test_change_table_clear_bad_type(ct):
 def test_change_table_clear_bad_key(ct):
     with pytest.raises(ValueError):
         ct.clear({"plantttt"})
+
+
+def test_remove_branch(ct):
+    ct.remove_branch({0})
+    with pytest.raises(ValueError):
+        # Can't remove again, because it shouldn't exist
+        ct.remove_branch({0})
+
+
+def test_remove_bus(ct):
+    with pytest.raises(ValueError):
+        # Can't remove, because there are branches attached to it
+        ct.remove_bus({1})
+    ct.remove_branch({0, 1, 2})
+    ct.remove_bus({1})
+    with pytest.raises(ValueError):
+        # Can't remove again, because it shouldn't exist
+        ct.remove_bus({1})
+    # Evan after we remove the branch connected to bus 845...
+    ct.remove_branch({1094})
+    with pytest.raises(ValueError):
+        # We can't remove this bus, since there's a generator with non-zero capacity
+        ct.remove_bus({845})
+    ct.scale_plant_capacity(resource="ng", plant_id={0: 0})
+    ct.remove_bus({845})

--- a/powersimdata/input/tests/test_transform_grid.py
+++ b/powersimdata/input/tests/test_transform_grid.py
@@ -558,3 +558,23 @@ def test_add_bus(ct):
     assert new_grid.bus.index.dtype == grid.bus.index.dtype
     assert new_grid.bus2sub.index.dtype == grid.bus2sub.index.dtype
     assert new_grid.sub.index.dtype == grid.sub.index.dtype
+
+
+def test_remove_branch(ct):
+    assert 0 in grid.branch.index
+    ct.ct["remove_branch"] = {0}
+    new_grid = TransformGrid(grid, ct.ct).get_grid()
+    assert 0 not in new_grid.branch.index
+    ct.ct["remove_branch"] = {1, 2}
+    new_grid = TransformGrid(grid, ct.ct).get_grid()
+    assert all(i not in new_grid.branch.index for i in [1, 2])
+
+
+def test_remove_bus(ct):
+    assert 1 in grid.bus.index
+    ct.ct["remove_bus"] = {1}
+    new_grid = TransformGrid(grid, ct.ct).get_grid()
+    assert 1 not in new_grid.bus.index
+    ct.ct["remove_bus"] = {2, 3}
+    new_grid = TransformGrid(grid, ct.ct).get_grid()
+    assert all(i not in new_grid.bus.index for i in [2, 3])

--- a/powersimdata/input/transform_grid.py
+++ b/powersimdata/input/transform_grid.py
@@ -71,7 +71,7 @@ class TransformGrid:
         if "storage" in self.ct.keys():
             self._add_storage()
 
-        # Finally, scale by IDs, so that additions can be scaled.
+        # Scale by IDs, so that additions can be scaled.
         for g in self.gen_types:
             if g in self.ct.keys():
                 self._scale_gen_by_id(g)
@@ -85,6 +85,12 @@ class TransformGrid:
 
         if "dcline" in self.ct.keys():
             self._scale_dcline()
+
+        # Finally, remove elements (so that removal doesn't cause downstream errors)
+        if "remove_branch" in self.ct.keys():
+            self._remove_branch()
+        if "remove_bus" in self.ct.keys():
+            self._remove_bus()
 
     def _scale_gen_by_zone(self, gen_type):
         """Scales capacity of generators, by zone. Also scales the associated generation
@@ -472,6 +478,26 @@ class TransformGrid:
         )
         # Maintain int columns after the append converts them to float
         storage["StorageData"] = storage["StorageData"].astype({"UnitIdx": "int"})
+
+    def _remove_branch(self):
+        """Removes branches."""
+        branch = self.grid.branch
+        self.grid.branch = branch.loc[~branch.index.isin(self.ct["remove_branch"])]
+
+    def _remove_bus(self):
+        """Removes buses."""
+        bus = self.grid.bus
+        self.grid.bus = bus.loc[~bus.index.isin(self.ct["remove_bus"])]
+
+    def _remove_dcline(self):
+        """Removes DC lines."""
+        dcline = self.grid.dcline
+        self.grid.dcline = dcline.loc[~dcline.index.isin(self.ct["remove_dcline"])]
+
+    def _remove_plant(self):
+        """Removes plants."""
+        plant = self.grid.plant
+        self.grid.plant = plant.loc[~plant.index.isin(self.ct["remove_plant"])]
 
 
 def voltage_to_x_per_distance(grid):


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
~Partial fulfilment of~ Closes #423. Plants and DC lines can already be _effectively_ removed by scaling them down to zero, this allows branches and buses to be removed as well. If we like the structure of the branch and bus removal, and want to enable full removal of plants, DC lines, storage, etc., then I can amend this PR to include those analogous methods as well.

### What the code is doing
Within the `ChangeTable` class:
- We add new methods `remove_bus` and `remove_branch`, which check that the elements to be removed are actually in the grid before adding to the change table dictionary. `remove_bus` has a check to ensure that a bus cannot be removed if there's at least one plant with non-zero capacity at it, and to implement this we modify `_get_df_with_new_elements` so that if we request the `plant` table, we apply any plant scaling.
- We add a user notification method, to ensure that the user is aware if they've accidentally islanded some load buses. This will not break the simulation, but load shedding will be enabled which could slow simulation.

Within the `TransformGrid` class:
- We interpret the `"remove_bus"` and `"remove_branch"` change table keys.

### Testing
New unit tests added.

### Time estimate
15-30 minutes.
