### PR TITLE
fix: avoid Exception when calling get_load_shed on a Scenario without load shed

### DIFF
--- a/powersimdata/scenario/analyze.py
+++ b/powersimdata/scenario/analyze.py
@@ -196,7 +196,7 @@ class Analyze(Ready):
             scenario_id = self._scenario_info["id"]
             filename = scenario_id + "_LOAD_SHED.pkl"
             output_dir = server_setup.OUTPUT_DIR
-            filepath = os.path.join(server_setup.LOCAL_DIR, output_dir, filename)
+            filepath = os.path.join(server_setup.LOCAL_DIR, *output_dir, filename)
             with open(filepath, "wb") as f:
                 pickle.dump(load_shed, f)
 


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
Fix a bug, where calling `Scenario.get_load_shed()` on a Scenario without any load shed throws an Exception.
```python
>>> from powersimdata import Scenario
>>> Scenario(3497).get_load_shed()
[...truncated...]
No infeasibilities, constructing DataFrame
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\Users\DanielOlsen\repos\bes\PowerSimData\powersimdata\scenario\analyze.py", line 199, in get_load_shed
    filepath = os.path.join(server_setup.LOCAL_DIR, output_dir, filename)
  File "C:\Python39\lib\ntpath.py", line 117, in join
    genericpath._check_arg_types('join', path, *paths)
  File "C:\Python39\lib\genericpath.py", line 152, in _check_arg_types
    raise TypeError(f'{funcname}() argument must be str, bytes, or '
TypeError: join() argument must be str, bytes, or os.PathLike object, not 'tuple'
```

This bug seems to have been introduced in commit `5665083` within #475.

### What the code is doing
Since `output_dir` is a tuple of strings, rather than a single string, we need to unpack it before feeding to `os.path.join`.

### Testing
The same example above no longer throws an Exception.

### Time estimate
5 minutes.
