### PR TITLE
Specify demand flexibility in the scenario framework

### DIFF
--- a/powersimdata/data_access/data_access.py
+++ b/powersimdata/data_access/data_access.py
@@ -9,10 +9,7 @@ from fs.multifs import MultiFS
 from fs.path import basename, dirname
 from fs.tempfs import TempFS
 
-from powersimdata.data_access.profile_helper import (
-    get_profile_version_cloud,
-    get_profile_version_local,
-)
+from powersimdata.data_access.profile_helper import get_profile_version
 from powersimdata.data_access.ssh_fs import WrapSSHFS
 from powersimdata.utility import server_setup
 
@@ -186,8 +183,9 @@ class DataAccess:
         :param str kind: *'demand'*, *'hydro'*, *'solar'* or *'wind'*.
         :return: (*list*) -- available profile version.
         """
-        blob_version = get_profile_version_cloud(grid_model, kind)
-        local_version = get_profile_version_local(grid_model, kind)
+        bfs = fs.open_fs("azblob://besciences@profiles")
+        blob_version = get_profile_version(bfs, grid_model, kind)
+        local_version = get_profile_version(self.local_fs, grid_model, kind)
         return list(set(blob_version + local_version))
 
     def checksum(self, relative_path):

--- a/powersimdata/data_access/profile_helper.py
+++ b/powersimdata/data_access/profile_helper.py
@@ -1,51 +1,20 @@
-import fs
+def get_profile_version(_fs, grid_model, kind):
+    """Returns available raw profile from the given filesystem
 
-from powersimdata.utility import server_setup
-
-
-def _get_profile_version(_fs, kind):
-    """Returns available raw profiles from the given filesystem
     :param fs.base.FS _fs: filesystem instance
+    :param str grid_model: grid model.
     :param str kind: *'demand'*, *'hydro'*, *'solar'*, *'wind'*,
         *'demand_flexibility_up'*, *'demand_flexibility_dn'*,
         *'demand_flexibility_cost_up'*, or *'demand_flexibility_cost_dn'*.
     :return: (*list*) -- available profile version.
     """
+    _fs = _fs.makedirs(f"raw/{grid_model}", recreate=True)
     matching = [f for f in _fs.listdir(".") if kind in f]
 
     # Don't include demand flexibility profiles as possible demand profiles
     if kind == "demand":
-        matching_ = [p for p in matching if "demand_flexibility" not in p]
-        return [f.lstrip(f"{kind}_").rstrip(".csv") for f in matching_]
-    else:
-        return [f.lstrip(f"{kind}_").rstrip(".csv") for f in matching]
-
-
-def get_profile_version_cloud(grid_model, kind):
-    """Returns available raw profile from blob storage.
-
-    :param str grid_model: grid model.
-    :param str kind: *'demand'*, *'hydro'*, *'solar'*, *'wind'*,
-        *'demand_flexibility_up'*, *'demand_flexibility_dn'*,
-        *'demand_flexibility_cost_up'*, or *'demand_flexibility_cost_dn'*.
-    :return: (*list*) -- available profile version.
-    """
-    bfs = fs.open_fs("azblob://besciences@profiles").opendir(f"raw/{grid_model}")
-    return _get_profile_version(bfs, kind)
-
-
-def get_profile_version_local(grid_model, kind):
-    """Returns available raw profile from local file.
-
-    :param str grid_model: grid model.
-    :param str kind: *'demand'*, *'hydro'*, *'solar'*, *'wind'*,
-        *'demand_flexibility_up'*, *'demand_flexibility_dn'*,
-        *'demand_flexibility_cost_up'*, or *'demand_flexibility_cost_dn'*.
-    :return: (*list*) -- available profile version.
-    """
-    profile_dir = fs.path.join(server_setup.LOCAL_DIR, "raw", grid_model)
-    lfs = fs.open_fs(profile_dir, create=True)
-    return _get_profile_version(lfs, kind)
+        matching = [p for p in matching if "demand_flexibility" not in p]
+    return [f.lstrip(f"{kind}_").rstrip(".csv") for f in matching]
 
 
 class ProfileHelper:

--- a/powersimdata/data_access/profile_helper.py
+++ b/powersimdata/data_access/profile_helper.py
@@ -60,7 +60,10 @@ class ProfileHelper:
         :param str field_name: the kind of profile.
         :return: (*tuple*) -- file name and list of path components.
         """
-        version = scenario_info["base_" + field_name]
+        if "demand_flexibility" in field_name:
+            version = scenario_info[field_name]
+        else:
+            version = scenario_info["base_" + field_name]
         file_name = field_name + "_" + version + ".csv"
         grid_model = scenario_info["grid_model"]
         return file_name, ("raw", grid_model)

--- a/powersimdata/data_access/profile_helper.py
+++ b/powersimdata/data_access/profile_helper.py
@@ -4,20 +4,30 @@ from powersimdata.utility import server_setup
 
 
 def _get_profile_version(_fs, kind):
-    """Returns available raw profiles from the give filesystem
+    """Returns available raw profiles from the given filesystem
     :param fs.base.FS _fs: filesystem instance
-    :param str kind: *'demand'*, *'hydro'*, *'solar'* or *'wind'*.
+    :param str kind: *'demand'*, *'hydro'*, *'solar'*, *'wind'*,
+        *'demand_flexibility_up'*, *'demand_flexibility_dn'*,
+        *'demand_flexibility_cost_up'*, or *'demand_flexibility_cost_dn'*.
     :return: (*list*) -- available profile version.
     """
     matching = [f for f in _fs.listdir(".") if kind in f]
-    return [f.lstrip(f"{kind}_").rstrip(".csv") for f in matching]
+
+    # Don't include demand flexibility profiles as possible demand profiles
+    if kind == "demand":
+        matching_ = [p for p in matching if "demand_flexibility" not in p]
+        return [f.lstrip(f"{kind}_").rstrip(".csv") for f in matching_]
+    else:
+        return [f.lstrip(f"{kind}_").rstrip(".csv") for f in matching]
 
 
 def get_profile_version_cloud(grid_model, kind):
     """Returns available raw profile from blob storage.
 
     :param str grid_model: grid model.
-    :param str kind: *'demand'*, *'hydro'*, *'solar'* or *'wind'*.
+    :param str kind: *'demand'*, *'hydro'*, *'solar'*, *'wind'*,
+        *'demand_flexibility_up'*, *'demand_flexibility_dn'*,
+        *'demand_flexibility_cost_up'*, or *'demand_flexibility_cost_dn'*.
     :return: (*list*) -- available profile version.
     """
     bfs = fs.open_fs("azblob://besciences@profiles").opendir(f"raw/{grid_model}")
@@ -28,7 +38,9 @@ def get_profile_version_local(grid_model, kind):
     """Returns available raw profile from local file.
 
     :param str grid_model: grid model.
-    :param str kind: *'demand'*, *'hydro'*, *'solar'* or *'wind'*.
+    :param str kind: *'demand'*, *'hydro'*, *'solar'*, *'wind'*,
+        *'demand_flexibility_up'*, *'demand_flexibility_dn'*,
+        *'demand_flexibility_cost_up'*, or *'demand_flexibility_cost_dn'*.
     :return: (*list*) -- available profile version.
     """
     profile_dir = fs.path.join(server_setup.LOCAL_DIR, "raw", grid_model)

--- a/powersimdata/data_access/scenario_list.py
+++ b/powersimdata/data_access/scenario_list.py
@@ -75,7 +75,7 @@ class ScenarioListManager(CsvStore):
         scenario_info.move_to_end("id", last=False)
         table.reset_index(inplace=True)
         entry = pd.DataFrame({k: [v] for k, v in scenario_info.items()})
-        table = table.append(entry)
+        table = pd.concat([table, entry])
         table.set_index("id", inplace=True)
 
         print("--> Adding entry in %s" % self._FILE_NAME)

--- a/powersimdata/data_access/tests/test_profile_helper.py
+++ b/powersimdata/data_access/tests/test_profile_helper.py
@@ -1,16 +1,17 @@
 from fs.tempfs import TempFS
 
-from powersimdata.data_access.profile_helper import ProfileHelper, _get_profile_version
+from powersimdata.data_access.profile_helper import ProfileHelper, get_profile_version
 
 
 def test_get_profile_version():
     with TempFS() as tmp_fs:
-        tfs = tmp_fs.makedirs("raw/usa_tamu", recreate=True)
-        tfs.touch("solar_vOct2022.csv")
-        tfs.touch("foo_v1.0.1.csv")
-        v_solar = _get_profile_version(tfs, "solar")
-        v_foo = _get_profile_version(tfs, "foo")
-        v_missing = _get_profile_version(tfs, "missing")
+        grid_model = "usa_tamu"
+        sub_fs = tmp_fs.makedirs(f"raw/{grid_model}", recreate=True)
+        sub_fs.touch("solar_vOct2022.csv")
+        sub_fs.touch("foo_v1.0.1.csv")
+        v_solar = get_profile_version(tmp_fs, grid_model, "solar")
+        v_foo = get_profile_version(tmp_fs, grid_model, "foo")
+        v_missing = get_profile_version(tmp_fs, grid_model, "missing")
         assert "vOct2022" == v_solar[0]
         assert "v1.0.1" == v_foo[0]
         assert [] == v_missing

--- a/powersimdata/input/change_table.py
+++ b/powersimdata/input/change_table.py
@@ -538,7 +538,7 @@ class ChangeTable:
             "demand_flexibility_cost_up",
             "demand_flexibility_cost_dn",
         }
-        self._check_entry_keys(info, 1, "demand_flexibility", required, None, optional)
+        self._check_entry_keys(info, 0, "demand_flexibility", required, None, optional)
 
         # Add a key for demand flexibility in the change table, if necessary
         if "demand_flexibility" not in self.ct:

--- a/powersimdata/input/change_table.py
+++ b/powersimdata/input/change_table.py
@@ -550,8 +550,9 @@ class ChangeTable:
                 # Check that demand flexibility duration is an integer and positive
                 if not isinstance(info[k], int):
                     raise ValueError(f"The value of {k} is not integer-valued.")
-                if info[k] > 0:
-                    raise ValueError(f"The value of {k} is no positive.")
+                if info[k] <= 0:
+                    raise ValueError(f"The value of {k} is not positive.")
+                self.ct["demand_flexibility"][k] = info[k]
             else:
                 # Determine the available profile versions
                 possible = InputData().get_profile_version(self.grid.grid_model, k)

--- a/powersimdata/input/input_data.py
+++ b/powersimdata/input/input_data.py
@@ -72,7 +72,10 @@ def _read(f, filepath):
         data = pd.read_pickle(f)
     elif ext == "csv":
         data = pd.read_csv(f, index_col=0, parse_dates=True)
-        data.columns = data.columns.astype(int)
+        if "demand_flexibility" in filepath:
+            data.columns = data.columns.astype(str)
+        else:
+            data.columns = data.columns.astype(int)
     elif ext == "mat":
         # get fully qualified local path to matfile
         data = os.path.abspath(filepath)

--- a/powersimdata/input/input_data.py
+++ b/powersimdata/input/input_data.py
@@ -17,7 +17,6 @@ profile_kind = {
     "wind",
     "demand_flexibility_up",
     "demand_flexibility_dn",
-    "demand_flexibility_duration",
     "demand_flexibility_cost_up",
     "demand_flexibility_cost_dn",
 }
@@ -48,12 +47,12 @@ def _check_field(field_name):
 
     :param str field_name: *'demand'*, *'hydro'*, *'solar'*, *'wind'*,
         *'demand_flexibility_up'*, *'demand_flexibility_dn'*,
-        *'demand_flexibility_duration'*, *'demand_flexibility_cost_up'*,
-        *'demand_flexibility_cost_dn'*, *'ct'*, or *'grid'*.
+        *'demand_flexibility_cost_up'*, *'demand_flexibility_cost_dn'*, *'ct'*, or
+        *'grid'*.
     :raises ValueError: if not *'demand'*, *'hydro'*, *'solar'*, *'wind'*,
         *'demand_flexibility_up'*, *'demand_flexibility_dn'*,
-        *'demand_flexibility_duration'*, *'demand_flexibility_cost_up'*,
-        *'demand_flexibility_cost_dn'*, *'ct'*, or *'grid'*.
+        *'demand_flexibility_cost_up'*, *'demand_flexibility_cost_dn'*, *'ct'*, or
+        *'grid'*.
     """
     possible = list(_file_extension.keys())
     if field_name not in possible:
@@ -96,13 +95,12 @@ class InputData:
         :param dict scenario_info: scenario information.
         :param str field_name: *'demand'*, *'hydro'*, *'solar'*, *'wind'*,
             *'demand_flexibility_up'*, *'demand_flexibility_dn'*,
-            *'demand_flexibility_duration'*, *'demand_flexibility_cost_up'*,
-            *'demand_flexibility_cost_dn'*, *'ct'*, or *'grid'*.
+            *'demand_flexibility_cost_up'*, *'demand_flexibility_cost_dn'*, *'ct'*, or
+            *'grid'*.
         :return: (*pandas.DataFrame*, *dict*, or *str*) -- demand, hydro, solar, wind,
-            demand_flexibility_up, demand_flexibility_dn, demand_flexibility_duration,
-            demand_flexibility_cost_up, or demand_flexibility_cost_dn as a data frame;
-            change table as a dictionary; or the path to a matfile enclosing the grid
-            data.
+            demand_flexibility_up, demand_flexibility_dn, demand_flexibility_cost_up,
+            or demand_flexibility_cost_dn as a data frame; change table as a dictionary;
+            or the path to a matfile enclosing the grid data.
         :raises FileNotFoundError: if file not found on local machine.
         """
         _check_field(field_name)
@@ -131,8 +129,7 @@ class InputData:
         :param str grid_model: grid model.
         :param str kind: *'demand'*, *'hydro'*, *'solar'*, *'wind'*,
             *'demand_flexibility_up'*, *'demand_flexibility_dn'*,
-            *'demand_flexibility_duration'*, *'demand_flexibility_cost_up'*,
-            or *'demand_flexibility_cost_dn'*.
+            *'demand_flexibility_cost_up'*, or *'demand_flexibility_cost_dn'*.
         :return: (*list*) -- available profile version.
         """
         return self.data_access.get_profile_version(grid_model, kind)

--- a/powersimdata/input/input_data.py
+++ b/powersimdata/input/input_data.py
@@ -10,7 +10,17 @@ from powersimdata.utility.helpers import MemoryCache, cache_key
 
 _cache = MemoryCache()
 
-profile_kind = {"demand", "hydro", "solar", "wind"}
+profile_kind = {
+    "demand",
+    "hydro",
+    "solar",
+    "wind",
+    "demand_flexibility_up",
+    "demand_flexibility_dn",
+    "demand_flexibility_duration",
+    "demand_flexibility_cost_up",
+    "demand_flexibility_cost_dn",
+}
 
 
 _file_extension = {
@@ -37,9 +47,13 @@ def _check_field(field_name):
     """Checks field name.
 
     :param str field_name: *'demand'*, *'hydro'*, *'solar'*, *'wind'*,
-        *'ct'* or *'grid'*.
-    :raises ValueError: if not *'demand'*, *'hydro'*, *'solar'*, *'wind'*
-        *'ct'* or *'grid'*.
+        *'demand_flexibility_up'*, *'demand_flexibility_dn'*,
+        *'demand_flexibility_duration'*, *'demand_flexibility_cost_up'*,
+        *'demand_flexibility_cost_dn'*, *'ct'*, or *'grid'*.
+    :raises ValueError: if not *'demand'*, *'hydro'*, *'solar'*, *'wind'*,
+        *'demand_flexibility_up'*, *'demand_flexibility_dn'*,
+        *'demand_flexibility_duration'*, *'demand_flexibility_cost_up'*,
+        *'demand_flexibility_cost_dn'*, *'ct'*, or *'grid'*.
     """
     possible = list(_file_extension.keys())
     if field_name not in possible:
@@ -81,10 +95,14 @@ class InputData:
 
         :param dict scenario_info: scenario information.
         :param str field_name: *'demand'*, *'hydro'*, *'solar'*, *'wind'*,
-            *'ct'* or *'grid'*.
-        :return: (*pandas.DataFrame*, *dict*, or *str*) --
-            demand, hydro, solar or wind as a data frame, change table as a
-            dictionary, or the path to a matfile enclosing the grid data.
+            *'demand_flexibility_up'*, *'demand_flexibility_dn'*,
+            *'demand_flexibility_duration'*, *'demand_flexibility_cost_up'*,
+            *'demand_flexibility_cost_dn'*, *'ct'*, or *'grid'*.
+        :return: (*pandas.DataFrame*, *dict*, or *str*) -- demand, hydro, solar, wind,
+            demand_flexibility_up, demand_flexibility_dn, demand_flexibility_duration,
+            demand_flexibility_cost_up, or demand_flexibility_cost_dn as a data frame;
+            change table as a dictionary; or the path to a matfile enclosing the grid
+            data.
         :raises FileNotFoundError: if file not found on local machine.
         """
         _check_field(field_name)
@@ -111,7 +129,10 @@ class InputData:
         """Returns available raw profile from blob storage or local disk.
 
         :param str grid_model: grid model.
-        :param str kind: *'demand'*, *'hydro'*, *'solar'* or *'wind'*.
+        :param str kind: *'demand'*, *'hydro'*, *'solar'*, *'wind'*,
+            *'demand_flexibility_up'*, *'demand_flexibility_dn'*,
+            *'demand_flexibility_duration'*, *'demand_flexibility_cost_up'*,
+            or *'demand_flexibility_cost_dn'*.
         :return: (*list*) -- available profile version.
         """
         return self.data_access.get_profile_version(grid_model, kind)

--- a/powersimdata/input/tests/test_change_table.py
+++ b/powersimdata/input/tests/test_change_table.py
@@ -438,13 +438,26 @@ def test_add_new_elements_at_new_buses(ct):
 
 def test_change_table_clear_success(ct):
     fake_scaling = {"demand", "branch", "solar", "ng_cost", "coal_pmin", "dcline"}
-    fake_additions = {"storage", "new_dcline", "new_branch", "new_plant"}
+    fake_additions = {
+        "storage",
+        "new_dcline",
+        "new_branch",
+        "new_plant",
+        "demand_flexibility",
+    }
     all_fakes = fake_scaling | fake_additions
     original_dict_object = ct.ct
     for fake in all_fakes:
         ct.ct[fake] = {}
     # Test that each individual clear makes a change, and the ct ends up empty
-    clear_keys = {"branch", "dcline", "demand", "plant", "storage"}
+    clear_keys = {
+        "branch",
+        "dcline",
+        "demand",
+        "plant",
+        "storage",
+        "demand_flexibility",
+    }
     for key in clear_keys:
         old_keys = set(ct.ct.keys())
         ct.clear(key)
@@ -492,3 +505,21 @@ def test_remove_bus(ct):
         ct.remove_bus({845})
     ct.scale_plant_capacity(resource="ng", plant_id={0: 0})
     ct.remove_bus({845})
+
+
+def test_add_demand_flexibility(ct):
+    with pytest.raises(Exception):
+        # Fails because "demand_flexibility_dn", a required key, is not included
+        ct.add_demand_flexibility(
+            {"demand_flexibility_up": "test", "demand_flexibility_duration": 6}
+        )
+
+    with pytest.raises(Exception):
+        # Fails because
+        ct.add_demand_flexibility(
+            {
+                "demand_flexibility_up": "test",
+                "demand_flexibility_dn": "test",
+                "demand_flexibility_duration": 6,
+            }
+        )

--- a/powersimdata/input/tests/test_change_table.py
+++ b/powersimdata/input/tests/test_change_table.py
@@ -513,13 +513,13 @@ def test_remove_bus(ct):
 
 
 def test_add_demand_flexibility(ct):
-    with pytest.raises(Exception):
+    with pytest.raises(ValueError):
         # Fails because "demand_flexibility_dn", a required key, is not included
         ct.add_demand_flexibility(
             {"demand_flexibility_up": "Test", "demand_flexibility_duration": 6}
         )
 
-    with pytest.raises(Exception):
+    with pytest.raises(ValueError):
         # Fails because there is a key that should not be there
         ct.add_demand_flexibility(
             {
@@ -530,7 +530,7 @@ def test_add_demand_flexibility(ct):
             }
         )
 
-    with pytest.raises(Exception):
+    with pytest.raises(ValueError):
         # Fails because there are no profiles available that match the specified version
         ct.add_demand_flexibility(
             {

--- a/powersimdata/input/tests/test_change_table.py
+++ b/powersimdata/input/tests/test_change_table.py
@@ -1,12 +1,10 @@
-import os
-import shutil
-from pathlib import Path
-
 import pandas as pd
 import pytest
 
+from powersimdata.data_access.context import Context
 from powersimdata.input.change_table import ChangeTable
 from powersimdata.input.grid import Grid
+from powersimdata.tests.mock_context import MockContext
 
 grid = Grid(["USA"])
 
@@ -512,7 +510,7 @@ def test_remove_bus(ct):
     ct.remove_bus({845})
 
 
-def test_add_demand_flexibility(ct):
+def test_add_demand_flexibility(ct, monkeypatch):
     with pytest.raises(ValueError):
         # Fails because "demand_flexibility_dn", a required key, is not included
         ct.add_demand_flexibility(
@@ -540,15 +538,18 @@ def test_add_demand_flexibility(ct):
             }
         )
 
+    monkeypatch.setattr(Context, "get_data_access", MockContext().get_data_access)
+    data_access = Context.get_data_access()
+
     # Create fake files in the expected directory path
-    exp_path = os.path.join(Path.home(), "ScenarioData", "raw", str(grid.grid_model))
-    dir_exists_prev = True
-    if not os.path.isdir(exp_path):
-        os.makedirs(exp_path)
-        dir_exists_prev = False
-    fake_df = pd.DataFrame()
-    fake_df.to_csv(os.path.join(exp_path, "demand_flexibility_up_Test.csv"))
-    fake_df.to_csv(os.path.join(exp_path, "demand_flexibility_dn_Test.csv"))
+    exp_path = f"raw/{grid.grid_model}"
+
+    for csv_file in (
+        "demand_flexibility_up_Test.csv",
+        "demand_flexibility_dn_Test.csv",
+    ):
+        with data_access.write(exp_path + "/" + csv_file) as f:
+            pd.DataFrame().to_csv(f)
 
     # Add a test instance of demand flexibility to the change table
     ct.add_demand_flexibility(
@@ -566,10 +567,3 @@ def test_add_demand_flexibility(ct):
         },
     }
     assert ct.ct == exp_dict
-
-    # Delete the created directory and fake data
-    if dir_exists_prev:
-        os.remove(os.path.join(exp_path, "demand_flexibility_up_Test.csv"))
-        os.remove(os.path.join(exp_path, "demand_flexibility_dn_Test.csv"))
-    else:
-        shutil.rmtree(os.path.join(Path.home(), "ScenarioData"))

--- a/powersimdata/input/transform_profile.py
+++ b/powersimdata/input/transform_profile.py
@@ -150,8 +150,10 @@ class TransformProfile:
 
         # Warn if data frame is now empty (i.e., no relevant zones/buses were provided)
         if len(df.columns) == 0:
-            print(
-                f"WARNING: The {name} profile does not contain relevant zones or buses."
+            raise ValueError(
+                f"The {name} profile does not contain zone or buse IDs located in the "
+                + f"{self.scenario_info['interconnect']} interconnect of the "
+                + f"{self.scenario_info['grid_model']} grid model."
             )
 
         # Return the pruned data frame

--- a/powersimdata/input/transform_profile.py
+++ b/powersimdata/input/transform_profile.py
@@ -133,22 +133,20 @@ class TransformProfile:
 
         # Determine if the demand flexibility profile is indexed by zone, bus, or both
         area_indicator = [1 if "zone." in x else 0 for x in df.columns]
-        if len(area_indicator) == sum(area_indicator):
-            # Demand flexibility profile only contains zones; prune accordingly
+        area_ids = []
+        if sum(area_indicator) > 0:
+            # Demand flexibility profile contains zone IDs
             zone_id = sorted(self.grid.bus.zone_id.unique())
             zone_id = [f"zone.{x}" for x in zone_id]
-            df = df.loc[:, df.columns.isin(zone_id)]
-        else:
-            bus_id = sorted(self.grid.bus.bus_id.unique())
+            area_ids += zone_id
+        if sum(area_indicator) < len(area_indicator):
+            # Demand flexibility profile contains bus IDs
+            bus_id = sorted(self.grid.bus.index.unique().values)
             bus_id = [str(x) for x in bus_id]
-            if len(area_indicator) > 0:
-                # Demand flexibility profile contains zones and buses; prune accordingly
-                zone_id = sorted(self.grid.bus.zone_id.unique())
-                zone_id = [f"zone.{x}" for x in zone_id]
-                df = df.loc[:, df.columns.isin(zone_id + bus_id)]
-            else:
-                # Demand flexibility profile only contains buses; prune accordingly
-                df = df.loc[:, df.columns.isin(bus_id)]
+            area_ids += bus_id
+
+        # Prune the data frame according to the mix of zone IDs and bus IDs
+        df = df.loc[:, df.columns.isin(area_ids)]
 
         # Warn if data frame is now empty (i.e., no relevant zones/buses were provided)
         if len(df.columns) == 0:

--- a/powersimdata/input/transform_profile.py
+++ b/powersimdata/input/transform_profile.py
@@ -131,15 +131,31 @@ class TransformProfile:
     def get_profile(self, name):
         """Return profile.
 
-        :param str name: either *'demand'*, *'hydro'*, *'solar'*, *'wind'*.
+        :param str name: either *demand*, *'hydro'*, *'solar'*, *'wind'*,
+            *'demand_flexibility_up'*, *'demand_flexibility_dn'*,
+            *'demand_flexibility_cost_up'*, or *'demand_flexibility_cost_dn'*.
         :return: (*pandas.DataFrame*) -- profile.
-        :raises ValueError: if argument not one of *'demand'*, *'hydro'*, *'solar'* or
-            *'wind'*.
+        :raises ValueError: if argument not one of *'demand'*, *'hydro'*, *'solar'*,
+            *'wind'*, *'demand_flexibility_up'*, *'demand_flexibility_dn'*,
+            *'demand_flexibility_cost_up'*, or *'demand_flexibility_cost_dn'*.
         """
-        possible = ["demand", "hydro", "solar", "wind"]
+        possible = [
+            "demand",
+            "hydro",
+            "solar",
+            "wind",
+            "demand_flexibility_up",
+            "demand_flexibility_dn",
+            "demand_flexibility_cost_up",
+            "demand_flexibility_cost_dn",
+        ]
         if name not in possible:
             raise ValueError("Choose from %s" % " | ".join(possible))
         elif name == "demand":
             return self._slice_df(self._get_demand_profile())
+        elif "demand_flexibility" in name:
+            flex_dem_dict = self.ct["demand_flexibility"]
+            flex_dem_dict["grid_model"] = self.scenario_info["grid_model"]
+            return self._input_data.get_data(flex_dem_dict, name)
         else:
             return self._slice_df(self._get_renewable_profile(name))

--- a/powersimdata/output/output_data.py
+++ b/powersimdata/output/output_data.py
@@ -20,7 +20,8 @@ class OutputData:
 
         :param str scenario_id: scenario id.
         :param str field_name: *'PG'*, *'PF'*, *'LMP'*, *'CONGU'*, *'CONGL'*,
-            *'AVERAGED_CONG'*, *'STORAGE_PG'* or *'STORAGE_E'*.
+            *'AVERAGED_CONG'*, *'STORAGE_PG'*, *'STORAGE_E'*, *'LOAD_SHIFT_UP'*,
+            or *'LOAD_SHIFT_DN'*.
         :return: (*pandas.DataFrame*) -- specified field as a data frame.
         :raises FileNotFoundError: if file not found on local machine.
         :raises ValueError: if second argument is not an allowable field.
@@ -38,11 +39,11 @@ def _check_field(field_name):
     """Checks field name.
 
     :param str field_name: *'PG'*, *'PF'*, *'PF_DCLINE'*, *'LMP'*, *'CONGU'*,
-        *'CONGL'*, *'AVERAGED_CONG'*, *'STORAGE_PG'*, *'STORAGE_E'*,
-        or *'LOAD_SHED'*
+        *'CONGL'*, *'AVERAGED_CONG'*, *'STORAGE_PG'*, *'STORAGE_E'*, *'LOAD_SHED'*,
+        *'LOAD_SHIFT_UP'*, or *'LOAD_SHIFT_DN'*.
     :raises ValueError: if not *'PG'*, *'PF'*, *'PF_DCLINE'*, *'LMP'*,
         *'CONGU'*, or *'CONGL'*, *'AVERAGED_CONG'*, *'STORAGE_PG'*,
-        *'STORAGE_E'*, or *'LOAD_SHED'*.
+        *'STORAGE_E'*, *'LOAD_SHED'*, *'LOAD_SHIFT_UP'*, or *'LOAD_SHIFT_DN'*.
     """
     possible = [
         "PG",
@@ -55,6 +56,8 @@ def _check_field(field_name):
         "STORAGE_PG",
         "STORAGE_E",
         "LOAD_SHED",
+        "LOAD_SHIFT_UP",
+        "LOAD_SHIFT_DN",
     ]
     if field_name not in possible:
         raise ValueError("Only %s data can be loaded" % " | ".join(possible))

--- a/powersimdata/scenario/analyze.py
+++ b/powersimdata/scenario/analyze.py
@@ -208,12 +208,7 @@ class Analyze(Ready):
 
             :return: (*pandas.DataFrame*) -- data frame of load shifted up (hour x bus).
             """
-            output_data = OutputData(data_loc=self.data_loc)
-            load_shift_up = output_data.get_data(
-                self._scenario_info["id"], "LOAD_SHIFT_UP"
-            )
-
-            return load_shift_up
+            return self._get_data("LOAD_SHIFT_UP")
 
         def get_load_shift_dn(self):
             """Returns LOAD_SHIFT_DN data frame. This is the amount that flexible demand
@@ -222,12 +217,7 @@ class Analyze(Ready):
             :return: (*pandas.DataFrame*) -- data frame of load shifted down (hour x
                 bus).
             """
-            output_data = OutputData(data_loc=self.data_loc)
-            load_shift_dn = output_data.get_data(
-                self._scenario_info["id"], "LOAD_SHIFT_DN"
-            )
-
-            return load_shift_dn
+            return self._get_data("LOAD_SHIFT_DN")
 
     def get_demand(self, original=True):
         """Returns demand profiles.

--- a/powersimdata/scenario/analyze.py
+++ b/powersimdata/scenario/analyze.py
@@ -26,6 +26,8 @@ class Analyze(Ready):
         "get_dcline_pf",
         "get_lmp",
         "get_load_shed",
+        "get_load_shift_up",
+        "get_load_shift_dn",
         "get_pf",
         "get_pg",
         "get_storage_e",
@@ -199,6 +201,33 @@ class Analyze(Ready):
                 pickle.dump(load_shed, f)
 
         return load_shed
+
+        def get_load_shift_up(self):
+            """Returns LOAD_SHIFT_UP data frame. This is the amount that flexible demand
+            deviates above (e.g., recovers) the base demand.
+
+            :return: (*pandas.DataFrame*) -- data frame of load shifted up (hour x bus).
+            """
+            output_data = OutputData(data_loc=self.data_loc)
+            load_shift_up = output_data.get_data(
+                self._scenario_info["id"], "LOAD_SHIFT_UP"
+            )
+
+            return load_shift_up
+
+        def get_load_shift_dn(self):
+            """Returns LOAD_SHIFT_DN data frame. This is the amount that flexible demand
+            deviates below (e.g., curtails) the base demand.
+
+            :return: (*pandas.DataFrame*) -- data frame of load shifted down (hour x
+                bus).
+            """
+            output_data = OutputData(data_loc=self.data_loc)
+            load_shift_dn = output_data.get_data(
+                self._scenario_info["id"], "LOAD_SHIFT_DN"
+            )
+
+            return load_shift_dn
 
     def get_demand(self, original=True):
         """Returns demand profiles.

--- a/powersimdata/scenario/execute.py
+++ b/powersimdata/scenario/execute.py
@@ -1,3 +1,4 @@
+import pandas as pd
 from scipy.io import savemat
 
 from powersimdata.data_access.context import Context
@@ -108,6 +109,15 @@ class Execute(Ready):
 
             si.prepare_mpc_file()
 
+            if "demand_flexibility" in self.ct:
+                # Prepare all specified demand flexibility profiles
+                for p in list(self.ct["demand_flexibility"]):
+                    if p != "demand_flexibility_duration":
+                        si.prepare_profile(p, profiles_as)
+
+                # Create the demand_flexibility_parameters file
+                si.prepare_demand_flexibility_parameters_file()
+
             prepared = "prepared"
             self._execute_list_manager.set_status(self.scenario_id, prepared)
             self._scenario_status = prepared
@@ -212,7 +222,9 @@ class SimulationInput:
     def prepare_profile(self, kind, profile_as=None, slice=False):
         """Prepares profile for simulation.
 
-        :param kind: one of *demand*, *'hydro'*, *'solar'* or *'wind'*.
+        :param kind: one of *demand*, *'hydro'*, *'solar'*, *'wind'*,
+            *'demand_flexibility_up'*, *'demand_flexibility_dn'*,
+            *'demand_flexibility_cost_up'*, or *'demand_flexibility_cost_dn'*.
         :param int/str profile_as: if given, copy profile from this scenario.
         :param bool slice: whether to slice the profiles by the Scenario's time range.
         """
@@ -229,3 +241,24 @@ class SimulationInput:
             from_dir = self._data_access.tmp_folder(profile_as)
             src = "/".join([from_dir, file_name])
             self._data_access.copy(src, self.REL_TMP_DIR)
+
+    def prepare_demand_flexibility_parameters_file(self):
+        """Creates the demand_flexibility_parameters file."""
+        # Construct a dictionary of the necessary parameters
+        print("Building demand flexibility parameters file")
+        params = {}
+        params["enabled"] = [True]
+        params["interval_balance"] = [True]
+        if "demand_flexibility_duration" in self.ct["demand_flexibility"]:
+            params["duration"] = [
+                self.ct["demand_flexibility"]["demand_flexibility_duration"]
+            ]
+            params["rolling_balance"] = [True]
+
+        # Convert the dictionary to a DataFrame to more easily save as a .csv file
+        params = pd.DataFrame.from_dict(params)
+
+        # Save the parameters as a .csv file and move the file to the correct location
+        file_path = "/".join([self.REL_TMP_DIR, "demand_flexibility_parameters.csv"])
+        with self._data_access.write(file_path, save_local=False) as f:
+            params.to_csv(f)

--- a/powersimdata/scenario/execute.py
+++ b/powersimdata/scenario/execute.py
@@ -249,11 +249,16 @@ class SimulationInput:
         params = {}
         params["enabled"] = [True]
         params["interval_balance"] = [True]
-        if "demand_flexibility_duration" in self.ct["demand_flexibility"]:
-            params["rolling_balance"] = [True]
-            params["duration"] = [
-                self.ct["demand_flexibility"]["demand_flexibility_duration"]
-            ]
+        params["rolling_balance"] = [
+            True
+            if "demand_flexibility_duration" in self.ct["demand_flexibility"]
+            else False
+        ]
+        params["duration"] = [
+            self.ct["demand_flexibility"]["demand_flexibility_duration"]
+            if "demand_flexibility_duration" in self.ct["demand_flexibility"]
+            else 0
+        ]
 
         # Convert the dictionary to a DataFrame to more easily save as a .csv file
         params = pd.DataFrame.from_dict(params)

--- a/powersimdata/scenario/execute.py
+++ b/powersimdata/scenario/execute.py
@@ -250,10 +250,10 @@ class SimulationInput:
         params["enabled"] = [True]
         params["interval_balance"] = [True]
         if "demand_flexibility_duration" in self.ct["demand_flexibility"]:
+            params["rolling_balance"] = [True]
             params["duration"] = [
                 self.ct["demand_flexibility"]["demand_flexibility_duration"]
             ]
-            params["rolling_balance"] = [True]
 
         # Convert the dictionary to a DataFrame to more easily save as a .csv file
         params = pd.DataFrame.from_dict(params)


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
The goal of this PR is to allow users to specify demand flexibility profiles and parameters in `PowerSimData`. This PR closes Issue #511.

### What the code is doing
Demand flexibility profiles and parameters are specified using the change table (via the `add_demand_flexibility` function). Demand flexibility profiles are accessed using the same core functionality as the other profile data. Accessing the demand flexibility profiles does differ slightly in that the profiles are not scaled (as you might see with demand, solar, wind, and hydro) and different area granularity can potentially be included (some combination of zone IDs and bus IDs, consistent with the allowed inputs in `REISE.jl`). This functionality is located in the `_get_demand_flexibility_profile` function. The final main addition is that the demand flexibility parameters file is created (via the `prepare_demand_flexibility_parameters` function) using the parameters input by the user. Other changes are less significant, such as including demand flexibility as a recognizable profile type and differentiating between demand profiles and demand flexibility profiles.

### Testing
Tests were completed locally using the Native set-up specified [here](https://breakthrough-energy.github.io/docs/user/installation_guide.html#natively). As has been discussed, there is an error when trying to run the specified scenario in `REISE.jl` from `PowerSimData`. Since the scenario creation works as expected (i.e., all input files are created in a single directory) and those files can be used in the standalone version of `REISE.jl`, I believe this problem lies not with the feature presented in this PR, but with the Native set-up (it seems to be an environment issue). This will be explored in a separate PR.

I have also started to include pytests (located in `test_change_table.py`), but I ran into an issue with what I was able to implement. Many of the demand-flexibility-related functions rely on checking or including the names of the different versions of the different demand flexibility profiles (e.g., version `EFS_x_y_z` of the demand flexibility up profile). Since none of these profiles are included in blob storage, the only location they are looked for is locally; unless these profiles are included locally, the functions will fail (e.g., as would be the case when pushing to GitHub). I was trying to implement something like what is seen in `mock_input_data.py` and `test_transform_profile.py`, but I couldn't figure out how to overcome the functions looking for the existence of the profiles. Any suggestions are welcome.

### Where to look
Most of the main changes are located in:
- `powersimdata/input/change_table.py`
- `powersimdata/input/transform_profile.py`
- `powersimdata/scenario/execute.py`

Smaller ancillary changes were made to:
- `powersimdata/data_access/profile_helper.py`
- `powersimdata/data_access/scenario_list.py`
- `powersimdata/input/input_data.py`

`powersimdata/output/output_data.py` and `powersimdata/scenario/analyze.py` include some changes that allow the demand-flexibility-related data to be accessed following the simulation. The test is located in `powersimdata/input/tests/test_change_table.py`.

### Time estimate
This will probably take a bit longer since it is a fairly big new feature.
