### PR TITLE
chore: bump release number

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = powersimdata
-version = 0.4.5
+version = 0.5.0
 author = Breakthrough Energy
 author_email = sciences@breakthroughenergy.org
 description = Power Simulation Data
@@ -13,9 +13,9 @@ classifiers =
     License :: OSI Approved :: MIT License
     Operating System :: OS Independent
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
 
 [options]
 zip_safe = False


### PR DESCRIPTION
### Purpose
Bump the release number for PowerSimData, in anticipation of a breaking change to the API from https://github.com/Breakthrough-Energy/PowerSimData/pull/581. At the same time, also update the list of supported python versions to reflect that our new requirements are 3.8+.

### Time estimate
2 minutes.
