### PR TITLE
Fix some of the pandas deprecation warnings

### DIFF
--- a/powersimdata/input/tests/test_grid.py
+++ b/powersimdata/input/tests/test_grid.py
@@ -405,10 +405,8 @@ def test_grid_eq_failure_storage(base_texas):
     test_grid = copy.deepcopy(base_texas)
     gencost = {g: 0 for g in test_grid.storage["gencost"].columns}
     gen = {g: 0 for g in test_grid.storage["gen"].columns}
-    test_grid.storage["gencost"] = test_grid.storage["gencost"].append(
-        gencost, ignore_index=True
-    )
-    test_grid.storage["gen"] = test_grid.storage["gen"].append(gen, ignore_index=True)
+    test_grid.storage["gencost"].loc[0, :] = gencost
+    test_grid.storage["gen"].loc[0, :] = gen
     assert base_texas != test_grid
 
 


### PR DESCRIPTION
### Purpose
Pandas has been yelling at me whenever I run tests because we are still using `.append` instead of `.concat`. This PR should make pandas happier. 

### What the code is doing
Change some of the append to concat. It defaults to `sort=False` (see [docs](https://pandas.pydata.org/docs/reference/api/pandas.concat.html)) so I removed that where applicable. 

### Testing
tox

### Time estimate
10 min
