### PR TITLE
ci: enable tests and linting for PRs from forks to develop

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,10 @@
 name: Lint
 
-on: push
+on:
+  push:
+  pull_request:
+    branches:
+      - develop
 
 jobs:
   formatting:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,10 @@
 name: Pytest
 
-on: push
+on:
+  push:
+  pull_request:
+    branches:
+      - develop
 
 jobs:
   test:


### PR DESCRIPTION
### Purpose
Enable tests and linting to automatically run for PRs from forks of this repo to the develop branch.

### What the code is doing
Expanding when the tests run from just pushes to this repo (only possible for members of the organization) to pushes to this repo or pull requests to the `develop` branch.

### Testing
Not tested in this repo, but seems to work in PreREISE where the code was copied from.

### Time estimate
2 minutes.
