### PR TITLE
fix: make distribute_demand_from_zones_to_buses robust to zero-demand zone

### DIFF
--- a/powersimdata/input/input_data.py
+++ b/powersimdata/input/input_data.py
@@ -168,7 +168,11 @@ def distribute_demand_from_zones_to_buses(zone_demand, bus):
         [pd.Series(bus["Pd"] / bus_zone_pd, name="zone_share"), bus["zone_id"]], axis=1
     )
     zone_bus_shares = bus_zone_share.pivot_table(
-        index="bus_id", columns="zone_id", values="zone_share", fill_value=0
+        index="bus_id",
+        columns="zone_id",
+        values="zone_share",
+        dropna=False,
+        fill_value=0,
     )
     bus_demand = zone_demand.dot(zone_bus_shares.T)
 


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
If there is a zone with zero demand (i.e. all `"Pd"` values are zero for buses in that zone), `distribute_demand_from_zones_to_buses` will fail, since `pandas.pivot_table` will by default drop some rows/columns and we will end up with a matrix of a different size. This tweak fixes that.

### What the code is doing
By passing `dropna=False`, we ensure that `pivot_table` returns a matrix of a constant size, no matter whether there are zero-demand zones or not.

### Testing
Tested manually. Before:
```python
>>> from powersimdata import Scenario
>>> from powersimdata.input.input_data import distribute_demand_from_zones_to_buses
>>> scenario = Scenario()
>>> scenario.set_grid("usa_tamu", "Texas")
>>> scenario.set_base_profile("demand", "vJan2021")
>>> demand = scenario.get_demand()
>>> grid = scenario.get_grid()
>>> grid.bus.loc[grid.bus.zone_id == 301, "Pd"] = 0
>>> distribute_demand_from_zones_to_buses(demand, grid.bus)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\Users\DanielOlsen\repos\bes\PowerSimData\powersimdata\input\input_data.py", line 173, in distribute_demand_from_zones_to_buses
    bus_demand = zone_demand.dot(zone_bus_shares.T)
  File "C:\Python39\lib\site-packages\pandas\core\frame.py", line 1446, in dot
    raise ValueError("matrices are not aligned")
ValueError: matrices are not aligned
```
After:
```python
>>> from powersimdata import Scenario
>>> from powersimdata.input.input_data import distribute_demand_from_zones_to_buses
>>> scenario = Scenario()
>>> scenario.set_grid("usa_tamu", "Texas")
>>> scenario.set_base_profile("demand", "vJan2021")
>>> demand = scenario.get_demand()
>>> grid = scenario.get_grid()
>>> grid.bus.loc[grid.bus.zone_id == 301, "Pd"] = 0
>>> distribute_demand_from_zones_to_buses(demand, grid.bus)
bus_id               3001001  3001002  3001003  ...  3008158  3008159    3008160
UTC Time                                        ...                             
2016-01-01 00:00:00      0.0      0.0      0.0  ...      0.0      0.0  38.204262
2016-01-01 01:00:00      0.0      0.0      0.0  ...      0.0      0.0  41.273131
2016-01-01 02:00:00      0.0      0.0      0.0  ...      0.0      0.0  38.596056
2016-01-01 03:00:00      0.0      0.0      0.0  ...      0.0      0.0  37.426936
2016-01-01 04:00:00      0.0      0.0      0.0  ...      0.0      0.0  37.894470
...                      ...      ...      ...  ...      ...      ...        ...
2016-12-31 19:00:00      0.0      0.0      0.0  ...      0.0      0.0  32.539467
2016-12-31 20:00:00      0.0      0.0      0.0  ...      0.0      0.0  32.040328
2016-12-31 21:00:00      0.0      0.0      0.0  ...      0.0      0.0  32.005590
2016-12-31 22:00:00      0.0      0.0      0.0  ...      0.0      0.0  31.855535
2016-12-31 23:00:00      0.0      0.0      0.0  ...      0.0      0.0  33.504717

[8784 rows x 2000 columns]
```

### Time estimate
5 minutes.
