### PR TITLE
test: Use fake profile data instead of test_usa_tamu

### DIFF
--- a/powersimdata/tests/mock_input_data.py
+++ b/powersimdata/tests/mock_input_data.py
@@ -1,0 +1,113 @@
+import numpy as np
+import pandas as pd
+
+from powersimdata.input.grid import Grid
+
+
+class MockInputData:
+    """
+    MockInputData is a mock of powersimdata.input.input_data.InputData
+    that generates random profiles.
+
+    Exactly 3 of {`start_time`, `end_time`, `periods`, `freq`} must be specified. See <https://pandas.pydata.org/docs/reference/api/pandas.date_range.html>.
+
+    :param powersimdata.input.grid.Grid grid: instance of Grid object.
+    :param str start_time: when profiles begin.
+    :param str end_time: when profiles end.
+    :param int periods: number of times in profile.
+    :param str freq: frequency of times in profile.
+    :param int random_seed: used to initialize the random generator.
+    :raises ValueError: raised if `field_name` specified in `get_data()` is not specified by this mock
+    :return: (*powersimdata.tests.mock_input_data.MockInputData*)
+    """
+
+    _RESOURCES = {
+        "wind": {"wind", "wind_offshore"},
+        "solar": {"solar"},
+        "hydro": {"hydro"},
+    }
+
+    def __init__(
+        self,
+        grid: Grid,
+        start_time="2016-01-01 00:00:00",
+        end_time=None,
+        periods=24,
+        freq="H",
+        random_seed=6669,
+    ):
+        self._grid = grid
+        self._start_time = start_time
+        self._end_time = end_time
+        self._periods = periods
+        self._freq = freq
+        self._random = np.random.default_rng(seed=random_seed)
+
+        self._profiles = {
+            "demand": self._get_demand(),
+            **{
+                resource: self._get_resource_profile(resource)
+                for resource in self._RESOURCES.keys()
+            },
+        }
+
+    def get_data(self, scenario_info, field_name):
+        """Returns fake profile data.
+
+        :param dict scenario_info: not used.
+        :param str field_name: Can be any of *'demand'*, *'hydro'*, *'solar'*, or *'wind'*.
+        :return: (*pandas.DataFrame*) -- fake profile data
+        """
+        profile = self._profiles.get(field_name)
+
+        if profile is None:
+            raise ValueError(f"No profile specified for {field_name}!")
+
+        return profile
+
+    def _get_demand(self):
+        """Returns fake demand data.
+
+        :return: (*pandas.DataFrame*) -- fake demand data
+        """
+        zone_ids = set(self._grid.plant["zone_id"])
+        fake_demand_profile = self._create_fake_profile(zone_ids)
+        return fake_demand_profile
+
+    def _get_resource_profile(self, resource_type):
+        """Returns fake data for given resource_type.
+
+        :param str resource_type: Can be any of *'hydro'*, *'solar'*, or *'wind'*.
+        :return: (*pandas.DataFrame*) -- fake data for resource
+        """
+        plant_ids = self._get_plant_ids_for_type(resource_type)
+        fake_resource_profile = self._create_fake_profile(plant_ids)
+        return fake_resource_profile
+
+    def _get_plant_ids_for_type(self, resource_type):
+        """Retrieves plant_ids for plants of `resource_type` from the grid.
+
+        :param str resource_type: Can be any of *'hydro'*, *'solar'*, or *'wind'*.
+        :return: (*list*) -- list of plant_ids
+        """
+        plant_ids = list(
+            self._grid.plant.query("type in @self._RESOURCES[@resource_type]").index
+        )
+        return plant_ids
+
+    def _create_fake_profile(self, columns):
+        """Generates a fake profile.
+
+        :param list columns: columns for the DataFrame
+        :return: (*pandas.DataFrame*) -- a fake profile
+        """
+        times = pd.date_range(
+            start=self._start_time,
+            end=self._end_time,
+            periods=self._periods,
+            freq=self._freq,
+        )
+        index = pd.Index(times, name="UTC Time")
+        data = self._random.uniform(low=0, high=1, size=(len(times), len(columns)))
+        fake_profile = pd.DataFrame(data=data, index=index, columns=columns)
+        return fake_profile

--- a/powersimdata/tests/test_mocks.py
+++ b/powersimdata/tests/test_mocks.py
@@ -1,7 +1,9 @@
+import numpy as np
 import pandas as pd
 import pytest
 
 from powersimdata.tests.mock_grid import MockGrid
+from powersimdata.tests.mock_input_data import MockInputData
 from powersimdata.tests.mock_scenario import MockScenario
 from powersimdata.tests.mock_scenario_info import MockScenarioInfo
 
@@ -120,3 +122,131 @@ class TestMockScenarioInfo:
         mock_scenario = MockScenario()
         mock_s_info = MockScenarioInfo(mock_scenario)
         assert mock_scenario.state.get_grid() == mock_s_info.grid
+
+
+class TestMockInputData:
+    @pytest.fixture
+    def grid(self):
+        grid = MockGrid(grid_attrs={"plant": mock_plant})
+        return grid
+
+    def test_create_mock_input_data(self, grid):
+        assert MockInputData(grid) is not None
+
+    def test_happy_case(self, grid):
+        mock_input_data = MockInputData(grid, periods=3)
+
+        demand = mock_input_data.get_data({}, "demand")
+        expected_demand_values = np.array(
+            [
+                [0.355565, 0.453391, 0.563135],
+                [0.873873, 0.342370, 0.766953],
+                [0.802850, 0.125095, 0.150314],
+            ]
+        )
+        expected_zone_ids = np.array([1, 2, 3])
+        self._assert_profile(demand, expected_demand_values, expected_zone_ids)
+
+        wind = mock_input_data.get_data({}, "wind")
+        expected_wind_values = np.array(
+            [
+                [0.460527],
+                [0.054347],
+                [0.278840],
+            ]
+        )
+        expected_wind_plant_ids = np.array([102])
+        self._assert_profile(wind, expected_wind_values, expected_wind_plant_ids)
+
+        solar = mock_input_data.get_data({}, "solar")
+        expected_solar_values = np.array(
+            [
+                [0.305825],
+                [0.219366],
+                [0.091358],
+            ]
+        )
+        expected_solar_plant_ids = np.array([101])
+        self._assert_profile(solar, expected_solar_values, expected_solar_plant_ids)
+
+        hydro = mock_input_data.get_data({}, "hydro")
+        expected_hydro_values = np.array(
+            [
+                [0.577557],
+                [0.867702],
+                [0.927690],
+            ]
+        )
+        expected_hydro_plant_ids = np.array([106])
+        self._assert_profile(hydro, expected_hydro_values, expected_hydro_plant_ids)
+
+    def test_multiple_get_data_calls_returns_same_data(self, grid):
+        mock_input_data = MockInputData(grid)
+
+        for type in ("demand", "wind", "solar", "hydro"):
+            profile1 = mock_input_data.get_data({}, type)
+            profile2 = mock_input_data.get_data({}, type)
+            pd.testing.assert_frame_equal(profile1, profile2)
+
+    def test_no_start_time(self, grid):
+        mock_input_data = MockInputData(
+            grid, start_time=None, end_time="2016-01-01 02:00", periods=3, freq="H"
+        )
+        demand = mock_input_data.get_data({}, "demand")
+        self._assert_dates(demand.index)
+
+    def test_no_end_time(self, grid):
+        mock_input_data = MockInputData(
+            grid, start_time="2016-01-01 00:00", end_time=None, periods=3, freq="H"
+        )
+        demand = mock_input_data.get_data({}, "demand")
+        self._assert_dates(demand.index)
+
+    def test_no_period(self, grid):
+        mock_input_data = MockInputData(
+            grid,
+            start_time="2016-01-01 00:00",
+            end_time="2016-01-01 02:00",
+            periods=None,
+            freq="H",
+        )
+        demand = mock_input_data.get_data({}, "demand")
+        self._assert_dates(demand.index)
+
+    def test_no_freq(self, grid):
+        mock_input_data = MockInputData(
+            grid,
+            start_time="2016-01-01 00:00",
+            end_time="2016-01-01 02:00",
+            periods=3,
+            freq=None,
+        )
+        demand = mock_input_data.get_data({}, "demand")
+        self._assert_dates(demand.index)
+
+    def test_raise_if_no_profile_specified(self, grid):
+        with pytest.raises(ValueError) as exc:
+            mock_input_data = MockInputData(grid)
+            mock_input_data.get_data({}, "fusion")
+        assert "No profile specified for fusion!" in str(exc.value)
+
+    def test_raise_if_all_date_range_fields_present(self, grid):
+        with pytest.raises(ValueError):
+            MockInputData(
+                grid,
+                start_time="2016-01-01 00:00",
+                end_time="2016-01-01 02:00",
+                freq="H",
+                periods=3,
+            )
+
+    def _assert_profile(self, profile, expected_values, expected_columns):
+        np.testing.assert_almost_equal(profile.values, expected_values, decimal=5)
+        np.testing.assert_almost_equal(profile.columns, expected_columns)
+        self._assert_dates(profile.index)
+
+    def _assert_dates(self, dates):
+        expected_dates = pd.to_datetime(
+            ["2016-01-01 00:00", "2016-01-01 01:00", "2016-01-01 02:00"]
+        )
+        np.testing.assert_array_equal(dates, expected_dates)


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)



### Purpose
Hi Breakthrough Energy Team! Thank you for your work on this interesting and important project!

This PR is an attempt to fix https://github.com/Breakthrough-Energy/PowerSimData/issues/489.

The  `test_usa_tamu` profiles are no longer needed for `test_transform_profile` and no Internet connection is required to run the tests.

### What the code is doing
To avoid the Azure blob call, I mocked `InputData` to return random profiles. I just used uniform random data in [0, 1) as suggested [here](https://github.com/Breakthrough-Energy/PowerSimData/pull/485#issuecomment-848331723)

### Testing
I ran `tox -e pytest-local -- --cov=powersimdata` and `tox -e checkformatting` and both are passing.

To make sure that `test_usa_tamu` was not required, I wiped `~/ScenarioData` and rebuilt it with `LocalConfig().initialize()`. After running the tests, `test_usa_tamu` is no longer loaded.

### Where to look
`powersimdata/input/tests/test_transform_grid.py`

### Usage Example/Visuals
n/a 

### Time estimate
15 minutes
