### PR TITLE
Wrap up initial data access refactor

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -19,7 +19,7 @@ jobs:
           python-version: 3.9
 
       - run: python -m pip install --upgrade pip tox
-      - run: tox -e pytest-local -- --cov-report=xml
+      - run: tox -e pytest-local -- --cov=powersimdata --cov-report=xml
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,4 +25,4 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - run: python -m pip install --upgrade pip tox
-      - run: tox -e pytest-local
+      - run: tox -e pytest-local -- --cov=powersimdata

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM python:3.8.3
 
 RUN apt-get update
-RUN apt-get install gawk
 RUN ln -s /mnt/bes/pcm $HOME/ScenarioData
 
 COPY powersimdata/utility/templates /mnt/bes/pcm/

--- a/powersimdata/data_access/csv_store.py
+++ b/powersimdata/data_access/csv_store.py
@@ -1,6 +1,5 @@
 import functools
 import os
-import shutil
 from pathlib import Path
 from tempfile import mkstemp
 
@@ -76,9 +75,6 @@ class CsvStore:
         """
         tmp_file, tmp_path = mkstemp(dir=server_setup.LOCAL_DIR)
         table.to_csv(tmp_path)
-        shutil.copy(tmp_path, os.path.join(server_setup.LOCAL_DIR, self._FILE_NAME))
-        os.close(tmp_file)
         tmp_name = os.path.basename(tmp_path)
-        self.data_access.push(tmp_name, checksum, change_name_to=self._FILE_NAME)
-        if os.path.exists(tmp_path):  # only required if data_access is LocalDataAccess
-            os.remove(tmp_path)
+        self.data_access.push(tmp_name, checksum, rename=self._FILE_NAME)
+        # os.close(tmp_file) # not sure if we need this anymore?

--- a/powersimdata/data_access/csv_store.py
+++ b/powersimdata/data_access/csv_store.py
@@ -77,4 +77,4 @@ class CsvStore:
         table.to_csv(tmp_path)
         tmp_name = os.path.basename(tmp_path)
         self.data_access.push(tmp_name, checksum, rename=self._FILE_NAME)
-        # os.close(tmp_file) # not sure if we need this anymore?
+        os.close(tmp_file)

--- a/powersimdata/data_access/csv_store.py
+++ b/powersimdata/data_access/csv_store.py
@@ -1,10 +1,6 @@
 import functools
-import os
-from tempfile import mkstemp
 
 import pandas as pd
-
-from powersimdata.utility import server_setup
 
 
 def verify_hash(func):
@@ -70,8 +66,5 @@ class CsvStore:
         :param pandas.DataFrame table: the data frame to save
         :param str checksum: the checksum prior to download
         """
-        tmp_file, tmp_path = mkstemp(dir=server_setup.LOCAL_DIR)
-        table.to_csv(tmp_path)
-        tmp_name = os.path.basename(tmp_path)
-        self.data_access.push(tmp_name, checksum, rename=self._FILE_NAME)
-        os.close(tmp_file)
+        with self.data_access.push(self._FILE_NAME, checksum) as f:
+            table.to_csv(f)

--- a/powersimdata/data_access/csv_store.py
+++ b/powersimdata/data_access/csv_store.py
@@ -61,7 +61,8 @@ class CsvStore:
 
     def _get_table(self, filename):
         self.data_access.copy_from(filename)
-        return self.data_access.read(filename, callback=lambda f, _: _parse_csv(f))
+        with self.data_access.get(filename) as (f, _):
+            return _parse_csv(f)
 
     def commit(self, table, checksum):
         """Save to local directory and upload if needed

--- a/powersimdata/data_access/data_access.py
+++ b/powersimdata/data_access/data_access.py
@@ -43,7 +43,6 @@ class DataAccess:
         :raises ValueError: if extension is unknown.
         """
         ext = os.path.basename(filepath).split(".")[-1]
-
         self._check_file_exists(filepath)
 
         with self.fs.open(filepath, mode="rb") as file_object:
@@ -66,11 +65,8 @@ class DataAccess:
         :param bool save_local: whether a copy should also be saved to the local filesystem, if
             such a filesystem is configured. Defaults to True.
         """
-
         self._check_file_exists(filepath, should_exist=False)
-
         print("Writing %s" % filepath)
-
         self._write(self.fs, filepath, data)
 
         if save_local and self.local_fs is not None:
@@ -84,8 +80,9 @@ class DataAccess:
         :param (*pandas.DataFrame* or *dict*) data: data to save
         :raises ValueError: if extension is unknown.
         """
-
         ext = os.path.basename(filepath).split(".")[-1]
+        dirpath = fs2.path.dirname(filepath)
+        fs.makedirs(dirpath, recreate=True)
 
         with fs.openbin(filepath, "w") as f:
             if ext == "pkl":
@@ -119,7 +116,7 @@ class DataAccess:
         :param str src: path to file
         :param str dest: destination folder
         """
-        if self.fs.exists(dest) and self.fs.isdir(dest):
+        if self.fs.isdir(dest):
             dest = self.join(dest, fs2.path.basename(src))
 
         self.fs.copy(src, dest)
@@ -150,13 +147,6 @@ class DataAccess:
             raise OSError(f"{path} not found on {self.description}")
         if not should_exist and exists:
             raise OSError(f"{path} already exists on {self.description}")
-
-    def makedir(self, path):
-        """Create path in current environment
-
-        :param str path: the relative path, excluding filename
-        """
-        self.fs.makedirs(path, recreate=True)
 
     def execute_command_async(self, command):
         """Execute a command locally at the DataAccess, without waiting for completion.
@@ -309,7 +299,7 @@ class SSHDataAccess(DataAccess):
         backup = f"{rename}.temp"
 
         self._check_file_exists(backup, should_exist=False)
-        print(f"Transferring {backup} to server")
+        print(f"Transferring {rename} to server")
         fs2.move.move_file(self.local_fs, file_name, self.fs, backup)
 
         values = {

--- a/powersimdata/data_access/data_access.py
+++ b/powersimdata/data_access/data_access.py
@@ -87,7 +87,7 @@ class DataAccess:
 
         ext = os.path.basename(filepath).split(".")[-1]
 
-        with fs.openbin(filepath) as f:
+        with fs.openbin(filepath, "w") as f:
             if ext == "pkl":
                 pickle.dump(data, f)
             elif ext == "csv":

--- a/powersimdata/data_access/data_access.py
+++ b/powersimdata/data_access/data_access.py
@@ -144,14 +144,17 @@ class DataAccess:
 
         :param str pattern: glob specifying files to remove
         :param bool confirm: prompt before executing command
+        :return: (*bool*) -- True if the operation is completed
         """
         if confirm:
             confirmed = input(f"Delete '{pattern}'? [y/n] (default is 'n')")
             if confirmed.lower() != "y":
                 print("Operation cancelled.")
-                return
+                return False
         self.fs.glob(pattern).remove()
+        self.local_fs.glob(pattern).remove()
         print("--> Done!")
+        return True
 
     def _check_file_exists(self, path, should_exist=True):
         """Check that file exists (or not) at the given path

--- a/powersimdata/data_access/data_access.py
+++ b/powersimdata/data_access/data_access.py
@@ -151,7 +151,7 @@ class DataAccess:
             if confirmed.lower() != "y":
                 print("Operation cancelled.")
                 return False
-        self.fs.glob(pattern).remove()
+        self.fs.write_fs.glob(pattern).remove()
         self.local_fs.glob(pattern).remove()
         print("--> Done!")
         return True

--- a/powersimdata/data_access/data_access.py
+++ b/powersimdata/data_access/data_access.py
@@ -279,6 +279,7 @@ class SSHDataAccess(DataAccess):
 
         self._check_file_exists(backup, should_exist=False)
         print(f"Transferring {rename} to server")
+        fs.copy.copy_file(self.local_fs, file_name, self.local_fs, rename)
         fs.move.move_file(self.local_fs, file_name, self.fs, backup)
 
         values = {

--- a/powersimdata/data_access/profile_helper.py
+++ b/powersimdata/data_access/profile_helper.py
@@ -1,8 +1,4 @@
-import os
-
 import fs
-import requests
-from tqdm.auto import tqdm
 
 from powersimdata.utility import server_setup
 
@@ -56,32 +52,3 @@ class ProfileHelper:
         file_name = field_name + "_" + version + ".csv"
         grid_model = scenario_info["grid_model"]
         return file_name, ("raw", grid_model)
-
-    @staticmethod
-    def download_file(file_name, from_dir):
-        """Download the profile from blob storage at the given path.
-
-        :param str file_name: profile csv.
-        :param tuple from_dir: tuple of path components.
-        :return: (*str*) -- path to downloaded file.
-        """
-        print(f"--> Downloading {file_name} from blob storage.")
-        url_path = "/".join(from_dir)
-        url = f"{ProfileHelper.BASE_URL}/{url_path}/{file_name}"
-        dest = os.path.join(server_setup.LOCAL_DIR, *from_dir, file_name)
-        os.makedirs(os.path.dirname(dest), exist_ok=True)
-        resp = requests.get(url, stream=True)
-        content_length = int(resp.headers.get("content-length", 0))
-        with open(dest, "wb") as f:
-            with tqdm(
-                unit="B",
-                unit_scale=True,
-                unit_divisor=1024,
-                miniters=1,
-                total=content_length,
-            ) as pbar:
-                for chunk in resp.iter_content(chunk_size=4096):
-                    f.write(chunk)
-                    pbar.update(len(chunk))
-
-        return dest

--- a/powersimdata/data_access/profile_helper.py
+++ b/powersimdata/data_access/profile_helper.py
@@ -32,7 +32,7 @@ def get_profile_version_local(grid_model, kind):
     :return: (*list*) -- available profile version.
     """
     profile_dir = fs.path.join(server_setup.LOCAL_DIR, "raw", grid_model)
-    lfs = fs.open_fs(profile_dir)
+    lfs = fs.open_fs(profile_dir, create=True)
     return _get_profile_version(lfs, kind)
 
 

--- a/powersimdata/data_access/tests/test_data_access.py
+++ b/powersimdata/data_access/tests/test_data_access.py
@@ -58,25 +58,3 @@ def test_copy_from_multi_path(data_access):
     make_temp(data_access.fs, filepath)
     data_access.copy_from(FILE_NAME, src_path)
     _check_content(data_access.local_fs, filepath)
-
-
-def test_move_to(data_access):
-    make_temp(data_access.local_fs, FILE_NAME)
-    data_access.move_to(FILE_NAME)
-    _check_content(data_access.fs, FILE_NAME)
-
-
-def test_move_to_multi_path(data_access):
-    rel_path = _join(data_access.local_root, "foo", "bar")
-    filepath = _join(rel_path, FILE_NAME)
-    make_temp(data_access.local_fs, FILE_NAME)
-    data_access.move_to(FILE_NAME, rel_path)
-    _check_content(data_access.fs, filepath)
-
-
-def test_move_to_rename(data_access):
-    make_temp(data_access.local_fs, FILE_NAME)
-
-    new_fname = "foo.txt"
-    data_access.move_to(FILE_NAME, change_name_to=new_fname)
-    _check_content(data_access.fs, new_fname)

--- a/powersimdata/input/input_data.py
+++ b/powersimdata/input/input_data.py
@@ -120,9 +120,6 @@ class InputData:
         :param dict ct: a change table
         :param str scenario_id: scenario id, used for file name
         """
-
-        # note pyfilesystem path conventions:
-        # https://docs.pyfilesystem.org/en/latest/reference/path.html
         filepath = "/".join([*server_setup.INPUT_DIR, f"{scenario_id}_ct.pkl"])
         self.data_access.write(filepath, ct)
 

--- a/powersimdata/input/input_data.py
+++ b/powersimdata/input/input_data.py
@@ -1,4 +1,5 @@
 import os
+import pickle
 
 import pandas as pd
 
@@ -125,7 +126,8 @@ class InputData:
         :param str scenario_id: scenario id, used for file name
         """
         filepath = "/".join([*server_setup.INPUT_DIR, f"{scenario_id}_ct.pkl"])
-        self.data_access.write(filepath, ct)
+        with self.data_access.write(filepath) as f:
+            pickle.dump(ct, f)
 
 
 def distribute_demand_from_zones_to_buses(zone_demand, bus):

--- a/powersimdata/input/input_data.py
+++ b/powersimdata/input/input_data.py
@@ -1,5 +1,3 @@
-import os
-
 import pandas as pd
 
 from powersimdata.data_access.context import Context
@@ -19,9 +17,6 @@ _file_extension = {
 
 
 class InputHelper:
-    def __init__(self, data_access):
-        self.data_access = data_access
-
     @staticmethod
     def get_file_components(scenario_info, field_name):
         """Get the file name and relative path for either ct or grid.
@@ -33,15 +28,6 @@ class InputHelper:
         ext = _file_extension[field_name]
         file_name = scenario_info["id"] + "_" + field_name + "." + ext
         return file_name, server_setup.INPUT_DIR
-
-    def download_file(self, file_name, from_dir):
-        """Download the file if using server, otherwise no-op.
-
-        :param str file_name: either grid or ct file name.
-        :param tuple from_dir: tuple of path components.
-        """
-        from_dir = self.data_access.join(*from_dir)
-        self.data_access.copy_from(file_name, from_dir)
 
 
 def _check_field(field_name):
@@ -84,24 +70,16 @@ class InputData:
         if field_name in profile_kind:
             helper = ProfileHelper
         else:
-            helper = InputHelper(self.data_access)
+            helper = InputHelper
 
         file_name, from_dir = helper.get_file_components(scenario_info, field_name)
 
-        filepath = os.path.join(server_setup.LOCAL_DIR, *from_dir, file_name)
+        filepath = "/".join([*from_dir, file_name])
         key = cache_key(filepath)
         cached = _cache.get(key)
         if cached is not None:
             return cached
-        try:
-            data = _read_data(filepath)
-        except FileNotFoundError:
-            print(
-                "%s not found in %s on local machine"
-                % (file_name, server_setup.LOCAL_DIR)
-            )
-            helper.download_file(file_name, from_dir)
-            data = _read_data(filepath)
+        data = self.data_access.read(filepath)
         _cache.put(key, data)
         return data
 
@@ -122,31 +100,6 @@ class InputData:
         """
         filepath = "/".join([*server_setup.INPUT_DIR, f"{scenario_id}_ct.pkl"])
         self.data_access.write(filepath, ct)
-
-
-def _read_data(filepath):
-    """Reads data from local machine.
-
-    :param str filepath: path to file, with extension either 'pkl', 'csv', or 'mat'.
-    :return: (*pandas.DataFrame*, *dict*, or *str*) -- demand, hydro, solar or
-        wind as a data frame, change table as a dict, or str containing a
-        local path to a matfile of grid data.
-    :raises ValueError: if extension is unknown.
-    """
-    ext = os.path.basename(filepath).split(".")[-1]
-    if ext == "pkl":
-        data = pd.read_pickle(filepath)
-    elif ext == "csv":
-        data = pd.read_csv(filepath, index_col=0, parse_dates=True)
-        data.columns = data.columns.astype(int)
-    elif ext == "mat":
-        # Try to load the matfile, just to check if it exists locally
-        open(filepath, "r")
-        data = filepath
-    else:
-        raise ValueError("Unknown extension! %s" % ext)
-
-    return data
 
 
 def distribute_demand_from_zones_to_buses(zone_demand, bus):

--- a/powersimdata/output/output_data.py
+++ b/powersimdata/output/output_data.py
@@ -33,7 +33,8 @@ class OutputData:
         print("--> Loading %s" % field_name)
         file_name = scenario_id + "_" + field_name + ".pkl"
         filepath = "/".join([*server_setup.OUTPUT_DIR, file_name])
-        return self._data_access.read(filepath)
+        with self._data_access.get(filepath) as (f, _):
+            return pd.read_pickle(f)
 
 
 def _check_field(field_name):

--- a/powersimdata/output/output_data.py
+++ b/powersimdata/output/output_data.py
@@ -1,6 +1,3 @@
-import os
-import pickle
-
 import numpy as np
 import pandas as pd
 from scipy.sparse import coo_matrix
@@ -35,20 +32,8 @@ class OutputData:
 
         print("--> Loading %s" % field_name)
         file_name = scenario_id + "_" + field_name + ".pkl"
-        from_dir = server_setup.OUTPUT_DIR
-        filepath = os.path.join(server_setup.LOCAL_DIR, *from_dir, file_name)
-
-        try:
-            return pd.read_pickle(filepath)
-        except pickle.UnpicklingError:
-            err_msg = f"Unable to unpickle {file_name}, possibly corrupted in download."
-            raise ValueError(err_msg)
-        except FileNotFoundError:
-            print(f"{filepath} not found on local machine")
-
-        remote_dir = self._data_access.join(*from_dir)
-        self._data_access.copy_from(file_name, remote_dir)
-        return pd.read_pickle(filepath)
+        filepath = "/".join([*server_setup.OUTPUT_DIR, file_name])
+        return self._data_access.read(filepath)
 
 
 def _check_field(field_name):

--- a/powersimdata/scenario/analyze.py
+++ b/powersimdata/scenario/analyze.py
@@ -18,7 +18,7 @@ class Analyze(Ready):
     """
 
     name = "analyze"
-    allowed = []
+    allowed = ["delete"]
     exported_methods = {
         "get_averaged_cong",
         "get_congl",
@@ -53,7 +53,7 @@ class Analyze(Ready):
     def _set_allowed_state(self):
         """Sets allowed state."""
         if self._scenario_status == "extracted":
-            self.allowed = ["delete", "move"]
+            self.allowed.append("move")
 
     def _set_ct_and_grid(self):
         """Sets change table and grid."""

--- a/powersimdata/scenario/create.py
+++ b/powersimdata/scenario/create.py
@@ -1,5 +1,4 @@
 import copy
-import pickle
 import warnings
 
 import numpy as np
@@ -355,18 +354,6 @@ class _Builder:
             return
         else:
             self.engine = engine
-
-    def load_change_table(self, filename):
-        """Uploads change table.
-
-        :param str filename: full path to change table pickle file.
-        :raises FileNotFoundError: if file not found.
-        """
-        try:
-            ct = pickle.load(open(filename, "rb"))
-            self.change_table.ct = ct
-        except FileNotFoundError:
-            raise ("%s not found. " % filename)
 
     def get_grid(self):
         """Returns a transformed grid.

--- a/powersimdata/scenario/delete.py
+++ b/powersimdata/scenario/delete.py
@@ -1,4 +1,3 @@
-from powersimdata.data_access.data_access import LocalDataAccess
 from powersimdata.scenario.ready import Ready
 from powersimdata.utility import server_setup
 
@@ -15,10 +14,7 @@ class Delete(Ready):
 
         :param bool confirm: prompt before each batch
         """
-        # Delete entry in scenario list
         scenario_id = self._scenario_info["id"]
-        self._scenario_list_manager.delete_entry(scenario_id)
-        self._execute_list_manager.delete_entry(scenario_id)
 
         print("--> Deleting scenario input data")
         target = self._data_access.join(*server_setup.INPUT_DIR, f"{scenario_id}_*")
@@ -33,10 +29,9 @@ class Delete(Ready):
         tmp_dir = self._data_access.tmp_folder(scenario_id)
         self._data_access.remove(f"{tmp_dir}/**", confirm=confirm)
 
-        print("--> Deleting input and output data on local machine")
-        local_data_access = LocalDataAccess()
-        target = local_data_access.join("data", "**", f"{scenario_id}_*")
-        local_data_access.remove(target, confirm=confirm)
+        print("--> Deleting entries in scenario and execute list")
+        self._scenario_list_manager.delete_entry(scenario_id)
+        self._execute_list_manager.delete_entry(scenario_id)
 
         # Delete attributes
         self._clean()

--- a/powersimdata/scenario/delete.py
+++ b/powersimdata/scenario/delete.py
@@ -15,19 +15,20 @@ class Delete(Ready):
         :param bool confirm: prompt before each batch
         """
         scenario_id = self._scenario_info["id"]
+        _join = self._data_access.join
 
-        print("--> Deleting scenario input data")
-        target = self._data_access.join(*server_setup.INPUT_DIR, f"{scenario_id}_*")
-        self._data_access.remove(target, confirm=confirm)
-
-        print("--> Deleting scenario output data")
-        target = self._data_access.join(*server_setup.OUTPUT_DIR, f"{scenario_id}_*")
-        self._data_access.remove(target, confirm=confirm)
-
-        # Delete temporary folder enclosing simulation inputs
-        print("--> Deleting temporary folder")
+        input_dir = _join(*server_setup.INPUT_DIR, f"{scenario_id}_*")
+        output_dir = _join(*server_setup.OUTPUT_DIR, f"{scenario_id}_*")
         tmp_dir = self._data_access.tmp_folder(scenario_id)
-        self._data_access.remove(f"{tmp_dir}/**", confirm=confirm)
+
+        proceed = True
+        for target in (input_dir, output_dir, f"{ tmp_dir }/**"):
+            if proceed:
+                proceed = self._data_access.remove(target, confirm=confirm)
+
+        if not proceed:
+            print("Cancelling deletion.")
+            return
 
         print("--> Deleting entries in scenario and execute list")
         self._scenario_list_manager.delete_entry(scenario_id)

--- a/powersimdata/scenario/delete.py
+++ b/powersimdata/scenario/delete.py
@@ -17,14 +17,21 @@ class Delete(Ready):
         scenario_id = self._scenario_info["id"]
         _join = self._data_access.join
 
-        input_dir = _join(*server_setup.INPUT_DIR, f"{scenario_id}_*")
-        output_dir = _join(*server_setup.OUTPUT_DIR, f"{scenario_id}_*")
-        tmp_dir = self._data_access.tmp_folder(scenario_id)
+        input_dir = _join(*server_setup.INPUT_DIR)
+        output_dir = _join(*server_setup.OUTPUT_DIR)
 
-        proceed = True
-        for target in (input_dir, output_dir, f"{ tmp_dir }/**"):
-            if proceed:
-                proceed = self._data_access.remove(target, confirm=confirm)
+        proceed = self._data_access.remove(
+            input_dir, f"{scenario_id}_*", confirm=confirm
+        )
+        if proceed:
+            proceed = self._data_access.remove(
+                output_dir, f"{scenario_id}_*", confirm=confirm
+            )
+        if proceed:
+            pattern = f"scenario_{scenario_id}/*"
+            proceed = self._data_access.remove(
+                server_setup.EXECUTE_DIR, pattern, confirm=confirm
+            )
 
         if not proceed:
             print("Cancelling deletion.")

--- a/powersimdata/scenario/execute.py
+++ b/powersimdata/scenario/execute.py
@@ -1,3 +1,5 @@
+from scipy.io import savemat
+
 from powersimdata.data_access.context import Context
 from powersimdata.input.export_data import export_case_mat
 from powersimdata.input.grid import Grid
@@ -200,10 +202,12 @@ class SimulationInput:
         print("Building MPC file")
         mpc, mpc_storage = export_case_mat(self.grid)
 
-        self._data_access.write(file_path, mpc, save_local=False)
+        with self._data_access.write(file_path, save_local=False) as f:
+            savemat(f, mpc, appendmat=False)
 
         if mpc_storage is not None:
-            self._data_access.write(storage_file_path, mpc_storage, save_local=False)
+            with self._data_access.write(storage_file_path, save_local=False) as f:
+                savemat(f, mpc, appendmat=False)
 
     def prepare_profile(self, kind, profile_as=None, slice=False):
         """Prepares profile for simulation.
@@ -219,7 +223,8 @@ class SimulationInput:
             tp = TransformProfile(self._scenario_info, self.grid, self.ct, slice)
             profile = tp.get_profile(kind)
             print(f"Writing scaled {kind} profile to {filepath}")
-            self._data_access.write(filepath, profile, save_local=False)
+            with self._data_access.write(filepath, save_local=False) as f:
+                profile.to_csv(f)
         else:
             from_dir = self._data_access.tmp_folder(profile_as)
             src = "/".join([from_dir, file_name])

--- a/powersimdata/scenario/execute.py
+++ b/powersimdata/scenario/execute.py
@@ -201,10 +201,8 @@ class SimulationInput:
 
     def prepare_mpc_file(self):
         """Creates MATPOWER case file."""
-        file_name = f"{self.scenario_id}_case.mat"
-        storage_file_name = f"{self.scenario_id}_case_storage.mat"
-        file_path = "/".join([self.REL_TMP_DIR, file_name])
-        storage_file_path = "/".join([self.REL_TMP_DIR, storage_file_name])
+        file_path = "/".join([self.REL_TMP_DIR, "case.mat"])
+        storage_file_path = "/".join([self.REL_TMP_DIR, "case_storage.mat"])
 
         print("Building MPC file")
         mpc, mpc_storage = export_case_mat(self.grid)
@@ -221,8 +219,8 @@ class SimulationInput:
         :param int/str profile_as: if given, copy profile from this scenario.
         :param bool slice: whether to slice the profiles by the Scenario's time range.
         """
+        file_name = f"{kind}.csv"
         if profile_as is None:
-            file_name = "%s_%s.csv" % (self.scenario_id, kind)
             filepath = "/".join([self.REL_TMP_DIR, file_name])
 
             tp = TransformProfile(self._scenario_info, self.grid, self.ct, slice)
@@ -231,5 +229,5 @@ class SimulationInput:
             self._data_access.write(filepath, profile, save_local=False)
         else:
             from_dir = self._data_access.tmp_folder(profile_as)
-            src = self._data_access.join(from_dir, f"{kind}.csv")
+            src = self._data_access.join(from_dir, file_name)
             self._data_access.copy(src, self.REL_TMP_DIR)

--- a/powersimdata/scenario/execute.py
+++ b/powersimdata/scenario/execute.py
@@ -211,7 +211,7 @@ class SimulationInput:
 
         self._data_access.write(file_path, mpc, save_local=False)
 
-        if mpc_storage:
+        if mpc_storage is not None:
             self._data_access.write(storage_file_path, mpc_storage, save_local=False)
 
     def prepare_profile(self, kind, profile_as=None, slice=False):

--- a/powersimdata/scenario/execute.py
+++ b/powersimdata/scenario/execute.py
@@ -17,7 +17,7 @@ class Execute(Ready):
     """
 
     name = "execute"
-    allowed = []
+    allowed = ["delete"]
     exported_methods = {
         "check_progress",
         "extract_simulation_output",

--- a/powersimdata/scenario/execute.py
+++ b/powersimdata/scenario/execute.py
@@ -101,7 +101,6 @@ class Execute(Ready):
             si = SimulationInput(
                 self._data_access, self._scenario_info, self.grid, self.ct
             )
-            si.create_folder()
             for p in ["demand", "hydro", "solar", "wind"]:
                 si.prepare_profile(p, profiles_as)
 
@@ -193,12 +192,6 @@ class SimulationInput:
 
         self.REL_TMP_DIR = self._data_access.tmp_folder(self.scenario_id)
 
-    def create_folder(self):
-        """Creates folder on server that will enclose simulation inputs."""
-        description = self._data_access.description
-        print(f"--> Creating temporary folder on {description} for simulation inputs")
-        self._data_access.makedir(self.REL_TMP_DIR)
-
     def prepare_mpc_file(self):
         """Creates MATPOWER case file."""
         file_path = "/".join([self.REL_TMP_DIR, "case.mat"])
@@ -229,5 +222,5 @@ class SimulationInput:
             self._data_access.write(filepath, profile, save_local=False)
         else:
             from_dir = self._data_access.tmp_folder(profile_as)
-            src = self._data_access.join(from_dir, file_name)
+            src = "/".join([from_dir, file_name])
             self._data_access.copy(src, self.REL_TMP_DIR)

--- a/powersimdata/scenario/tests/test_scenario.py
+++ b/powersimdata/scenario/tests/test_scenario.py
@@ -1,11 +1,8 @@
-import os
-
 import pytest
 
 from powersimdata.data_access.context import Context
-from powersimdata.data_access.data_access import TempDataAccess, get_blob_fs
 from powersimdata.scenario.scenario import Scenario
-from powersimdata.utility import templates
+from powersimdata.tests.mock_context import MockContext
 
 
 @pytest.mark.integration
@@ -14,23 +11,6 @@ def test_bad_scenario_name():
     # This test will fail if we do add a scenario with this name
     with pytest.raises(ValueError):
         Scenario("this_scenario_does_not_exist")
-
-
-class MockContext:
-    def __init__(self):
-        self.data_access = self._setup()
-
-    def get_data_access(self, ignored=None):
-        return self.data_access
-
-    def _setup(self):
-        tda = TempDataAccess()
-        tda.fs.add_fs("profile_fs", get_blob_fs("profiles"), priority=2)
-        for path in ("ExecuteList.csv", "ScenarioList.csv"):
-            orig = os.path.join(templates.__path__[0], path)
-            with open(orig, "rb") as f:
-                tda.fs.upload(path, f)
-        return tda
 
 
 def test_scenario_workflow(monkeypatch):

--- a/powersimdata/scenario/tests/test_scenario.py
+++ b/powersimdata/scenario/tests/test_scenario.py
@@ -1,6 +1,11 @@
+import os
+
 import pytest
 
+from powersimdata.data_access.context import Context
+from powersimdata.data_access.data_access import TempDataAccess
 from powersimdata.scenario.scenario import Scenario
+from powersimdata.utility import templates
 
 
 @pytest.mark.integration
@@ -9,3 +14,48 @@ def test_bad_scenario_name():
     # This test will fail if we do add a scenario with this name
     with pytest.raises(ValueError):
         Scenario("this_scenario_does_not_exist")
+
+
+def _mock_return(x=None):
+    tda = TempDataAccess()
+    for path in ("ExecuteList.csv", "ScenarioList.csv"):
+        orig = os.path.join(templates.__path__[0], path)
+        with open(orig, "rb") as f:
+            tda.fs.upload(path, f)
+    return tda
+
+
+def test_scenario_workflow(monkeypatch):
+    monkeypatch.setattr(Context, "get_data_access", _mock_return)
+
+    s = Scenario()
+    print(s.state.name)
+
+    s.set_grid(interconnect="Texas")
+
+    s.set_name("test", "dummy")
+    s.set_time("2016-01-01 00:00:00", "2016-01-01 03:00:00", "1H")
+
+    s.set_base_profile("demand", "vJan2021")
+    s.set_base_profile("hydro", "vJan2021")
+    s.set_base_profile("solar", "vJan2021")
+    s.set_base_profile("wind", "vJan2021")
+    s.change_table.ct = {
+        "wind": {
+            "zone_id": {
+                301: 1.1293320940114195,
+                302: 2.2996731828360466,
+                303: 1.1460693669609412,
+                304: 1.5378918905751389,
+                305: 1.6606575751914816,
+            },
+            "plant_id": {12912: 0},
+        }
+    }
+
+    s.get_grid()
+    s.get_ct()
+
+    s.print_scenario_info()
+    # s.create_scenario()
+    # s.prepare_simulation_input()

--- a/powersimdata/tests/mock_context.py
+++ b/powersimdata/tests/mock_context.py
@@ -1,0 +1,21 @@
+import os
+
+from powersimdata.data_access.data_access import TempDataAccess, get_blob_fs
+from powersimdata.utility import templates
+
+
+class MockContext:
+    def __init__(self):
+        self.data_access = self._setup()
+
+    def get_data_access(self, ignored=None):
+        return self.data_access
+
+    def _setup(self):
+        tda = TempDataAccess()
+        tda.fs.add_fs("profile_fs", get_blob_fs("profiles"), priority=2)
+        for path in ("ExecuteList.csv", "ScenarioList.csv"):
+            orig = os.path.join(templates.__path__[0], path)
+            with open(orig, "rb") as f:
+                tda.fs.upload(path, f)
+        return tda

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ deps =
 commands =
     pytest: pipenv sync --dev
     local: pytest -m 'not integration' {posargs}
-    integration: pytest
+    integration: pytest {posargs}
     format: black .
     format: isort .
     checkformatting: black . --check --diff
@@ -29,7 +29,7 @@ ignore = E501,W503,E741,E203,W605
 profile = black
 
 [pytest]
-addopts = --cov=powersimdata --ignore-glob=**/sql/*
+addopts = --ignore-glob=**/sql/*
 markers =
     integration: marks tests that require external dependencies (deselect with '-m "not integration"')
     db: marks tests that connect to a local database


### PR DESCRIPTION
### Purpose

Relates to https://github.com/Breakthrough-Energy/PowerSimData/issues/552

Based on the changes introduced in the `data_access_refactor` feature branch, this contains bugfixes and some code cleanup. Additionally it introduces blob storage as a read only source of scenario data, using fs-azureblob to maintain consistency across filesystems. 

### What the code is doing
* Fix bugs encountered while launching simulations in a container and in preparing one on the server. 
* Remove the `move_to` method which is only being used for the scenario/execute list, and combine with `push` which is what is used for those files
* use `MultiFS` to combine remote filesystems (represented by the `DataAccess.fs` attribute)
* make code coverage report opt in
* new unit test for creating/preparing a scenario using an ephemeral filesystem for local and "remote" storage. only external dependency is the `test_usa_tamu` profiles from blob storage
* enable switch to delete state once scenario is created, and unit test for deletion


### Testing
Ran a simulation in a container, and created/prepared one on the server. For the container, I removed the `pip install .` from the Dockerfile and mounted the PowerSimData repo on my local machine into `/PowerSimData` in the client container, so changes could be tested more quickly. However this is optional and shouldn't affect functionality. 

### Time estimate
40 min
