### PR TITLE
mock_input_data: fix eval computation for new pandas version

### DIFF
--- a/powersimdata/tests/mock_input_data.py
+++ b/powersimdata/tests/mock_input_data.py
@@ -90,9 +90,8 @@ class MockInputData:
         :param str resource_type: Can be any of *'hydro'*, *'solar'*, or *'wind'*.
         :return: (*list*) -- list of plant_ids
         """
-        plant_ids = list(
-            self._grid.plant.query("type in @self._RESOURCES[@resource_type]").index
-        )
+        resources = self._RESOURCES[resource_type]
+        plant_ids = list(self._grid.plant[lambda ds: ds.type.isin(resources)].index)
         return plant_ids
 
     def _create_fake_profile(self, columns):


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
With the up-to-date pandas version the eval string in `powersimdata/tests/mock_input_data.py` fails due to a chained call of the `@` accessor. This PR provides a fix for that the error. 

### What the code is doing
Instead of the `eval` call, use a lambda function for the selection.  

### Testing
It fixes the tests with the new pandas version.

### Time estimate
3 min