### PR TITLE
Fix data access integration tests

### DIFF
--- a/powersimdata/data_access/data_access.py
+++ b/powersimdata/data_access/data_access.py
@@ -257,6 +257,10 @@ class SSHDataAccess(DataAccess):
             self._fs = get_multi_fs(self.root)
         return self._fs
 
+    def exec_command(self, command):
+        ssh_fs = self.fs.get_fs("ssh_fs")
+        return ssh_fs.exec_command(command)
+
     def execute_command_async(self, command):
         """Execute a command via ssh, without waiting for completion.
 

--- a/powersimdata/data_access/tests/test_data_access.py
+++ b/powersimdata/data_access/tests/test_data_access.py
@@ -42,7 +42,7 @@ def test_tmp_folder(ssh_data_access):
 @pytest.mark.integration
 @pytest.mark.ssh
 def test_setup_server_connection(ssh_data_access):
-    _, stdout, _ = ssh_data_access.fs.exec_command("whoami")
+    _, stdout, _ = ssh_data_access.exec_command("whoami")
     assert stdout.read().decode("utf-8").strip() == server_setup.get_server_user()
 
 

--- a/powersimdata/data_access/tests/test_execute_csv.py
+++ b/powersimdata/data_access/tests/test_execute_csv.py
@@ -5,7 +5,6 @@ from collections import OrderedDict
 import pandas as pd
 import pytest
 from numpy.testing import assert_array_equal
-from pandas.testing import assert_frame_equal
 
 from powersimdata.data_access.data_access import LocalDataAccess, SSHDataAccess
 from powersimdata.data_access.execute_list import ExecuteListManager
@@ -21,14 +20,6 @@ def data_access():
 def execute_table(data_access):
     execute_list_manager = ExecuteListManager(data_access)
     return execute_list_manager.get_execute_table()
-
-
-@pytest.mark.integration
-@pytest.mark.ssh
-def test_get_execute_file_local(execute_table):
-    ecm = ExecuteListManager(None)
-    from_local = ecm.get_execute_table()
-    assert_frame_equal(from_local, execute_table)
 
 
 @pytest.mark.integration

--- a/powersimdata/data_access/tests/test_scenario_csv.py
+++ b/powersimdata/data_access/tests/test_scenario_csv.py
@@ -5,7 +5,6 @@ from collections import OrderedDict
 import pandas as pd
 import pytest
 from numpy.testing import assert_array_equal
-from pandas.testing import assert_frame_equal
 
 from powersimdata.data_access.data_access import LocalDataAccess, SSHDataAccess
 from powersimdata.data_access.scenario_list import ScenarioListManager
@@ -52,14 +51,6 @@ def test_get_scenario_file_from_server_header(data_access, scenario_table):
     ]
     assert_array_equal(scenario_table.columns, header)
     assert "id" == scenario_table.index.name
-
-
-@pytest.mark.integration
-@pytest.mark.ssh
-def test_get_scenario_file_local(scenario_table):
-    scm = ScenarioListManager(None)
-    from_local = scm.get_scenario_table()
-    assert_frame_equal(from_local, scenario_table)
 
 
 def clone_template():


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
Fix failing integration tests. This is a clean-up from #584.

### What the code is doing
- `SSHDataAccess` gets an `exec_command` method which passes the command through to the SSH filesystem.
- Two obsolete tests are removed from the ScenarioListManager and ExecuteListManager test sets. @jon-hagg said 'they were testing fallback logic that moved from `csv_store.py` to the `copy_from` method in `DataAccess`, so that is tested elsewhere'.

### Testing
`pytest .` passes all tests when connected to the VPN, and when not connected to the VPN the only test failure is `test_setup_server_connection`.

### Time estimate
5 minutes to understand these changes, longer if you want to go back to #584 and trace the evolution of tests there.
