### PR TITLE
feat: add mapping from state abbreviations to load zone IDs

### DIFF
--- a/powersimdata/network/usa_tamu/constants/zones.py
+++ b/powersimdata/network/usa_tamu/constants/zones.py
@@ -1,9 +1,11 @@
 import os
+from collections import defaultdict
 
 import pandas as pd
 
 _exports = [
     "abv",
+    "abv2id",
     "abv2interconnect",
     "abv2loadzone",
     "abv2state",
@@ -129,6 +131,10 @@ interconnect2id = {
 # Map load zone id to state abbreviations
 id2abv = {k: state2abv[v] for k, v in zone_df.state.to_dict().items()}
 
+# Map state abbreviations to load zone IDs
+abv2id = defaultdict(set)
+for k, v in id2abv.items():
+    abv2id[v].add(k)
 
 # Map state abbreviations to load zone name
 abv2loadzone = {


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
Add a mapping from state abbreviations to load zone IDs to `zones.py`, where other similar mappings are found.

### What the code is doing
This mapping essentially inverts the mapping from load zone IDs to state abbreviations, which is also found in `zones.py`.

### Testing
This new mapping was tested locally and works as expected.

### Where to look
The new mapping can be found in `powersimdata\network\usa_tamu\constants\zones.py`.

### Time estimate
This should be very quick. Let me know if you think other reviewers should be added.
