### PR TITLE
fix: convert set to list after intersection operation

### DIFF
--- a/powersimdata/input/helpers.py
+++ b/powersimdata/input/helpers.py
@@ -274,7 +274,7 @@ def decompose_plant_data_frame_into_resources(df, resources, grid):
     resources = _check_resources_are_in_grid_and_format(resources, grid)
 
     df_resources = {
-        r: df[list(get_plant_id_for_resources(r, grid)) & plant_id].sort_index(axis=1)
+        r: df[list(get_plant_id_for_resources(r, grid) & plant_id)].sort_index(axis=1)
         for r in resources
     }
     return df_resources


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
Fix bug introduced in #609.

### What the code is doing
We change `list(set_a) & set_b` to `list(set_a & set_b)`

### Testing
Tested manually. Before: PostREISE tests which use `decompose_plant_data_frame_into_resources` fail. After: they don't.

### Time estimate
2 minutes.
