### PR TITLE
feat: EIA ID of buses in the synthetic grid

### DIFF
--- a/powersimdata/input/const/grid_const.py
+++ b/powersimdata/input/const/grid_const.py
@@ -96,6 +96,7 @@ col_name_bus = [
     "mu_Vmax",
     "mu_Vmin",
     "interconnect",
+    "eia_id",
     "lat",
     "lon",
 ]

--- a/powersimdata/input/const/pypsa_const.py
+++ b/powersimdata/input/const/pypsa_const.py
@@ -22,6 +22,7 @@ pypsa_const = {
             "mu_Vmax",
             "mu_Vmin",
             "GenFuelCost",
+            "eia_id",
         ],
     },
     "generator": {


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
Add the EIA ID LSE of each bus in the system as an additional column, to be used later to match with LSE-based demand flexibility and use for simulation in REISE.jl [(link).](https://github.com/Breakthrough-Energy/REISE.jl/pull/178) The EIA IDs are identified using an offline process that will be a separate PR in PreREISE.

### What the code is doing
added a new column in network/usa_tamu/bus.csv

### Testing

### Where to look
only change is in network/usa_tamu/bus.csv

### Usage Example/Visuals

### Time estimate
5 min