### PR TITLE
fix: when retrieving profiles for partial-year Scenario, slice to Scenario time range

### DIFF
--- a/powersimdata/input/export_data.py
+++ b/powersimdata/input/export_data.py
@@ -124,7 +124,7 @@ def export_case_mat(grid, filepath, storage_filepath=None):
     savemat(filepath, mpc, appendmat=False)
 
 
-def export_transformed_profile(kind, scenario_info, grid, ct, filepath):
+def export_transformed_profile(kind, scenario_info, grid, ct, filepath, slice=True):
     """Apply transformation to the given kind of profile and save the result locally.
 
     :param str kind: which profile to export. This parameter is passed to
@@ -135,8 +135,9 @@ def export_transformed_profile(kind, scenario_info, grid, ct, filepath):
         transformed.
     :param dict ct: change table.
     :param str filepath: path to save the result, including the filename
+    :param bool slice: whether to slice the profiles by the Scenario's time range.
     """
-    tp = TransformProfile(scenario_info, grid, ct)
+    tp = TransformProfile(scenario_info, grid, ct, slice)
     profile = tp.get_profile(kind)
     print(f"Writing scaled {kind} profile to {filepath} on local machine")
     profile.to_csv(filepath)

--- a/powersimdata/scenario/create.py
+++ b/powersimdata/scenario/create.py
@@ -7,7 +7,10 @@ import pandas as pd
 
 from powersimdata.input.change_table import ChangeTable
 from powersimdata.input.grid import Grid
-from powersimdata.input.input_data import InputData, get_bus_demand
+from powersimdata.input.input_data import (
+    InputData,
+    distribute_demand_from_zones_to_buses,
+)
 from powersimdata.input.transform_grid import TransformGrid
 from powersimdata.input.transform_profile import TransformProfile
 from powersimdata.network.model import ModelImmutables
@@ -86,8 +89,9 @@ class Create(State):
         :return: (*pandas.DataFrame*) -- data frame of demand (hour, bus).
         """
         self._update_scenario_info()
+        demand = self.get_demand()
         grid = self.get_grid()
-        return get_bus_demand(self._scenario_info, grid)
+        return distribute_demand_from_zones_to_buses(demand, grid.bus)
 
     def create_scenario(self):
         """Creates scenario."""

--- a/powersimdata/scenario/execute.py
+++ b/powersimdata/scenario/execute.py
@@ -217,17 +217,18 @@ class SimulationInput:
                 storage_file_name, self.REL_TMP_DIR, change_name_to="case_storage.mat"
             )
 
-    def prepare_profile(self, kind, profile_as=None):
+    def prepare_profile(self, kind, profile_as=None, slice=False):
         """Prepares profile for simulation.
 
         :param kind: one of *demand*, *'hydro'*, *'solar'* or *'wind'*.
         :param int/str profile_as: if given, copy profile from this scenario.
+        :param bool slice: whether to slice the profiles by the Scenario's time range.
         """
         if profile_as is None:
             file_name = "%s_%s.csv" % (self.scenario_id, kind)
             filepath = os.path.join(server_setup.LOCAL_DIR, file_name)
             export_transformed_profile(
-                kind, self._scenario_info, self.grid, self.ct, filepath
+                kind, self._scenario_info, self.grid, self.ct, filepath, slice
             )
 
             self._data_access.move_to(

--- a/powersimdata/scenario/ready.py
+++ b/powersimdata/scenario/ready.py
@@ -1,7 +1,7 @@
 import copy
 
 from powersimdata.input.grid import Grid
-from powersimdata.input.input_data import get_bus_demand
+from powersimdata.input.input_data import distribute_demand_from_zones_to_buses
 from powersimdata.input.transform_profile import TransformProfile
 from powersimdata.scenario.state import State
 
@@ -120,5 +120,6 @@ class Ready(State):
 
         :return: (*pandas.DataFrame*) -- data frame of demand (hour, bus).
         """
+        zone_demand = self.get_demand()
         grid = self.get_grid()
-        return get_bus_demand(self._scenario_info, grid)
+        return distribute_demand_from_zones_to_buses(zone_demand, grid.bus)

--- a/powersimdata/scenario/tests/test_create.py
+++ b/powersimdata/scenario/tests/test_create.py
@@ -1,12 +1,42 @@
 import pytest
+from pandas.testing import assert_series_equal
 
 from powersimdata.scenario.scenario import Scenario
 
 
 @pytest.mark.integration
-@pytest.mark.ssh
-def test_get_bus_demand():
+def test_get_demand_and_get_bus_demand():
     scenario = Scenario("")
-    scenario.state.set_grid(interconnect="Texas")
-    scenario.state.builder.set_base_profile("demand", "vJan2021")
-    scenario.state.get_bus_demand()
+    scenario.set_grid(interconnect="Texas")
+    # Before we set the profile version, we should get errors trying to access
+    with pytest.raises(Exception):
+        scenario.get_bus_demand()
+    with pytest.raises(Exception):
+        scenario.get_demand()
+    # After we set the profile version, we should get the right len (default full year)
+    scenario.set_base_profile("demand", "vJan2021")
+    assert len(scenario.get_bus_demand()) == 8784
+    scenario.set_time("2016-01-01 00:00", "2016-01-03 23:00", "24H")
+    demand = scenario.get_demand()
+    bus_demand = scenario.get_bus_demand()
+    assert len(demand) == 72
+    assert len(bus_demand) == 72
+    assert_series_equal(demand.sum(axis=1), bus_demand.sum(axis=1))
+    unscaled_total_demand = demand.sum().sum()
+    scenario.change_table.scale_demand(zone_id={301: 1.5})
+    new_demand = scenario.get_demand()
+    new_bus_demand = scenario.get_bus_demand()
+    assert_series_equal(new_demand.sum(axis=1), new_bus_demand.sum(axis=1))
+    assert new_demand.sum().sum() > unscaled_total_demand
+
+
+@pytest.mark.integration
+def test_get_solar():
+    scenario = Scenario("")
+    scenario.set_grid(interconnect="Texas")
+    with pytest.raises(Exception):
+        scenario.get_solar()
+    scenario.set_base_profile("solar", "vJan2021")
+    assert len(scenario.get_solar()) == 8784
+    scenario.set_time("2016-01-01 00:00", "2016-01-03 23:00", "24H")
+    assert len(scenario.get_solar()) == 72

--- a/powersimdata/tests/mock_analyze.py
+++ b/powersimdata/tests/mock_analyze.py
@@ -43,6 +43,7 @@ class MockAnalyze:
         "get_congl",
         "get_congu",
         "get_ct",
+        "get_bus_demand",
         "get_demand",
         "get_grid",
         "get_lmp",
@@ -63,6 +64,7 @@ class MockAnalyze:
         congu=None,
         ct=None,
         demand=None,
+        bus_demand=None,
         lmp=None,
         pf=None,
         pg=None,
@@ -79,6 +81,7 @@ class MockAnalyze:
         self.congu = _ensure_ts_index(congu)
         self.ct = ct if ct is not None else {}
         self.demand = _ensure_ts_index(demand)
+        self.bus_demand = _ensure_ts_index(bus_demand)
         self.lmp = _ensure_ts_index(lmp)
         self.pf = _ensure_ts_index(pf)
         self.dcline_pf = _ensure_ts_index(dcline_pf)
@@ -113,6 +116,12 @@ class MockAnalyze:
         :return: (pandas.DataFrame) -- dummy demand
         """
         return self.demand
+
+    def get_bus_demand(self):
+        """Get bus demand.
+        :return: (pandas.DataFrame) -- dummy bus demand
+        """
+        return self.bus_demand
 
     def get_grid(self):
         """Get grid.


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
Currently, when we retrieve profiles for a partial-year Scenario, we still return the entire year's profile. This can cause problems, since the time-series results are only defined over the Scenario's time range (see https://github.com/Breakthrough-Energy/PostREISE/issues/327 as an example). This corrects that issue, by slicing both the raw profiles (demand, solar, hydro, wind) and the bus-distributed profiles (via the method/function `get_bus_demand`).

### What the code is doing
Within `input_data.py`, we decompose the current `get_bus_demand` function into a scenario-info-retrieval step and a decomposition step. The scenario-info-retrieval step now slices the demand profile by time before the decomposition step. The decomposition step is now refactored to avoid mutating the `bus` input.

Within `create.py` and `ready.py`: we slice profiles before returning them to the user.

### Testing
Tested manually: ~for now, unit tests to be added:~
**EDIT**: unit tests are also added.
```python
>>> from powersimdata import Scenario
>>> scenario = Scenario()
>>> scenario.set_grid("usa_tamu", "Texas")
>>> scenario.set_base_profile("demand", "vJan2021")
>>> scenario.set_base_profile("solar", "vJan2021")
>>> # Before we set the time, the default is the full year
>>> scenario.get_demand().shape
--> Loading demand
(8784, 8)
>>> scenario.get_bus_demand().shape
--> Loading demand
(8784, 2000)
>>> scenario.get_solar().shape
--> Loading solar
(8784, 36)
>>> # After we set the time, we get just the slice
>>> scenario.set_time("2016-01-01 00:00", "2016-01-03 23:00", "24H")
>>> scenario.get_demand().shape
--> Loading demand
(72, 8)
>>> scenario.get_bus_demand().shape
--> Loading demand
(72, 2000)
>>> scenario.get_solar().shape
--> Loading solar
(72, 36)
```

### Time estimate
15 minutes.
