### PR TITLE
fix: make start_date and end_date applicable to boundaries

### DIFF
--- a/powersimdata/scenario/create.py
+++ b/powersimdata/scenario/create.py
@@ -304,9 +304,9 @@ class _Builder:
         hours = (end_ts - start_ts) / np.timedelta64(1, "h") + 1
         if start_ts > end_ts:
             raise ValueError("start_date > end_date")
-        elif start_ts < min_ts or start_ts >= max_ts:
+        elif start_ts < min_ts or start_ts > max_ts:
             raise ValueError("start_date not in [%s,%s[" % (min_ts, max_ts))
-        elif end_ts <= min_ts or end_ts > max_ts:
+        elif end_ts < min_ts or end_ts > max_ts:
             raise ValueError("end_date not in ]%s,%s]" % (min_ts, max_ts))
         elif hours % int(interval.split("H", 1)[0]) != 0:
             raise ValueError("Incorrect interval for start and end dates")


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
Fix a bug when creating scenarios, `start_date` and `end_date` can be set at the boundaries of the time range, i.e. `start_date` can't be `2016-12-31 23:00:00` and `end_date` can't be `2016-01-01 00:00:00`. This shouldn't be the case given our time range is inclusive, which will prevent users from running 1h scenarios for the first or the last hour of the year.

### What the code is doing
A hot fix on the input checks.

### Testing
An integration test of running a 1h USA scenario is successfully conducted.

### Where to look
`powersimdata/scenario/create.py`

### Usage Example/Visuals
Before it gives value error: 
<img width="692" alt="image" src="https://user-images.githubusercontent.com/52716585/161826966-8843409b-a356-4fb5-ae43-72a8c764198d.png">
Now it runs successfully

### Time estimate
2 min