### PR TITLE
refactor: move add_demand_flexibility to own module

### DIFF
--- a/powersimdata/input/changes/__init__.py
+++ b/powersimdata/input/changes/__init__.py
@@ -1,0 +1,7 @@
+# flake8: noqa
+from .bus import add_bus, remove_bus
+from .demand_flex import add_demand_flexibility
+from .electrification import add_electrification
+from .helpers import ordinal
+from .plant import add_plant, remove_plant, scale_plant_pmin
+from .storage import add_storage_capacity

--- a/powersimdata/input/changes/demand_flex.py
+++ b/powersimdata/input/changes/demand_flex.py
@@ -1,0 +1,59 @@
+import copy
+
+from powersimdata.input.input_data import InputData
+
+
+def add_demand_flexibility(obj, info):
+    """Adds demand flexibility to the system.
+
+    :param powersimdata.input.change_table.ChangeTable obj: change table
+    :param dict info: Each key refers to a different component required to
+        parameterize the demand flexibility model. Each value associated with the
+        keys corresponds to the profile version of the profile in question.
+        Required keys: "demand_flexibility_up", "demand_flexibility_dn".
+        Optional keys: "demand_flexibility_duration", "demand_flexibility_cost_up",
+            "demand_flexibility_cost_dn".
+    :raises TypeError:
+    :raises ValueError:
+    """
+
+    # Check inputs
+    if not isinstance(info, dict):
+        raise TypeError(
+            "Argument enclosing new demand flexibility info must be a dictionary."
+        )
+    info = copy.deepcopy(info)
+    required = {"demand_flexibility_up", "demand_flexibility_dn"}
+    optional = {
+        "demand_flexibility_duration",
+        "demand_flexibility_cost_up",
+        "demand_flexibility_cost_dn",
+    }
+    obj._check_entry_keys(info, 0, "demand_flexibility", required, None, optional)
+
+    # Add a key for demand flexibility in the change table, if necessary
+    if "demand_flexibility" not in obj.ct:
+        obj.ct["demand_flexibility"] = {}
+
+    # Access the specified demand flexibility profiles that are required
+    for k in required | (optional & info.keys()):
+        if k == "demand_flexibility_duration":
+            # Check that demand flexibility duration is an integer and positive
+            if not isinstance(info[k], int):
+                raise ValueError(f"The value of {k} is not integer-valued.")
+            if info[k] <= 0:
+                raise ValueError(f"The value of {k} is not positive.")
+            obj.ct["demand_flexibility"][k] = info[k]
+        else:
+            # Determine the available profile versions
+            possible = InputData().get_profile_version(obj.grid.grid_model, k)
+
+            # Add the profile to the change table
+            if len(possible) == 0:
+                del obj.ct["demand_flexibility"]
+                raise ValueError(f"No {k} profile available.")
+            elif info[k] in possible:
+                obj.ct["demand_flexibility"][k] = info[k]
+            else:
+                del obj.ct["demand_flexibility"]
+                raise ValueError(f"Available {k} profiles: {', '.join(possible)}")

--- a/powersimdata/input/changes/demand_flex.py
+++ b/powersimdata/input/changes/demand_flex.py
@@ -12,9 +12,9 @@ def add_demand_flexibility(obj, info):
         keys corresponds to the profile version of the profile in question.
         Required keys: "demand_flexibility_up", "demand_flexibility_dn".
         Optional keys: "demand_flexibility_duration", "demand_flexibility_cost_up",
-            "demand_flexibility_cost_dn".
-    :raises TypeError:
-    :raises ValueError:
+        "demand_flexibility_cost_dn".
+    :raises TypeError: if info is not a dict
+    :raises ValueError: if duration is not a positive int, or if no profile is found
     """
 
     # Check inputs

--- a/powersimdata/input/changes/storage.py
+++ b/powersimdata/input/changes/storage.py
@@ -1,6 +1,6 @@
 import copy
 
-from powersimdata.input.changes.helpers import ordinal
+from powersimdata.input.changes import ordinal
 
 
 def add_storage_capacity(obj, info):


### PR DESCRIPTION
### Purpose
Continue factoring out change table methods. 

### What the code is doing
Move add_demand_flexibility to a separate module. Also combined imports into the `__init__.py`, which is not really a thing we do elsewhere, but seemed ok (can't think of any issues, but if there are we can skip that). 

### Testing
tox

### Time estimate
5 min
