### PR TITLE
Add electrification profiles to change table

### DIFF
--- a/powersimdata/input/change_table.py
+++ b/powersimdata/input/change_table.py
@@ -523,7 +523,10 @@ class ChangeTable:
                     raise ValueError(f"Available {k} profiles: {', '.join(possible)}")
 
     def add_electrification(self, kind, info):
-        """TODO"""
+        """Add profiles and scaling factors for electrified demand.
+
+        See :func:`powersimdata.input.changes.electrification.add_electrification`
+        """
         add_electrification(self, kind, info)
 
     def add_dcline(self, info):

--- a/powersimdata/input/change_table.py
+++ b/powersimdata/input/change_table.py
@@ -6,6 +6,7 @@ from powersimdata.design.transmission.upgrade import (
     scale_renewable_stubs,
 )
 from powersimdata.input.changes.bus import add_bus, remove_bus
+from powersimdata.input.changes.electrification import add_electrification
 from powersimdata.input.changes.helpers import ordinal
 from powersimdata.input.changes.plant import add_plant, remove_plant, scale_plant_pmin
 from powersimdata.input.changes.storage import add_storage_capacity
@@ -520,6 +521,10 @@ class ChangeTable:
                 else:
                     del self.ct["demand_flexibility"]
                     raise ValueError(f"Available {k} profiles: {', '.join(possible)}")
+
+    def add_electrification(self, kind, info):
+        """TODO"""
+        add_electrification(self, kind, info)
 
     def add_dcline(self, info):
         """Adds HVDC line(s).

--- a/powersimdata/input/changes/electrification.py
+++ b/powersimdata/input/changes/electrification.py
@@ -8,6 +8,8 @@ def _check_scale_factors(scale_factors):
 
     :param dict scale_factors: see :func:`add_electrification`
     """
+    if not isinstance(scale_factors, dict):
+        raise ValueError("scale factors must be a dict")
     if not all(isinstance(k, str) for k in scale_factors):
         raise ValueError("profile name must be str")
     if not all(isinstance(d, (int, float)) for d in scale_factors.values()):
@@ -21,9 +23,9 @@ def _check_scale_factors(scale_factors):
 
 @dataclass
 class ScaleFactors:
-    """Map profile(s) to adoption rate
+    """Map technology to adoption rate
 
-    :param dict sf: a dictionary mapping profiles names to adoption rate
+    :param dict sf: a dictionary mapping tech to adoption rate
     """
 
     sf: Dict[str, float]
@@ -48,7 +50,7 @@ class AreaScaling:
 
     def __init__(self, info):
         if not isinstance(info, dict):
-            raise ValueError("scale factors must be a dict")
+            raise ValueError("zone/grid scaling must be a dict")
         if not all(isinstance(k, str) for k in info):
             raise ValueError("end use must be str")
         self.end_uses = {k: ScaleFactors(v) for k, v in info.items()}
@@ -59,7 +61,8 @@ class AreaScaling:
 
 @dataclass
 class ElectrifiedDemand:
-    """Container object for specifying profiles within a given class of electrification
+    """Container object for specifying zone or grid level adoption of any technologies
+    for a given class of electrification
 
     :param powersimdata.input.change_table.ChangeTable obj: change table
     :param dict info: see :func:`add_electrification`
@@ -89,7 +92,7 @@ class ElectrifiedDemand:
 
 
 def add_electrification(obj, kind, info):
-    """Add profiles and scaling factors for electrified demand.
+    """Add electrification profiles
 
     :param powersimdata.input.change_table.ChangeTable obj: change table
     :param str kind: the kind of demand, e.g. building

--- a/powersimdata/input/changes/electrification.py
+++ b/powersimdata/input/changes/electrification.py
@@ -26,7 +26,16 @@ def _check_zone_scaling(obj, info):
 
 
 def add_electrification(obj, kind, info):
-    """TODO"""
+    """Add profiles and scaling factors for electrified demand.
+
+    :param powersimdata.input.change_table.ChangeTable obj: change table
+    :param str kind: the kind of demand, e.g. building
+    :param dict info: Keys are *'grid'* and *'zone'*, to specify the scale factors in
+        the given area. For grid scaling, the value is a *dict*, which maps a *str* to
+        *float*. This dict is referred to as *scale_factors* here. The values in
+        *scale_factors* must be nonnegative and sum to at most 1. For zone scaling, the
+        value is also a *dict*, mapping zone names (*str*) to *scale_factors*.
+    """
 
     allowed = ["building", "transportation"]
     if kind not in allowed:

--- a/powersimdata/input/changes/electrification.py
+++ b/powersimdata/input/changes/electrification.py
@@ -2,6 +2,10 @@ import copy
 
 
 def _check_scale_factors(scale_factors):
+    """Validate schema of scale factors dict
+
+    :param dict scale_factors: see :func:`add_electrification`
+    """
     if not all(isinstance(k, str) for k in scale_factors):
         raise ValueError("profile name must be str")
     if not all(isinstance(d, (int, float)) for d in scale_factors.values()):
@@ -14,6 +18,11 @@ def _check_scale_factors(scale_factors):
 
 
 def _check_zone_scaling(obj, info):
+    """Validate schema for zone scaling
+
+    :param powersimdata.input.change_table.ChangeTable obj: change table
+    :param dict info: see :func:`add_electrification`
+    """
     if not all(isinstance(k, str) for k in info):
         raise ValueError("zone name must be str")
     if all(isinstance(d, dict) for d in info.values()):

--- a/powersimdata/input/changes/electrification.py
+++ b/powersimdata/input/changes/electrification.py
@@ -1,0 +1,41 @@
+import copy
+
+
+def add_electrification(obj, kind, info):
+    """TODO"""
+
+    allowed = ["building", "transportation"]
+    if kind not in allowed:
+        raise ValueError(f"unrecognized class of electrification: {kind}")
+
+    info = copy.deepcopy(info)
+
+    # list of dictionaries, each of which must have scaling factors sum
+    # between 0 and 1
+    scale_factors = []
+
+    if all(isinstance(k, str) for k in info):
+        # scale by zone
+        if all(isinstance(d, dict) for d in info.values()):
+            obj._check_zone(info.keys())
+            scale_factors.extend(info.values())
+        # scale entire grid by same factor
+        elif all(isinstance(d, (int, float)) for d in info.values()):
+            scale_factors.append(info)
+        else:
+            raise ValueError("unrecognized structure")
+    else:
+        raise ValueError("unrecognized structure")
+
+    for sf in scale_factors:
+        vals = list(sf.values())
+        if any(v < 0 for v in vals):
+            raise ValueError("scaling factor must be non negative")
+        if sum(vals) > 1:
+            raise ValueError("scaling factors must sum to between 0 and 1")
+
+    curr = obj.ct.get(kind)
+    if curr is None:
+        obj.ct[kind] = info
+    else:
+        obj.ct[kind].update(info)

--- a/powersimdata/input/changes/electrification.py
+++ b/powersimdata/input/changes/electrification.py
@@ -38,13 +38,13 @@ def add_electrification(obj, kind, info):
     if not set(info) <= {"zone", "grid"}:
         raise ValueError("unrecognized scaling key")
 
-    if "zone" in info:
-        _check_zone_scaling(obj, info["zone"])
-    if "grid" in info:
-        _check_grid_scaling(info["grid"])
+    zone = info.get("zone", {})
+    grid = info.get("grid", {})
+    _check_zone_scaling(obj, zone)
+    _check_grid_scaling(grid)
 
     curr = obj.ct.get(kind)
     if curr is None:
         obj.ct[kind] = {"grid": {}, "zone": {}}
-    obj.ct[kind]["grid"].update(info.get("grid", {}))
-    obj.ct[kind]["zone"].update(info.get("zone", {}))
+    obj.ct[kind]["grid"].update(grid)
+    obj.ct[kind]["zone"].update(zone)

--- a/powersimdata/input/changes/electrification.py
+++ b/powersimdata/input/changes/electrification.py
@@ -2,28 +2,27 @@ import copy
 
 
 def _check_scale_factors(scale_factors):
-    for sf in scale_factors:
-        vals = list(sf.values())
-        if any(v < 0 for v in vals):
-            raise ValueError("scaling factor must be non negative")
-        if sum(vals) > 1:
-            raise ValueError("scaling factors must sum to between 0 and 1")
+    if not all(isinstance(k, str) for k in scale_factors):
+        raise ValueError("profile name must be str")
+    if not all(isinstance(d, (int, float)) for d in scale_factors.values()):
+        raise ValueError("scale factors must be numeric")
+    vals = list(scale_factors.values())
+    if any(v < 0 for v in vals):
+        raise ValueError("scaling factor must be non negative")
+    if sum(vals) > 1:
+        raise ValueError("scaling factors must sum to between 0 and 1")
 
 
 def _check_zone_scaling(obj, info):
     if not all(isinstance(k, str) for k in info):
-        raise ValueError("unrecognized structure")
+        raise ValueError("zone name must be str")
     if all(isinstance(d, dict) for d in info.values()):
         obj._check_zone(info.keys())
-    _check_scale_factors(list(info.values()))
+    else:
+        raise ValueError("zone scaling must be specified via a dict")
 
-
-def _check_grid_scaling(info):
-    if not all(isinstance(k, str) for k in info):
-        raise ValueError("keys must be str")
-    if not all(isinstance(d, (int, float)) for d in info.values()):
-        raise ValueError("scale factors must be numeric")
-    _check_scale_factors([info])
+    for sf in list(info.values()):
+        _check_scale_factors(sf)
 
 
 def add_electrification(obj, kind, info):
@@ -41,7 +40,7 @@ def add_electrification(obj, kind, info):
     zone = info.get("zone", {})
     grid = info.get("grid", {})
     _check_zone_scaling(obj, zone)
-    _check_grid_scaling(grid)
+    _check_scale_factors(grid)
 
     curr = obj.ct.get(kind)
     if curr is None:

--- a/powersimdata/input/changes/tests/test_add_electrification.py
+++ b/powersimdata/input/changes/tests/test_add_electrification.py
@@ -1,0 +1,43 @@
+import pytest
+
+from powersimdata.input.change_table import ChangeTable
+from powersimdata.input.changes.electrification import add_electrification
+from powersimdata.input.grid import Grid
+
+
+def test_add_electrification():
+    obj = ChangeTable(Grid("Texas"))
+    kind = "building"
+
+    info = {"standard_heat_pump_v1": 0.7, "advanced_heat_pump_v2": 0.3}
+    add_electrification(obj, kind, info)
+
+    with pytest.raises(ValueError):
+        add_electrification(obj, "foo", info)
+
+    with pytest.raises(ValueError):
+        info = {"standard_heat_pump_v1": 0.7, "advanced_heat_pump_v2": -3}
+        add_electrification(obj, kind, info)
+
+    with pytest.raises(ValueError):
+        info = {"standard_heat_pump_v1": 0.7, "advanced_heat_pump_v2": 0.8}
+        add_electrification(obj, kind, info)
+
+
+def test_add_electrification_by_zone():
+    obj = ChangeTable(Grid("Eastern"))
+    kind = "building"
+
+    info = {
+        "New York City": {"standard_heat_pump_v1": 0.3, "advanced_heat_pump_v2": 0.7},
+        "Western North Carolina": {
+            "standard_heat_pump_v1": 0.5,
+            "advanced_heat_pump_v2": 0.5,
+        },
+        "Maine": {"standard_heat_pump_v1": 0.2, "advanced_heat_pump_v2": 0.8},
+    }
+    add_electrification(obj, kind, info)
+
+    with pytest.raises(ValueError):
+        info = {1: {"foo": 3}, "wrong": {}}
+        add_electrification(obj, kind, info)

--- a/powersimdata/input/changes/tests/test_add_electrification.py
+++ b/powersimdata/input/changes/tests/test_add_electrification.py
@@ -2,21 +2,11 @@ import pytest
 
 from powersimdata.input.change_table import ChangeTable
 from powersimdata.input.changes.electrification import (
-    _check_grid_scaling,
     _check_scale_factors,
     _check_zone_scaling,
     add_electrification,
 )
 from powersimdata.input.grid import Grid
-
-
-def test_check_grid():
-    info = {"tech1": 0.8}
-    _check_grid_scaling(info)
-
-    with pytest.raises(ValueError):
-        info = {"tech1": 4}
-        _check_grid_scaling(info)
 
 
 def test_check_zone():
@@ -30,13 +20,17 @@ def test_check_zone():
 
 
 def test_check_scale_factors():
+    with pytest.raises(ValueError):
+        info = {"tech1": "foo"}
+        _check_scale_factors(info)
+
     info = {"standard_heat_pump_v1": 0.7, "advanced_heat_pump_v2": -3}
     with pytest.raises(ValueError):
-        _check_scale_factors([info])
+        _check_scale_factors(info)
 
     with pytest.raises(ValueError):
         info = {"standard_heat_pump_v1": 0.7, "advanced_heat_pump_v2": 0.8}
-        _check_scale_factors([info])
+        _check_scale_factors(info)
 
 
 def test_add_electrification():

--- a/powersimdata/input/changes/tests/test_add_electrification.py
+++ b/powersimdata/input/changes/tests/test_add_electrification.py
@@ -12,8 +12,11 @@ from powersimdata.input.grid import Grid
 
 def test_scale_factors():
     info = {"standard_heat_pump_v1": 0.7, "advanced_heat_pump_v2": -3}
-    with pytest.raises(ValueError):
-        ScaleFactors(info)
+
+    invalid = (info, [1, 2, 3], {123: 456}, {"foo": "bar"})
+    for arg in invalid:
+        with pytest.raises(ValueError):
+            ScaleFactors(arg)
 
     info["advanced_heat_pump_v2"] = 0.3
     result = ScaleFactors(info)

--- a/powersimdata/input/changes/tests/test_add_electrification.py
+++ b/powersimdata/input/changes/tests/test_add_electrification.py
@@ -29,14 +29,20 @@ def test_add_electrification_by_zone():
     kind = "building"
 
     info = {
-        "New York City": {"standard_heat_pump_v1": 0.3, "advanced_heat_pump_v2": 0.7},
+        "New York City": {"advanced_heat_pump_v2": 0.7},
         "Western North Carolina": {
             "standard_heat_pump_v1": 0.5,
             "advanced_heat_pump_v2": 0.5,
         },
-        "Maine": {"standard_heat_pump_v1": 0.2, "advanced_heat_pump_v2": 0.8},
     }
     add_electrification(obj, kind, info)
+    assert 2 == len(obj.ct[kind].keys())
+
+    info = {"Maine": {"standard_heat_pump_v1": 0.2, "advanced_heat_pump_v2": 0.8}}
+    add_electrification(obj, kind, info)
+    result = obj.ct[kind]
+    assert 3 == len(result.keys())
+    assert "Maine" in result
 
     with pytest.raises(ValueError):
         info = {1: {"foo": 3}, "wrong": {}}

--- a/powersimdata/input/changes/tests/test_add_electrification.py
+++ b/powersimdata/input/changes/tests/test_add_electrification.py
@@ -47,3 +47,18 @@ def test_add_electrification_by_zone():
     with pytest.raises(ValueError):
         info = {1: {"foo": 3}, "wrong": {}}
         add_electrification(obj, kind, info)
+
+
+def test_add_electrification_combined():
+    obj = ChangeTable(Grid("Eastern"))
+    kind = "building"
+
+    info = {"Maine": {"standard_heat_pump_v1": 0.2, "advanced_heat_pump_v2": 0.8}}
+    add_electrification(obj, kind, info)
+
+    info = {"standard_heat_pump_v1": 0.7}
+    add_electrification(obj, kind, info)
+
+    result = obj.ct[kind]
+    assert "Maine" in result
+    assert "standard_heat_pump_v1" in result

--- a/powersimdata/input/changes/tests/test_add_electrification.py
+++ b/powersimdata/input/changes/tests/test_add_electrification.py
@@ -13,22 +13,22 @@ from powersimdata.input.grid import Grid
 def test_scale_factors():
     info = {"standard_heat_pump_v1": 0.7, "advanced_heat_pump_v2": -3}
     with pytest.raises(ValueError):
-        ScaleFactors.from_dict(info)
+        ScaleFactors(info)
 
     info["advanced_heat_pump_v2"] = 0.3
-    result = ScaleFactors.from_dict(info)
+    result = ScaleFactors(info)
     assert info == result.value()
 
 
 def test_area_scaling():
     with pytest.raises(ValueError):
-        AreaScaling.from_dict([])
+        AreaScaling([])
     with pytest.raises(ValueError):
-        AreaScaling.from_dict({1: 2})
+        AreaScaling({1: 2})
 
     sf = {"standard_heat_pump_v1": 0.7, "advanced_heat_pump_v2": 0.2}
     info = {"res_heating": sf}
-    result = AreaScaling.from_dict(info)
+    result = AreaScaling(info)
     assert info == result.value()
 
 

--- a/powersimdata/input/changes/tests/test_add_electrification.py
+++ b/powersimdata/input/changes/tests/test_add_electrification.py
@@ -34,6 +34,10 @@ def test_check_scale_factors():
     with pytest.raises(ValueError):
         _check_scale_factors([info])
 
+    with pytest.raises(ValueError):
+        info = {"standard_heat_pump_v1": 0.7, "advanced_heat_pump_v2": 0.8}
+        _check_scale_factors([info])
+
 
 def test_add_electrification():
     obj = ChangeTable(Grid("Texas"))
@@ -44,14 +48,6 @@ def test_add_electrification():
 
     with pytest.raises(ValueError):
         add_electrification(obj, "foo", {"grid": info})
-
-    with pytest.raises(ValueError):
-        info = {"standard_heat_pump_v1": 0.7, "advanced_heat_pump_v2": -3}
-        add_electrification(obj, kind, {"grid": info})
-
-    with pytest.raises(ValueError):
-        info = {"standard_heat_pump_v1": 0.7, "advanced_heat_pump_v2": 0.8}
-        add_electrification(obj, kind, {"grid": info})
 
 
 def test_add_electrification_by_zone():
@@ -65,14 +61,11 @@ def test_add_electrification_by_zone():
             "advanced_heat_pump_v2": 0.5,
         },
     }
-
-    with pytest.raises(ValueError):
-        add_electrification(obj, kind, info)
-
     add_electrification(obj, kind, {"zone": info})
 
     info = {"Maine": {"standard_heat_pump_v1": 0.2, "advanced_heat_pump_v2": 0.8}}
     add_electrification(obj, kind, {"zone": info})
+
     result = obj.ct[kind]
     assert "Maine" in result["zone"]
     assert "New York City" in result["zone"]
@@ -82,11 +75,9 @@ def test_add_electrification_combined():
     obj = ChangeTable(Grid("Eastern"))
     kind = "building"
 
-    info = {"Maine": {"standard_heat_pump_v1": 0.2, "advanced_heat_pump_v2": 0.8}}
-    add_electrification(obj, kind, {"zone": info})
-
-    info = {"standard_heat_pump_v1": 0.7}
-    add_electrification(obj, kind, {"grid": info})
+    zone = {"Maine": {"standard_heat_pump_v1": 0.2, "advanced_heat_pump_v2": 0.8}}
+    grid = {"standard_heat_pump_v1": 0.7}
+    add_electrification(obj, kind, {"grid": grid, "zone": zone})
 
     result = obj.ct[kind]
     assert "Maine" in result["zone"]

--- a/powersimdata/scenario/scenario.py
+++ b/powersimdata/scenario/scenario.py
@@ -17,6 +17,7 @@ class Scenario:
 
     :param int/str descriptor: scenario name or index. If None, default to a Scenario
         in Create state.
+    :raises TypeError: if descriptor is not int or str
     """
 
     _setattr_allowlist = {


### PR DESCRIPTION
### Purpose
Define/implement new schema for electrification profiles and scaling by grid/zone. 

### What the code is doing
Define one new function `add_electrification` which can specify profiles and scaling for supported types: currently these are building and transportation. If specifying scaling factors by zone, the zone name is checked against the current grid object. There isn't yet validation for the profile name/version, but I'll add that if the general approach looks good. 

Depending on expected usage patterns, the schema could also be "inverted" by mapping profiles to zones and scaling factors, but I think either way has trade offs in how easy it is to specify the change table and how much code is required to aggregate the profiles during the preparation phase. 

### Testing
New unit tests.

### Usage Example/Visuals
The tests are the best usage example. The full schema will look like:
```
{
    "building": {
        "grid": [scale_factors],
        "zone": { zone_name: [scale_factors], ... }
    },
    "transportation": {...}
}
```
Where the `scale_factors` dict has the structure:
```
{profile_name_and_version_1: s_1, profile_name_and_version_2: s_2, ...} 
```
And `0 <= s_i <= 1`

### Time estimate
20 min
