### PR TITLE
fix: pass _Builder start and end date to TransformProfile

### DIFF
--- a/powersimdata/scenario/create.py
+++ b/powersimdata/scenario/create.py
@@ -232,6 +232,8 @@ class _Builder:
                 {
                     "grid_model": self.grid_model,
                     "base_%s" % kind: getattr(self, kind),
+                    "start_date": self.start_date,
+                    "end_date": self.end_date,
                 },
                 self.get_grid(),
                 self.get_ct(),


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
Ensure that profiles of appropriate length are being returned in partial-year `Create`-state Scenarios. This got broken during the refactor of #581, and must have been missed while we tested partial-year `Analyze`-state Scenarios.

### What the code is doing
Now that profile slicing is contained within `TransformProfile`, with a dictionary of Scenario information passed to control the start & end timestamps to slice, we need to make sure that the `_Builder` object passes this information to the `TransformProfile` init.

### Testing
Manually ran the tests in `powersimdata/scenario/tests/test_create.py` which aren't normally run (since they're marked `integration`.

### Time estimate
5 minutes.
