### PR TITLE
Feat: Update Saving REISE.jl Inputs with Pyfilesystem

### DIFF
--- a/powersimdata/data_access/data_access.py
+++ b/powersimdata/data_access/data_access.py
@@ -61,33 +61,39 @@ class DataAccess:
 
         :param str filepath: path to save data to, with extension either 'pkl', 'csv', or 'mat'.
         :param (*pandas.DataFrame* or *dict*) data: data to save
-        :raises ValueError: if extension is unknown.
+        :param bool save_local: whether a copy should also be saved to the local filesystem, if
+            such a filesystem is configured. Defaults to True.
         """
-
-        ext = os.path.basename(filepath).split(".")[-1]
 
         self._check_file_exists(filepath, should_exist=False)
 
         print("Writing %s" % filepath)
 
-        if save_local:
-            f = self.local_fs.openbin(filepath, mode="w")
-        else:
-            f = self.fs.openbin(filepath, mode="w")
+        self._write(self.fs, filepath, data)
 
-        if ext == "pkl":
-            pickle.dump(data, f)
-        elif ext == "csv":
-            data.to_csv(f)
-        elif ext == "mat":
-            savemat(f, data, appendmat=False)
-        else:
-            raise ValueError("Unknown extension! %s" % ext)
+        if save_local and self.local_fs is not None:
+            self._write(self.local_fs, filepath, data)
 
-        f.close()
+    def _write(self, fs, filepath, data):
+        """Write a file to given data store.
 
-        if save_local and self.local_fs != self.fs:
-            fs2.copy.copy_file(self.local_fs, filepath, self.fs, filepath)
+        :param fs fs: pyfilesystem to which to write data
+        :param str filepath: path to save data to, with extension either 'pkl', 'csv', or 'mat'.
+        :param (*pandas.DataFrame* or *dict*) data: data to save
+        :raises ValueError: if extension is unknown.
+        """
+
+        ext = os.path.basename(filepath).split(".")[-1]
+
+        with fs.openbin(filepath) as f:
+            if ext == "pkl":
+                pickle.dump(data, f)
+            elif ext == "csv":
+                data.to_csv(f)
+            elif ext == "mat":
+                savemat(f, data, appendmat=False)
+            else:
+                raise ValueError("Unknown extension! %s" % ext)
 
     def copy_from(self, file_name, from_dir):
         """Copy a file from data store to userspace.
@@ -200,7 +206,6 @@ class LocalDataAccess(DataAccess):
         super().__init__(root)
         self.description = "local machine"
         self.fs = fs2.open_fs(root)
-        self.local_fs = self.fs
 
     def copy_from(self, file_name, from_dir=None):
         """Copy a file from data store to userspace.

--- a/powersimdata/data_access/data_access.py
+++ b/powersimdata/data_access/data_access.py
@@ -56,7 +56,7 @@ class DataAccess:
 
         return data
 
-    def write(self, filepath, data):
+    def write(self, filepath, data, save_local=True):
         """Write a file to data store.
 
         :param str filepath: path to save data to, with extension either 'pkl', 'csv', or 'mat'.
@@ -70,17 +70,23 @@ class DataAccess:
 
         print("Writing %s" % filepath)
 
-        with self.local_fs.openbin(filepath, mode="w") as f:
-            if ext == "pkl":
-                pickle.dump(data, f)
-            elif ext == "csv":
-                data.to_csv(f)
-            elif ext == "mat":
-                savemat(f, data, appendmat=False)
-            else:
-                raise ValueError("Unknown extension! %s" % ext)
+        if save_local:
+            f = self.local_fs.openbin(filepath, mode="w")
+        else:
+            f = self.fs.openbin(filepath, mode="w")
+            
+        if ext == "pkl":
+            pickle.dump(data, f)
+        elif ext == "csv":
+            data.to_csv(f)
+        elif ext == "mat":
+            savemat(f, data, appendmat=False)
+        else:
+            raise ValueError("Unknown extension! %s" % ext)
 
-        if self.local_fs != self.fs:
+        f.close()
+
+        if save_local and self.local_fs != self.fs:
             fs2.copy.copy_file(self.local_fs, filepath, self.fs, filepath)
 
     def copy_from(self, file_name, from_dir):

--- a/powersimdata/data_access/data_access.py
+++ b/powersimdata/data_access/data_access.py
@@ -74,7 +74,7 @@ class DataAccess:
             f = self.local_fs.openbin(filepath, mode="w")
         else:
             f = self.fs.openbin(filepath, mode="w")
-            
+
         if ext == "pkl":
             pickle.dump(data, f)
         elif ext == "csv":

--- a/powersimdata/input/export_data.py
+++ b/powersimdata/input/export_data.py
@@ -110,7 +110,7 @@ def export_case_mat(grid, filepath=None, storage_filepath=None):
 
     # energy storage
     mpc_storage = None
-    
+
     if len(grid.storage["gen"]) > 0:
         storage = grid.storage.copy()
 
@@ -124,13 +124,12 @@ def export_case_mat(grid, filepath=None, storage_filepath=None):
                 },
             }
         }
-        
 
     if filepath:
         savemat(filepath, mpc, appendmat=False)
         if mpc_storage:
             savemat(storage_filepath, mpc_storage, appendmat=False)
-    
+
     return mpc, mpc_storage
 
 

--- a/powersimdata/input/export_data.py
+++ b/powersimdata/input/export_data.py
@@ -125,9 +125,9 @@ def export_case_mat(grid, filepath=None, storage_filepath=None):
             }
         }
 
-    if filepath:
+    if filepath is not None:
         savemat(filepath, mpc, appendmat=False)
-        if mpc_storage:
+        if mpc_storage is not None:
             savemat(storage_filepath, mpc_storage, appendmat=False)
 
     return mpc, mpc_storage

--- a/powersimdata/input/export_data.py
+++ b/powersimdata/input/export_data.py
@@ -6,12 +6,16 @@ from scipy.io import savemat
 from powersimdata.input.transform_profile import TransformProfile
 
 
-def export_case_mat(grid, filepath, storage_filepath=None):
+def export_case_mat(grid, filepath=None, storage_filepath=None):
     """Export a grid to a format suitable for loading into simulation engine.
+    If optional filepath arguments are used, the results will also be saved to
+    the filepaths provided
 
     :param powersimdata.input.grid.Grid grid: Grid instance.
-    :param str filepath: path where main grid file will be saved.
+    :param str filepath: path where main grid file will be saved, if present
     :param str storage_filepath: path where storage data file will be saved, if present.
+    :return: (*tuple*) -- the mpc data as a dictionary and the mpc storage data
+        as a dictionary, if present. The storage data will be None if not present.
     """
     grid = copy.deepcopy(grid)
 
@@ -105,6 +109,8 @@ def export_case_mat(grid, filepath, storage_filepath=None):
         mpc["mpc"]["dclineid"] = dclineid
 
     # energy storage
+    mpc_storage = None
+    
     if len(grid.storage["gen"]) > 0:
         storage = grid.storage.copy()
 
@@ -118,10 +124,14 @@ def export_case_mat(grid, filepath, storage_filepath=None):
                 },
             }
         }
+        
 
-        savemat(storage_filepath, mpc_storage, appendmat=False)
-
-    savemat(filepath, mpc, appendmat=False)
+    if filepath:
+        savemat(filepath, mpc, appendmat=False)
+        if mpc_storage:
+            savemat(storage_filepath, mpc_storage, appendmat=False)
+    
+    return mpc, mpc_storage
 
 
 def export_transformed_profile(kind, scenario_info, grid, ct, filepath):

--- a/powersimdata/scenario/execute.py
+++ b/powersimdata/scenario/execute.py
@@ -205,17 +205,16 @@ class SimulationInput:
         """Creates MATPOWER case file."""
         file_name = f"{self.scenario_id}_case.mat"
         storage_file_name = f"{self.scenario_id}_case_storage.mat"
-        file_path = os.path.join(server_setup.LOCAL_DIR, file_name)
-        storage_file_path = os.path.join(server_setup.LOCAL_DIR, storage_file_name)
+        file_path = "/".join(server_setup.LOCAL_DIR, file_name)
+        storage_file_path = "/".join(server_setup.LOCAL_DIR, storage_file_name)
+        
         print("Building MPC file")
-        export_case_mat(self.grid, file_path, storage_file_path)
-        self._data_access.move_to(
-            file_name, self.REL_TMP_DIR, change_name_to="case.mat"
-        )
-        if len(self.grid.storage["gen"]) > 0:
-            self._data_access.move_to(
-                storage_file_name, self.REL_TMP_DIR, change_name_to="case_storage.mat"
-            )
+        mpc, mpc_storage = export_case_mat(self.grid, file_path, storage_file_path)
+
+        self.data_access.write(file_path, mpc)
+
+        if mpc_storage:
+            self.data_access.write(storage_file_path, mpc_storage)
 
     def prepare_profile(self, kind, profile_as=None):
         """Prepares profile for simulation.

--- a/powersimdata/scenario/execute.py
+++ b/powersimdata/scenario/execute.py
@@ -1,5 +1,3 @@
-import os
-
 from powersimdata.data_access.context import Context
 from powersimdata.input.export_data import export_case_mat
 from powersimdata.input.grid import Grid
@@ -7,7 +5,6 @@ from powersimdata.input.input_data import InputData
 from powersimdata.input.transform_grid import TransformGrid
 from powersimdata.input.transform_profile import TransformProfile
 from powersimdata.scenario.ready import Ready
-from powersimdata.utility import server_setup
 from powersimdata.utility.config import get_deployment_mode
 
 
@@ -206,16 +203,16 @@ class SimulationInput:
         """Creates MATPOWER case file."""
         file_name = f"{self.scenario_id}_case.mat"
         storage_file_name = f"{self.scenario_id}_case_storage.mat"
-        file_path = "/".join(server_setup.LOCAL_DIR, file_name)
-        storage_file_path = "/".join(server_setup.LOCAL_DIR, storage_file_name)
+        file_path = "/".join([self.REL_TMP_DIR, file_name])
+        storage_file_path = "/".join([self.REL_TMP_DIR, storage_file_name])
 
         print("Building MPC file")
-        mpc, mpc_storage = export_case_mat(self.grid, file_path, storage_file_path)
+        mpc, mpc_storage = export_case_mat(self.grid)
 
-        self.data_access.write(file_path, mpc)
+        self._data_access.write(file_path, mpc, save_local=False)
 
         if mpc_storage:
-            self.data_access.write(storage_file_path, mpc_storage, save_local=False)
+            self._data_access.write(storage_file_path, mpc_storage, save_local=False)
 
     def prepare_profile(self, kind, profile_as=None):
         """Prepares profile for simulation.
@@ -225,12 +222,12 @@ class SimulationInput:
         """
         if profile_as is None:
             file_name = "%s_%s.csv" % (self.scenario_id, kind)
-            filepath = os.path.join(server_setup.LOCAL_DIR, file_name)
+            filepath = "/".join([self.REL_TMP_DIR, file_name])
 
             tp = TransformProfile(self._scenario_info, self.grid, self.ct)
             profile = tp.get_profile(kind)
-            print(f"Writing scaled {kind} profile to {filepath} on local machine")
-            self.data_access_write(filepath, profile, save_local=False)
+            print(f"Writing scaled {kind} profile to {filepath}")
+            self._data_access.write(filepath, profile, save_local=False)
         else:
             from_dir = self._data_access.tmp_folder(profile_as)
             src = self._data_access.join(from_dir, f"{kind}.csv")

--- a/powersimdata/scenario/execute.py
+++ b/powersimdata/scenario/execute.py
@@ -1,10 +1,11 @@
 import os
 
 from powersimdata.data_access.context import Context
-from powersimdata.input.export_data import export_case_mat, export_transformed_profile
+from powersimdata.input.export_data import export_case_mat
 from powersimdata.input.grid import Grid
 from powersimdata.input.input_data import InputData
 from powersimdata.input.transform_grid import TransformGrid
+from powersimdata.input.transform_profile import TransformProfile
 from powersimdata.scenario.ready import Ready
 from powersimdata.utility import server_setup
 from powersimdata.utility.config import get_deployment_mode
@@ -207,14 +208,14 @@ class SimulationInput:
         storage_file_name = f"{self.scenario_id}_case_storage.mat"
         file_path = "/".join(server_setup.LOCAL_DIR, file_name)
         storage_file_path = "/".join(server_setup.LOCAL_DIR, storage_file_name)
-        
+
         print("Building MPC file")
         mpc, mpc_storage = export_case_mat(self.grid, file_path, storage_file_path)
 
         self.data_access.write(file_path, mpc)
 
         if mpc_storage:
-            self.data_access.write(storage_file_path, mpc_storage)
+            self.data_access.write(storage_file_path, mpc_storage, save_local=False)
 
     def prepare_profile(self, kind, profile_as=None):
         """Prepares profile for simulation.
@@ -225,13 +226,11 @@ class SimulationInput:
         if profile_as is None:
             file_name = "%s_%s.csv" % (self.scenario_id, kind)
             filepath = os.path.join(server_setup.LOCAL_DIR, file_name)
-            export_transformed_profile(
-                kind, self._scenario_info, self.grid, self.ct, filepath
-            )
 
-            self._data_access.move_to(
-                file_name, self.REL_TMP_DIR, change_name_to=f"{kind}.csv"
-            )
+            tp = TransformProfile(self._scenario_info, self.grid, self.ct)
+            profile = tp.get_profile(kind)
+            print(f"Writing scaled {kind} profile to {filepath} on local machine")
+            self.data_access_write(filepath, profile, save_local=False)
         else:
             from_dir = self._data_access.tmp_folder(profile_as)
             src = self._data_access.join(from_dir, f"{kind}.csv")


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
Update how the inputs to `REISE.jl` get saved to go through exclusively through pyfilesystem instead of saving to local and using pyfilesystem to move to the expected folders for `REISE.jl`

### What the code is doing
The write function in `data_access` was updated to reflect the fact that the `REISE.jl` inputs don't get saved locally if in the server mode. `export_data` was updated to return the mpc and mpc_storage data instead of saving directly to the local filesystem, though that option was kept in for researchers who may want to use that function to save and investigate the mpc files outside of a scenario workflow (e.g. without having to create a whole scenario and finding it in the `/tmp` folder). Finally, the `execute` state was updated to reflect these new changes and save the input files (mpc and profiles) via `pyfilesystem` and `data_access` instead.

### Testing
Tested locally, as well as with the dev server.

### Where to look
Only three files were updated. Additionally, I left `SimulationInput` within `execute` to be moved around at a later date.

### Time estimate
10 min
