### PR TITLE
fix: prevent max recursion error

### DIFF
--- a/powersimdata/data_access/launcher.py
+++ b/powersimdata/data_access/launcher.py
@@ -46,7 +46,10 @@ class Launcher:
 
     def __init__(self, scenario):
         self.scenario = scenario
-        self.scenario_id = scenario.scenario_id
+
+    @property
+    def scenario_id(self):
+        return self.scenario.scenario_id
 
     def _launch(self, threads=None, solver=None, extract_data=True):
         """Launches simulation on target environment


### PR DESCRIPTION
### Purpose
When a scenario is in the execute state and we try to create a new scenario object, there is a max recursion error. This happens because due to the following loop (rough outline):
```
scenario.__init__
execute.__init__
execute.refresh
launcher.__init__
scenario.scenario_id
scenario.__getattr__
self.state (in the process of being set)
scenario.__getattr__
self.state (in the process of being set)
scenario.__getattr__
etc
```

### What the code is doing
Delay evaluation of `scenario.scenario_id` until after the objects are fully instantiated.

### Testing
Loaded scenario 3898 which is in execute state:
* before: max recursion error
* after: loads successfully

### Time estimate
Not sure
