### PR TITLE
Add import_data module with pypsa importer

### DIFF
--- a/powersimdata/input/export_data.py
+++ b/powersimdata/input/export_data.py
@@ -5,7 +5,6 @@ import numpy as np
 import pandas as pd
 from scipy.io import savemat
 
-from powersimdata import Grid
 from powersimdata.input.transform_profile import TransformProfile
 
 PYPSA_AVAILABLE = True
@@ -317,6 +316,7 @@ def export_to_pypsa(
         generators to the exported pypsa network. This ensures feasibility when
         optimizing the exported pypsa network as is. The default is True.
     """
+    from powersimdata.input.grid import Grid  # avoid circular import
     from powersimdata.scenario.scenario import Scenario  # avoid circular import
 
     if not PYPSA_AVAILABLE:

--- a/powersimdata/input/export_data.py
+++ b/powersimdata/input/export_data.py
@@ -450,7 +450,6 @@ def export_to_pypsa(
     transformers = branches.query(
         "branch_device_type in ['TransformerWinding', 'Transformer']"
     )
-    transformers = transformers.drop(columns="branch_device_type")
 
     if scenario:
         lines_t = {}

--- a/powersimdata/input/export_data.py
+++ b/powersimdata/input/export_data.py
@@ -524,5 +524,5 @@ def export_to_pypsa(
         )
         n.add("Carrier", "load", nice_name="Load Shedding", color="red")
 
-    n.name = ", ".join(grid.interconnect)
+    n.name = ", ".join([grid.data_loc] + grid.interconnect)
     return n

--- a/powersimdata/input/export_data.py
+++ b/powersimdata/input/export_data.py
@@ -524,4 +524,5 @@ def export_to_pypsa(
         )
         n.add("Carrier", "load", nice_name="Load Shedding", color="red")
 
+    n.name = ", ".join(grid.interconnect)
     return n

--- a/powersimdata/input/grid.py
+++ b/powersimdata/input/grid.py
@@ -18,6 +18,7 @@ class Grid:
 
     SUPPORTED_MODELS = {"usa_tamu"}
     SUPPORTED_ENGINES = {"REISE", "REISE.jl"}
+    SUPPORTED_IMPORTS = {"pypsa"}
 
     """Grid
 
@@ -82,8 +83,9 @@ class Grid:
         if use_cache:
             _cache.put(key, self)
 
-        self.grid_model = self._get_grid_model()
-        self.model_immutables = ModelImmutables(self.grid_model)
+        if self.data_loc not in self.SUPPORTED_IMPORTS:
+            self.grid_model = self._get_grid_model()
+            self.model_immutables = ModelImmutables(self.grid_model)
 
     def _get_grid_model(self):
         """Get the grid model.

--- a/powersimdata/input/grid.py
+++ b/powersimdata/input/grid.py
@@ -35,7 +35,10 @@ class Grid:
         """Constructor."""
         if not isinstance(source, str):
             raise TypeError("source must be a str")
-        if source not in self.SUPPORTED_MODELS and not source.endswith(".mat"):
+        if (
+            source not in self.SUPPORTED_MODELS | self.SUPPORTED_IMPORTS
+            and not source.endswith(".mat")
+        ):
             raise ValueError(
                 f"Source must be one of {','.join(self.SUPPORTED_MODELS)} "
                 "or the path to a .mat file that represents a grid "

--- a/powersimdata/input/grid.py
+++ b/powersimdata/input/grid.py
@@ -1,7 +1,5 @@
 import os
 
-from pandas import DataFrame
-
 from powersimdata.data_access.context import Context
 from powersimdata.data_access.scenario_list import ScenarioListManager
 from powersimdata.input.import_data import FromPyPSA, is_pypsa_network
@@ -113,12 +111,16 @@ class Grid:
             :raises AssertionError: if no equality can be confirmed (w/o failure_flag).
             """
             try:
-                if isinstance(ref, DataFrame) and isinstance(test, DataFrame):
+                try:
+                    test_eq = ref == test
+                    if isinstance(test_eq, bool):
+                        assert test_eq
+                    else:
+                        assert test_eq.all().all()
+                except ValueError:
                     assert set(ref.columns) == set(test.columns)
                     for col in ref.columns:
                         assert (ref[col] == test[col]).all()
-                else:
-                    assert ref == test
             except (AssertionError, ValueError):
                 if failure_flag is None:
                     raise

--- a/powersimdata/input/grid.py
+++ b/powersimdata/input/grid.py
@@ -1,5 +1,7 @@
 import os
 
+from pandas import DataFrame
+
 from powersimdata.data_access.context import Context
 from powersimdata.data_access.scenario_list import ScenarioListManager
 from powersimdata.input.import_data import FromPyPSA, is_pypsa_network
@@ -101,7 +103,7 @@ class Grid:
         """
 
         def _univ_eq(ref, test, failure_flag=None):
-            """Check for {boolean, dataframe, or column data} equality.
+            """Check for {boolean or column data} equality.
 
             :param object ref: one object to be tested (order does not matter).
             :param object test: another object to be tested.
@@ -109,16 +111,12 @@ class Grid:
             :raises AssertionError: if no equality can be confirmed (w/o failure_flag).
             """
             try:
-                try:
-                    test_eq = ref == test
-                    if isinstance(test_eq, bool):
-                        assert test_eq
-                    else:
-                        assert test_eq.all().all()
-                except ValueError:
+                if isinstance(ref, DataFrame) and isinstance(test, DataFrame):
                     assert set(ref.columns) == set(test.columns)
                     for col in ref.columns:
                         assert (ref[col] == test[col]).all()
+                else:
+                    assert ref == test
             except (AssertionError, ValueError):
                 if failure_flag is None:
                     raise

--- a/powersimdata/input/import_data.py
+++ b/powersimdata/input/import_data.py
@@ -1,0 +1,250 @@
+from .abstract_grid import AbstractGrid
+from .export_data import pypsa_const as pypsa_export_const
+import pandas as pd
+import numpy as np
+import warnings
+
+pypsa_import_const = {
+    "bus": {
+        "default_drop_cols": [
+            "interconnect_sub_id",
+            "is_substation",
+            "name",
+            "substation",
+            "unit",
+            "v_mag_pu_max",
+            "v_mag_pu_min",
+            "v_mag_pu_set",
+            "zone_name",
+            "carrier",
+            "sub_network",
+        ]
+    },
+    "generator": {
+        "default_drop_cols": [
+            "build_year",
+            "capital_cost",
+            "committable",
+            "control",
+            "down_time_before",
+            "efficiency",
+            "lifetime",
+            "marginal_cost",
+            "min_down_time",
+            "min_up_time",
+            "p_max_pu",
+            "p_nom_extendable",
+            "p_nom_max",
+            "p_nom_min",
+            "p_nom_opt",
+            "p_set",
+            "q_set",
+            "ramp_limit_down",
+            "ramp_limit_shut_down",
+            "ramp_limit_start_up",
+            "ramp_limit_up",
+            "shutdown_cost",
+            "sign",
+            "startup_cost",
+            "up_time_before",
+        ]
+    },
+    "branch": {
+        "default_drop_cols": [
+            "build_year",
+            "capital_cost",
+            "carrier",
+            "g",
+            "length",
+            "lifetime",
+            "model",
+            "num_parallel",
+            "phase_shift",
+            "r_pu_eff",
+            "s_max_pu",
+            "s_nom_extendable",
+            "s_nom_max",
+            "s_nom_min",
+            "s_nom_opt",
+            "sub_network",
+            "tap_position",
+            "tap_side",
+            "terrain_factor",
+            "type",
+            "v_ang_max",
+            "v_ang_min",
+            "v_nom",
+            "x_pu_eff",
+        ]
+    },
+    "link": {
+        "default_drop_cols": [
+            "build_year",
+            "capital_cost",
+            "carrier",
+            "efficiency",
+            "length",
+            "lifetime",
+            "marginal_cost",
+            "p_max_pu",
+            "p_nom_extendable",
+            "p_nom_max",
+            "p_nom_min",
+            "p_nom_opt",
+            "p_set",
+            "ramp_limit_down",
+            "ramp_limit_up",
+            "terrain_factor",
+            "type",
+        ]
+    },
+}
+
+
+class FromPyPSA(AbstractGrid):
+    """Network reader for PyPSA networks."""
+
+    def __init__(self, network, drop_cols=True):
+        """Constructor.
+
+        :param pypsa.Network network: Network to read in.
+        """
+        super().__init__()
+        self._read_network(network, drop_cols=drop_cols)
+
+    def _read_network(self, n, drop_cols=True):
+
+        # BUS, INTERCONNECT, SUB, SHUNTS
+        interconnect = n.name.split(", ")
+        df = n.df("Bus").drop(columns="type")
+        bus = _translate_df(df, "bus")
+        bus["type"] = bus.type.replace(["PQ", "PV", "slack", ""], [1, 2, 3, 4])
+        bus.index.name = "bus_id"
+
+        if "zone_id" in n.buses and "zone_name" in n.buses:
+            uniques = ~n.buses.zone_id.duplicated() * n.buses.zone_id.notnull()
+            zone2id = (
+                n.buses[uniques].set_index("zone_name").zone_id.astype(int).to_dict()
+            )
+            id2zone = revert_dict(zone2id)
+
+        if "is_substation" in bus:
+            # TODO: Hard-coded:
+            cols = ["name", "interconnect_sub_id", "lat", "lon", "interconnect"]
+            sub = bus[bus.is_substation][cols]
+            sub.index = sub[sub.index.str.startswith("sub")].index.str[3:]
+            sub.index.name = "sub_id"
+            bus = bus[~bus.is_substation]
+        else:
+            warnings.warn("Substations could not be parsed.")
+            sub = pd.DataFrame()
+
+        if not n.shunt_impedances.empty:
+            shunts = _translate_df(n.shunt_impedances, "bus")
+            bus[["Bs", "Gs"]] = shunts[["Bs", "Gs"]]
+
+        # PLANT & GENCOST
+        df = n.generators.drop(columns=["type"])
+        plant = _translate_df(df, "generator")
+        plant["ramp_30"] = n.generators["ramp_limit_up"].fillna(0)
+        plant["Pmin"] *= plant["Pmax"]  # from relative to absolute value
+        plant["bus_id"] = pd.to_numeric(plant.bus_id, errors="ignore")
+        plant.index.name = "plant_id"
+
+        # TODO: Hard-coded:
+        keep_cols = [
+            "type",
+            "startup",
+            "shutdown",
+            "n",
+            "c2",
+            "c1",
+            "c0",
+            "interconnect",
+        ]
+        gencost = _translate_df(df, "cost")
+        gencost = gencost.assign(type=2, n=3, c0=0, c2=0)
+        gencost = gencost[keep_cols]
+        gencost.index.name = "plant_id"
+
+        # BRANCHES
+        # TODO: Hard-coded:
+        drop_cols = ["x", "r", "b", "g"]  # drop these in advance
+        df = n.lines.drop(columns=drop_cols)
+        lines = _translate_df(df, "branch")
+        lines["branch_device_type"] = "Line"
+
+        df = n.transformers.drop(columns=drop_cols)
+        transformers = _translate_df(df, "branch")
+        transformers["branch_device_type"] = "Transformer"
+
+        branch = pd.concat([lines, transformers])
+        branch["x"] *= 100
+        branch["r"] *= 100
+        branch["from_bus_id"] = pd.to_numeric(branch.from_bus_id, errors="ignore")
+        branch["to_bus_id"] = pd.to_numeric(branch.to_bus_id, errors="ignore")
+        branch.index.name = "branch_id"
+
+        # DC LINES
+        df = n.df("Link")[lambda df: df.index.str[:3] != "sub"]
+        dcline = _translate_df(df, "link")
+        dcline["Pmin"] *= dcline["Pmax"]  # convert relative to absolute
+
+        # STORAGES
+        if not n.storage_units.empty or not n.stores.empty:
+            warnings.warn("The export of storages are not implemented yet.")
+
+        # Drop columns if wanted
+        if drop_cols:
+            _drop_cols(bus, "bus")
+            _drop_cols(plant, "generator")
+            _drop_cols(branch, "branch")
+            _drop_cols(dcline, "link")
+
+        # Pull operational properties into grid object
+        if len(n.snapshots) == 1:
+            bus = bus.assign(**_translate_pnl(n.pnl("Bus"), "bus"))
+            bus["Va"] = np.rad2deg(bus["Va"])
+            bus = bus.assign(**_translate_pnl(n.pnl("Load"), "bus"))
+            plant = plant.assign(**_translate_pnl(n.pnl("Generator"), "generator"))
+            _ = pd.concat(
+                [_translate_pnl(n.pnl(c), "branch") for c in ["Line", "Transformer"]]
+            )
+            branch = branch.assign(**_)
+            dcline = dcline.assign(**_translate_pnl(n.pnl("Link"), "link"))
+
+        # Convert to numeric
+        for df in (bus, sub, gencost, plant, branch, dcline):
+            df.index = pd.to_numeric(df.index, errors="ignore")
+
+        self.interconnect = interconnect
+        self.bus = bus
+        self.sub = sub
+        self.branch = branch.sort_index()
+        self.dcline = dcline
+        self.zone2id = zone2id
+        self.id2zone = id2zone
+        self.plant = plant
+        self.gencost["before"] = gencost
+        self.gencost["after"] = gencost
+
+
+def _drop_cols(df, key):
+    df.drop(columns=pypsa_import_const[key]["default_drop_cols"], inplace=True)
+
+
+def _translate_df(df, key):
+    translators = revert_dict(pypsa_export_const[key]["rename"])
+    return df.rename(columns=translators)
+
+
+def _translate_pnl(pnl, key):
+    translators = revert_dict(pypsa_export_const[key]["rename_t"])
+    df = pd.concat(
+        {v: pnl[k].iloc[0] for k, v in translators.items() if k in pnl}, axis=1
+    )
+    return df
+
+
+def revert_dict(d):
+    return {v: k for (k, v) in d.items()}

--- a/powersimdata/input/import_data.py
+++ b/powersimdata/input/import_data.py
@@ -1,8 +1,10 @@
+import warnings
+
+import numpy as np
+import pandas as pd
+
 from .abstract_grid import AbstractGrid
 from .export_data import pypsa_const as pypsa_export_const
-import pandas as pd
-import numpy as np
-import warnings
 
 pypsa_import_const = {
     "bus": {
@@ -71,14 +73,14 @@ pypsa_import_const = {
         ]
     },
     "branch": {
-        # these need to be dropped as they appear in both pypsa and powersimdata but need 
+        # these need to be dropped as they appear in both pypsa and powersimdata but need
         # to be translated at the same time
         "drop_cols_in_advance": [
             "x",
             "r",
             "b",
             "g",
-        ],  
+        ],
         "default_drop_cols": [
             "build_year",
             "capital_cost",

--- a/powersimdata/input/import_data.py
+++ b/powersimdata/input/import_data.py
@@ -210,6 +210,8 @@ class FromPyPSA(AbstractGrid):
 
         df = n.transformers.drop(columns=drop_cols, errors="ignore")
         transformers = self._translate_df(df, "branch")
+        if "branch_device_type" not in transformers:
+            transformers["branch_device_type"] = "Transfomer"
 
         branch = pd.concat([lines, transformers])
         branch["x"] *= 100

--- a/powersimdata/input/tests/test_import_from_pypsa.py
+++ b/powersimdata/input/tests/test_import_from_pypsa.py
@@ -9,6 +9,8 @@ from powersimdata.input.grid import Grid
 def test_import_arbitrary_network_from_pypsa():
     import pypsa
 
+    # TODO: How to deal with immutables and data_loc which is not in
+    # powersimdata.grid.Grid.SUPPORTED_MODELS?
     n = pypsa.examples.ac_dc_meshed()
     grid = Grid(n)
 

--- a/powersimdata/input/tests/test_import_from_pypsa.py
+++ b/powersimdata/input/tests/test_import_from_pypsa.py
@@ -23,8 +23,14 @@ def test_import_exported_network():
     n = export_to_pypsa(ref, **kwargs)
     test = Grid(n)
 
-    # TODO: Only the linear cost term is exported to pypsa
-    for c in ["c0", "c2"]:
+    # Only a scaled version of linear cost term is exported to pypsa
+    # Test whether the exported marginal cost is in the same order of magnitude
+    ref_total_c1 = ref.gencost["before"]["c1"].sum()
+    test_total_c1 = test.gencost["before"]["c1"].sum()
+    assert ref_total_c1 / test_total_c1 > 0.95 and ref_total_c1 / test_total_c1 < 1.05
+
+    # Now overwrite costs
+    for c in ["c0", "c1", "c2"]:
         test.gencost["before"][c] = ref.gencost["before"][c]
         test.gencost["after"][c] = ref.gencost["after"][c]
 

--- a/powersimdata/input/tests/test_import_from_pypsa.py
+++ b/powersimdata/input/tests/test_import_from_pypsa.py
@@ -4,18 +4,16 @@ from pandas.testing import assert_series_equal
 from powersimdata.input.export_data import PYPSA_AVAILABLE, export_to_pypsa
 from powersimdata.input.grid import Grid
 
-# @pytest.mark.skipif(not PYPSA_AVAILABLE, reason="Package PyPSA not available.")
-# def test_import_arbitrary_network_from_pypsa():
-#     import pypsa
 
-# TODO: How to deal with immutables and data_loc which is not in
-# powersimdata.grid.Grid.SUPPORTED_MODELS?
+@pytest.mark.skipif(not PYPSA_AVAILABLE, reason="Package PyPSA not available.")
+def test_import_arbitrary_network_from_pypsa():
+    import pypsa
 
-# n = pypsa.examples.ac_dc_meshed()
-# grid = Grid(n)
+    n = pypsa.examples.ac_dc_meshed()
+    grid = Grid(n)
 
-# assert not grid.bus.empty
-# assert len(n.buses) == len(grid.bus)
+    assert not grid.bus.empty
+    assert len(n.buses) == len(grid.bus)
 
 
 @pytest.mark.skipif(not PYPSA_AVAILABLE, reason="Package PyPSA not available.")

--- a/powersimdata/input/tests/test_import_from_pypsa.py
+++ b/powersimdata/input/tests/test_import_from_pypsa.py
@@ -11,11 +11,12 @@ def test_import_arbitrary_network_from_pypsa():
 
     # TODO: How to deal with immutables and data_loc which is not in
     # powersimdata.grid.Grid.SUPPORTED_MODELS?
-    n = pypsa.examples.ac_dc_meshed()
-    grid = Grid(n)
 
-    assert not grid.bus.empty
-    assert len(n.buses) == len(grid.bus)
+    # n = pypsa.examples.ac_dc_meshed()
+    # grid = Grid(n)
+
+    # assert not grid.bus.empty
+    # assert len(n.buses) == len(grid.bus)
 
 
 @pytest.mark.skipif(not PYPSA_AVAILABLE, reason="Package PyPSA not available.")

--- a/powersimdata/input/tests/test_import_from_pypsa.py
+++ b/powersimdata/input/tests/test_import_from_pypsa.py
@@ -33,9 +33,6 @@ def test_import_exported_network():
     # TODO: storages are not yet exported to pypsa
     test.storage = ref.storage
 
-    # TODO: TransformerWinding is not translated to pypsa
-    test.branch["branch_device_type"] = ref.branch.branch_device_type
-
     # Due to rounding errors we have to compare some columns in advance
     rtol = 1e-15
     assert_series_equal(ref.branch.x, test.branch.x, rtol=rtol)

--- a/powersimdata/input/tests/test_import_from_pypsa.py
+++ b/powersimdata/input/tests/test_import_from_pypsa.py
@@ -4,19 +4,18 @@ from pandas.testing import assert_series_equal
 from powersimdata.input.export_data import PYPSA_AVAILABLE, export_to_pypsa
 from powersimdata.input.grid import Grid
 
+# @pytest.mark.skipif(not PYPSA_AVAILABLE, reason="Package PyPSA not available.")
+# def test_import_arbitrary_network_from_pypsa():
+#     import pypsa
 
-@pytest.mark.skipif(not PYPSA_AVAILABLE, reason="Package PyPSA not available.")
-def test_import_arbitrary_network_from_pypsa():
-    import pypsa
+# TODO: How to deal with immutables and data_loc which is not in
+# powersimdata.grid.Grid.SUPPORTED_MODELS?
 
-    # TODO: How to deal with immutables and data_loc which is not in
-    # powersimdata.grid.Grid.SUPPORTED_MODELS?
+# n = pypsa.examples.ac_dc_meshed()
+# grid = Grid(n)
 
-    # n = pypsa.examples.ac_dc_meshed()
-    # grid = Grid(n)
-
-    # assert not grid.bus.empty
-    # assert len(n.buses) == len(grid.bus)
+# assert not grid.bus.empty
+# assert len(n.buses) == len(grid.bus)
 
 
 @pytest.mark.skipif(not PYPSA_AVAILABLE, reason="Package PyPSA not available.")

--- a/powersimdata/input/tests/test_import_from_pypsa.py
+++ b/powersimdata/input/tests/test_import_from_pypsa.py
@@ -1,0 +1,47 @@
+import pytest
+from pandas.testing import assert_series_equal
+
+from powersimdata.input.export_data import PYPSA_AVAILABLE, export_to_pypsa
+from powersimdata.input.grid import Grid
+
+
+@pytest.mark.skipif(not PYPSA_AVAILABLE, reason="Package PyPSA not available.")
+def test_import_arbitrary_network_from_pypsa():
+    import pypsa
+
+    n = pypsa.examples.ac_dc_meshed()
+    grid = Grid(n)
+
+    assert not grid.bus.empty
+    assert len(n.buses) == len(grid.bus)
+
+
+@pytest.mark.skipif(not PYPSA_AVAILABLE, reason="Package PyPSA not available.")
+def test_import_exported_network():
+    ref = Grid("Western")
+    kwargs = dict(add_substations=True, add_load_shedding=False, add_all_columns=True)
+    n = export_to_pypsa(ref, **kwargs)
+    test = Grid(n)
+
+    # TODO: Only the linear cost term is exported to pypsa
+    for c in ["c0", "c2"]:
+        test.gencost["before"][c] = ref.gencost["before"][c]
+        test.gencost["after"][c] = ref.gencost["after"][c]
+
+    # TODO: storages are not yet exported to pypsa
+    test.storage = ref.storage
+
+    # TODO: TransformerWinding is not translated to pypsa
+    test.branch["branch_device_type"] = ref.branch.branch_device_type
+
+    # Due to rounding errors we have to compare some columns in advance
+    rtol = 1e-15
+    assert_series_equal(ref.branch.x, test.branch.x, rtol=rtol)
+    assert_series_equal(ref.branch.r, test.branch.r, rtol=rtol)
+    assert_series_equal(ref.bus.Va, test.bus.Va, rtol=rtol)
+
+    test.branch.x = ref.branch.x
+    test.branch.r = ref.branch.r
+    test.bus.Va = ref.bus.Va
+
+    assert ref == test


### PR DESCRIPTION
### Purpose
Allow to create Grid objects from PyPSA networks. The PR also introduces some changes outside of the newly introduced `import_data` module. This are: 

*  The `Grid` class has a new attribute `SUPPORTED_IMPORTS` used in the `Grid` initialization process. The check in the beginning of the initialization that the `source` argument is in `SUPPORTED_MODELS` was extended to a check that `source` is in `SUPPOERTED_MODELS` or in `SUPPERTED_IMPORTS`. Further, when `data_loc` of the imported data is in `SUPPORTED_IMPORTS`, immutables are not loaded into the Grid. This means, as soon as `data_loc` is in the `SUPPORTED_IMPORTS` set, the model is not required to be in `SUPPORTED_MODELS`. The `SUPPORTED_IMPORTS` set is for now only containing "pypsa". 
* The `Grid` initialization skips loading from cache if the imported object is a pypsa Network.
* An alignment of the implementation introduced in #603 with the import. Since the import from pypsa relies on the same dictionary used for the export, it is helpful to include the `marginal_cost` key into the translation dict again. 


### What the code is doing
For now a new `AbstractGrid` class `FromPyPSA` was implemented. When initializing it takes a pypsa network and converts all data fields according to the `PowerSimData` convention. As discussed, storages are not yet imported from pypsa. This remains a point on the TODO list and will be covered in a separate PR. 

The code does not yet load a `Scenario` object from `PyPSA`. I do not want to bloat this PR, thus it will be introduced via a separate PR. 

### Testing
Tests for initializing a Grid object from a pypsa Network were added to the CI. 

### Where to look

* `powersimdata/input/import_data.py`
* `powersimdata/input/grid.py`

### Time estimate
~ 40 min