### PR TITLE
List profile versions from blob storage

### DIFF
--- a/powersimdata/data_access/data_access.py
+++ b/powersimdata/data_access/data_access.py
@@ -5,7 +5,10 @@ from subprocess import Popen
 import fs as fs2
 from fs.tempfs import TempFS
 
-from powersimdata.data_access.profile_helper import ProfileHelper
+from powersimdata.data_access.profile_helper import (
+    get_profile_version_cloud,
+    get_profile_version_local,
+)
 from powersimdata.data_access.ssh_fs import WrapSSHFS
 from powersimdata.utility import server_setup
 
@@ -127,8 +130,8 @@ class DataAccess:
         :param str kind: *'demand'*, *'hydro'*, *'solar'* or *'wind'*.
         :return: (*list*) -- available profile version.
         """
-        blob_version = ProfileHelper.get_profile_version_cloud(grid_model, kind)
-        local_version = ProfileHelper.get_profile_version_local(grid_model, kind)
+        blob_version = get_profile_version_cloud(grid_model, kind)
+        local_version = get_profile_version_local(grid_model, kind)
         return list(set(blob_version + local_version))
 
 

--- a/powersimdata/data_access/tests/test_profile_helper.py
+++ b/powersimdata/data_access/tests/test_profile_helper.py
@@ -1,22 +1,6 @@
 from powersimdata.data_access.profile_helper import ProfileHelper
 
 
-def test_parse_version_default():
-    assert [] == ProfileHelper.parse_version("usa_tamu", "solar", {})
-
-
-def test_parse_version_missing_key():
-    version = {"solar": ["v123"]}
-    assert [] == ProfileHelper.parse_version("usa_tamu", "solar", version)
-
-
-def test_parse_version():
-    expected = ["v123", "v456"]
-    version = {"usa_tamu": {"solar": expected}}
-    assert expected == ProfileHelper.parse_version("usa_tamu", "solar", version)
-    assert [] == ProfileHelper.parse_version("usa_tamu", "hydro", version)
-
-
 def test_get_file_components():
     s_info = {"base_wind": "v8", "grid_model": "europe"}
     file_name, from_dir = ProfileHelper.get_file_components(s_info, "wind")

--- a/powersimdata/data_access/tests/test_profile_helper.py
+++ b/powersimdata/data_access/tests/test_profile_helper.py
@@ -1,4 +1,19 @@
-from powersimdata.data_access.profile_helper import ProfileHelper
+from fs.tempfs import TempFS
+
+from powersimdata.data_access.profile_helper import ProfileHelper, _get_profile_version
+
+
+def test_get_profile_version():
+    with TempFS() as tmp_fs:
+        tfs = tmp_fs.makedirs("raw/usa_tamu", recreate=True)
+        tfs.touch("solar_vOct2022.csv")
+        tfs.touch("foo_v1.0.1.csv")
+        v_solar = _get_profile_version(tfs, "solar")
+        v_foo = _get_profile_version(tfs, "foo")
+        v_missing = _get_profile_version(tfs, "missing")
+        assert "vOct2022" == v_solar[0]
+        assert "v1.0.1" == v_foo[0]
+        assert [] == v_missing
 
 
 def test_get_file_components():


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
Currently the way we do this involves parsing a `version.json` file located in blob storage which must match the versions that are actually available. However to list locally available profiles, we check the files directly, which is more reliable than using the json file. This PR makes it so we use the same code for both local and blob storage, with the only difference being which filesystem is provided. 

### What the code is doing
See above. It is a refactor to be more consistent and eliminate the need for the `version.json` file.

### Testing
Ran the `_local` and `_cloud` functions interactively. Added new test for the shared logic (which was already in use, but untested). 

### Time estimate
10 min
