### PR TITLE
Fix warnings

### DIFF
--- a/powersimdata/design/generation/curtailment.py
+++ b/powersimdata/design/generation/curtailment.py
@@ -83,7 +83,9 @@ def temporal_curtailment(
         *[set(base_plant_ids_by_type[g]) for g in valid_profile_types]
     )
     summed_profiles = (
-        all_profiles[plant_ids_for_summed_profiles].groupby(plant["type"], axis=1).sum()
+        all_profiles[list(plant_ids_for_summed_profiles)]
+        .groupby(plant["type"], axis=1)
+        .sum()
     )
 
     # Build up a series of firm generation
@@ -120,7 +122,7 @@ def temporal_curtailment(
             firm_generation += pd.Series(plant_pmin, index=summed_demand.index)
 
     # Finally, compare this summed firm generation against summed curtailable generation
-    total_curtailable = summed_profiles[curtailable].sum(axis=1)
+    total_curtailable = summed_profiles[list(curtailable)].sum(axis=1)
     net_demand = summed_demand - firm_generation
     curtailable_max_gen = pd.concat([net_demand, total_curtailable], axis=1).min(axis=1)
     curtailment_fraction = 1 - curtailable_max_gen.sum() / total_curtailable.sum()

--- a/powersimdata/input/helpers.py
+++ b/powersimdata/input/helpers.py
@@ -274,7 +274,7 @@ def decompose_plant_data_frame_into_resources(df, resources, grid):
     resources = _check_resources_are_in_grid_and_format(resources, grid)
 
     df_resources = {
-        r: df[get_plant_id_for_resources(r, grid) & plant_id].sort_index(axis=1)
+        r: df[list(get_plant_id_for_resources(r, grid)) & plant_id].sort_index(axis=1)
         for r in resources
     }
     return df_resources

--- a/powersimdata/input/tests/test_helpers.py
+++ b/powersimdata/input/tests/test_helpers.py
@@ -177,7 +177,7 @@ def test_get_plant_id_for_resources(grid):
     expected = (["nuclear"], ["solar", "ng"])
     for a, e in zip(arg, expected):
         plant_id = get_plant_id_for_resources(a[0], a[1])
-        assert set(grid.plant.loc[plant_id].type) == set(e)
+        assert set(grid.plant.loc[list(plant_id)].type) == set(e)
 
 
 def test_get_plant_id_in_loadzones_argument_type(grid):
@@ -199,7 +199,7 @@ def test_get_plant_id_in_loadzones(grid):
     expected = (["Oregon"], ["Kentucky", "Montana Western", "El Paso"])
     for a, e in zip(arg, expected):
         plant_id = get_plant_id_in_loadzones(a[0], a[1])
-        assert set(grid.plant.loc[plant_id].zone_name) == set(e)
+        assert set(grid.plant.loc[list(plant_id)].zone_name) == set(e)
 
 
 def test_get_plant_id_in_interconnects_argument_type(grid):
@@ -221,7 +221,7 @@ def test_get_plant_id_in_interconnects(grid):
     expected = (["Western"], ["Texas", "Western", "Eastern"])
     for a, e in zip(arg, expected):
         plant_id = get_plant_id_in_interconnects(a[0], a[1])
-        assert set(grid.plant.loc[plant_id].interconnect) == set(e)
+        assert set(grid.plant.loc[list(plant_id)].interconnect) == set(e)
 
 
 def test_get_plant_id_in_states_argument_type(grid):
@@ -243,7 +243,7 @@ def test_get_plant_id_in_states(grid):
     expected = (({44, 45, 216} | set(range(301, 309))), {201, 202, 214})
     for a, e in zip(arg, expected):
         plant_id = get_plant_id_in_states(a[0], a[1])
-        assert set(grid.plant.loc[plant_id].zone_id) == e
+        assert set(grid.plant.loc[list(plant_id)].zone_id) == e
 
 
 def test_get_plant_id_for_resources_in_loadzones_argument_type(grid):
@@ -278,8 +278,8 @@ def test_get_plant_id_for_resources_in_loadzones(grid):
     )
     for a, e in zip(arg, expected):
         plant_id = get_plant_id_for_resources_in_loadzones(a[0], a[1], a[2])
-        assert set(grid.plant.loc[plant_id].type) == set(e[0])
-        assert set(grid.plant.loc[plant_id].zone_name) == set(e[1])
+        assert set(grid.plant.loc[list(plant_id)].type) == set(e[0])
+        assert set(grid.plant.loc[list(plant_id)].zone_name) == set(e[1])
 
 
 def test_get_plant_id_for_resources_in_interconnects_argument_type(grid):
@@ -316,8 +316,8 @@ def test_get_plant_id_for_resources_in_interconnects(grid):
     )
     for a, e in zip(arg, expected):
         plant_id = get_plant_id_for_resources_in_interconnects(a[0], a[1], a[2])
-        assert set(grid.plant.loc[plant_id].type) == set(e[0])
-        assert set(grid.plant.loc[plant_id].interconnect) == set(e[1])
+        assert set(grid.plant.loc[list(plant_id)].type) == set(e[0])
+        assert set(grid.plant.loc[list(plant_id)].interconnect) == set(e[1])
 
 
 def test_get_plant_id_for_resources_in_states_argument_type(grid):
@@ -357,8 +357,8 @@ def test_get_plant_id_for_resources_in_states(grid):
     )
     for a, e in zip(arg, expected):
         plant_id = get_plant_id_for_resources_in_states(a[0], a[1], a[2])
-        assert set(grid.plant.loc[plant_id].type) == set(e[0])
-        assert set(grid.plant.loc[plant_id].zone_id) == set(e[1])
+        assert set(grid.plant.loc[list(plant_id)].type) == set(e[0])
+        assert set(grid.plant.loc[list(plant_id)].zone_id) == set(e[1])
 
 
 def test_get_plant_id_for_resources_in_area():

--- a/powersimdata/input/tests/test_transform_grid.py
+++ b/powersimdata/input/tests/test_transform_grid.py
@@ -153,8 +153,8 @@ def test_scale_gencost_one_plant(ct):
     assert new_gencost.loc[plant_id, modified_columns].equals(
         old_gencost.loc[plant_id, modified_columns] * factor
     )
-    assert new_gencost.loc[plant_id, non_modified_columns].equals(
-        old_gencost.loc[plant_id, non_modified_columns]
+    assert new_gencost.loc[plant_id, list(non_modified_columns)].equals(
+        old_gencost.loc[plant_id, list(non_modified_columns)]
     )
 
 
@@ -180,22 +180,24 @@ def test_scale_gencost_two_types_two_zones(ct):
     # Make sure we didn't mess with any other plants
     changed_plants = set().union(*plant_id)
     unchanged_plants = set(grid.plant.index.tolist()) - changed_plants
-    assert old_gencost.loc[unchanged_plants].equals(new_gencost.loc[unchanged_plants])
+    assert old_gencost.loc[list(unchanged_plants)].equals(
+        new_gencost.loc[list(unchanged_plants)]
+    )
     for f, i in zip(factor, plant_id):
         # Make sure we modify cost coefficient columns and only those columns
         assert new_gencost.loc[i, modified_columns].equals(
             old_gencost.loc[i, modified_columns] * f
         )
-        assert new_gencost.loc[i, non_modified_columns].equals(
-            old_gencost.loc[i, non_modified_columns]
+        assert new_gencost.loc[i, list(non_modified_columns)].equals(
+            old_gencost.loc[i, list(non_modified_columns)]
         )
         for f, i in zip(factor, plant_id):
             # Make sure we modify cost coefficient columns and only those columns
             assert new_gencost.loc[i, modified_columns].equals(
                 old_gencost.loc[i, modified_columns] * f
             )
-            assert new_gencost.loc[i, non_modified_columns].equals(
-                old_gencost.loc[i, non_modified_columns]
+            assert new_gencost.loc[i, list(non_modified_columns)].equals(
+                old_gencost.loc[i, list(non_modified_columns)]
             )
 
 
@@ -219,8 +221,8 @@ def test_scale_gen_pmin_one_plant(ct):
     assert new_plant.loc[plant_id, modified_columns].equals(
         old_plant.loc[plant_id, modified_columns] * factor
     )
-    assert new_plant.loc[plant_id, non_modified_columns].equals(
-        old_plant.loc[plant_id, non_modified_columns]
+    assert new_plant.loc[plant_id, list(non_modified_columns)].equals(
+        old_plant.loc[plant_id, list(non_modified_columns)]
     )
 
 
@@ -246,14 +248,16 @@ def test_scale_gen_pmin_two_types_two_zones(ct):
     # Make sure we modify Pmin and only Pmin
     changed_plants = set().union(*plant_id)
     unchanged_plants = set(grid.plant.index.tolist()) - changed_plants
-    assert old_plant.loc[unchanged_plants].equals(new_plant.loc[unchanged_plants])
+    assert old_plant.loc[list(unchanged_plants)].equals(
+        new_plant.loc[list(unchanged_plants)]
+    )
     for f, i in zip(factor, plant_id):
         # Make sure we modify cost coefficient columns and only those columns
         assert new_plant.loc[i, modified_columns].equals(
             old_plant.loc[i, modified_columns] * f
         )
-        assert new_plant.loc[i, non_modified_columns].equals(
-            old_plant.loc[i, non_modified_columns]
+        assert new_plant.loc[i, list(non_modified_columns)].equals(
+            old_plant.loc[i, list(non_modified_columns)]
         )
 
 

--- a/powersimdata/input/tests/test_transform_profile.py
+++ b/powersimdata/input/tests/test_transform_profile.py
@@ -130,8 +130,8 @@ def _check_plants_are_scaled(ct, base_grid, raw_profile, resource):
 
     unscaled_plant_id = set(plant_id_type) - set(scaled_plant_id)
     if unscaled_plant_id:
-        assert transformed_profile[unscaled_plant_id].equals(
-            base_profile[unscaled_plant_id]
+        assert transformed_profile[list(unscaled_plant_id)].equals(
+            base_profile[list(unscaled_plant_id)]
         )
     return transformed_profile
 
@@ -271,7 +271,9 @@ def test_demand_is_scaled(base_grid, raw_demand):
         base_demand[scaled_zone].multiply(factor, axis=1)
     )
     if unscaled_zone:
-        assert transformed_profile[unscaled_zone].equals(base_demand[unscaled_zone])
+        assert transformed_profile[list(unscaled_zone)].equals(
+            base_demand[list(unscaled_zone)]
+        )
 
 
 def test_solar_is_scaled_by_zone(base_grid, raw_solar):


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
Fix warnings raised by our test suite. Went from 130 warnings down to 7.

### What the code is doing
Most warnings come from `pandas`. These were:
```
* FutureWarning: Passing a set as an indexer is deprecated and will raise in a future version. Use a list instead
* FutureWarning: The frame.append method is deprecated and will be removed from pandas in a future version. Use pandas.concat instead.
* SettingWithCopyWarning: A value is trying to be set on a copy of a slice from a DataFrame
* FutureWarning: Passing method to Int64Index.get_loc is deprecated and will raise in a future version. Use index.get_indexer([item], method=...) instead.
```

Remaining warnings come from from third party packages and a user warning, see below:
```
.tox/pytest-local/lib/python3.9/site-packages/pypsa/descriptors.py:31
  /Users/brdo/CEM/PowerSimData/.tox/pytest-local/lib/python3.9/site-packages/pypsa/descriptors.py:31: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    _nx_version = StrictVersion(nx.__version__)

.tox/pytest-local/lib/python3.9/site-packages/pypsa/linopf.py:37
  /Users/brdo/CEM/PowerSimData/.tox/pytest-local/lib/python3.9/site-packages/pypsa/linopf.py:37: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    pd_version = LooseVersion(pd.__version__)

.tox/pytest-local/lib/python3.9/site-packages/setuptools/_distutils/version.py:351
  /Users/brdo/CEM/PowerSimData/.tox/pytest-local/lib/python3.9/site-packages/setuptools/_distutils/version.py:351: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    other = LooseVersion(other)

powersimdata/design/investment/tests/test_investment_costs.py::test_calculate_gen_inv_costs_not_summed
  /Users/brdo/CEM/PowerSimData/powersimdata/design/investment/investment_costs.py:471: UserWarning: No cost data available for Nuclear for Advanced cost case, using Moderate cost case data instead
    warnings.warn(

powersimdata/input/tests/test_export_to_pypsa.py::test_export_grid_to_pypsa
powersimdata/input/tests/test_export_to_pypsa.py::test_export_grid_to_pypsa
powersimdata/input/tests/test_export_to_pypsa.py::test_export_grid_to_pypsa
  /Users/brdo/CEM/PowerSimData/.tox/pytest-local/lib/python3.9/site-packages/pypsa/components.py:701: FutureWarning: The frame.append method is deprecated and will be removed from pandas in a future version. Use pandas.concat instead.
    new_df = cls_df.append(obj_df, sort=False)

-- Docs: https://docs.pytest.org/en/stable/warnings.html
```

### Testing
Run `tox` successfully

### Where to look
Several modules are concerned. No major refactoring, only converting `set` to `list`, etc. The largest change is using `get_indexer()` in place of `get_loc`

### Usage Example/Visuals
N/A

### Time estimate
5 min
