### PR TITLE
Change access to area_to_loadzone function

### DIFF
--- a/powersimdata/design/generation/clean_capacity_scaling.py
+++ b/powersimdata/design/generation/clean_capacity_scaling.py
@@ -2,7 +2,6 @@ import numpy as np
 import pandas as pd
 
 from powersimdata.design.mimic_grid import mimic_generation_capacity
-from powersimdata.network.model import area_to_loadzone
 from powersimdata.scenario.scenario import Scenario
 
 
@@ -44,8 +43,8 @@ def _apply_zone_scale_factor_to_ct(ct, fuel, zone_id, scale_factor):
 
 
 def load_targets_from_csv(filename, drop_ignored=True):
-    """Interprets a CSV file as a set of targets, ensuring that required columns are present,
-    and filling in default values for optional columns.
+    """Interprets a CSV file as a set of targets, ensuring that required columns are
+    present, and filling in default values for optional columns.
 
     :param str filename: filepath to targets csv.
     :param bool drop_ignored: if True, drop all ignored columns from output.
@@ -100,12 +99,11 @@ def _make_zonename2target(grid, targets):
     :raises ValueError: if a zone is not present in any target areas, or
         if a zone is present in more than one target area.
     """
-    grid_model = grid.grid_model
     target_zones = {
-        target_name: area_to_loadzone(grid_model, target_name)
+        target_name: grid.model_immutables.area_to_loadzone(target_name)
         if pd.isnull(targets.loc[target_name, "area_type"])
-        else area_to_loadzone(
-            grid_model, target_name, targets.loc[target_name, "area_type"]
+        else grid.model_immutables.area_to_loadzone(
+            target_name, area_type=targets.loc[target_name, "area_type"]
         )
         for target_name in targets.index.tolist()
     }
@@ -379,8 +377,8 @@ def add_new_capacities_collaborative(
     :param int scenario_length: number of hours in new scenario.
     :param float/None solar_fraction: how much new capacity should be solar.
         If given None, maintain previous ratio.
-    :param dict/None addl_curtailment: how much new curtailment is expected, by resource.
-        If given None, assume zero.
+    :param dict/None addl_curtailment: how much new curtailment is expected, by
+        resource. If given None, assume zero.
     :return: (*pandas.DataFrame*) -- targets dataframe with next capacities added.
     """
     targets = input_targets.copy()
@@ -463,7 +461,7 @@ def create_change_table(input_targets, ref_scenario):
         prev_wind = input_targets.loc[region, "wind.prev_capacity"]
         next_solar = input_targets.loc[region, "solar.next_capacity"]
         next_wind = input_targets.loc[region, "wind.next_capacity"]
-        zone_names = area_to_loadzone(ref_scenario.info["grid_model"], region)
+        zone_names = base_grid.model_immutables.area_to_loadzone(region)
         zone_ids = [base_grid.zone2id[n] for n in zone_names if n in grid_zones]
         if prev_solar > 0:
             scale = next_solar / prev_solar

--- a/powersimdata/design/generation/cost_curves.py
+++ b/powersimdata/design/generation/cost_curves.py
@@ -4,7 +4,6 @@ import numpy as np
 import pandas as pd
 
 from powersimdata.input.grid import Grid
-from powersimdata.network.model import area_to_loadzone
 from powersimdata.utility.helpers import _check_import
 
 
@@ -195,9 +194,8 @@ def build_supply_curve(grid, num_segments, area, gen_type, area_type=None, plot=
     :param str area: Either the load zone, state name, state abbreviation, or
         interconnect.
     :param str/iterable gen_type: Generation type(s).
-    :param str area_type: one of: *'loadzone'*, *'state'*, *'state_abbr'*,
-        *'interconnect'*. Defaults to None, which allows
-        :func:`powersimdata.network.model.area_to_loadzone` to infer the type.
+    :param str area_type: one of *'loadzone'*, *'state'*, *'state_abbr'*,
+        *'interconnect'*. If set to None, type will be inferred.
     :param bool plot: If True, the supply curve plot is shown. If False, the plot is
         not shown.
     :return: (*tuple*) -- First element is a list of capacity (MW) amounts needed
@@ -232,7 +230,7 @@ def build_supply_curve(grid, num_segments, area, gen_type, area_type=None, plot=
         raise ValueError(f"{gen_type} contains invalid generation type.")
 
     # Identify the load zones that correspond to the specified area and area_type
-    returned_zones = area_to_loadzone(grid.grid_model, area, area_type)
+    returned_zones = grid.model_immutables.area_to_loadzone(area, area_type=area_type)
 
     # Trim the DataFrame to only be of the desired area and generation type
     supply_data = supply_data.loc[supply_data.zone_name.isin(returned_zones)]
@@ -427,8 +425,7 @@ def plot_linear_vs_quadratic_terms(
         interconnect.
     :param str gen_type: Generation type.
     :param str area_type: one of: *'loadzone'*, *'state'*, *'state_abbr'*,
-        *'interconnect'*. Defaults to None, which allows
-        :func:`powersimdata.network.model.area_to_loadzone` to infer the type.
+        *'interconnect'*. if set to None, the type will be inferred.
     :param bool plot: If True, the linear term vs. quadratic term plot is shown. If
         False, the plot is not shown.
     :param bool zoom: If True, filters out quadratic term outliers to enable better
@@ -474,7 +471,7 @@ def plot_linear_vs_quadratic_terms(
         raise ValueError(f"{gen_type} is not a valid generation type.")
 
     # Identify the load zones that correspond to the specified area and area_type
-    returned_zones = area_to_loadzone(grid.grid_model, area, area_type)
+    returned_zones = grid.model_immutables.area_to_loadzone(area, area_type=area_type)
 
     # Trim the DataFrame to only be of the desired area and generation type
     supply_data = supply_data.loc[supply_data.zone_name.isin(returned_zones)]
@@ -549,8 +546,7 @@ def plot_capacity_vs_price(
         interconnect.
     :param str gen_type: Generation type.
     :param str area_type: one of: *'loadzone'*, *'state'*, *'state_abbr'*,
-        *'interconnect'*. Defaults to None, which allows
-        :func:`powersimdata.network.model.area_to_loadzone` to infer the type.
+        *'interconnect'*. If set to None, the type will be inferred.
     :param bool plot: If True, the supply curve plot is shown. If False, the plot is
         not shown.
     :return: (*None*) -- The capacity vs. price plot is displayed according to the user.
@@ -581,7 +577,7 @@ def plot_capacity_vs_price(
         raise ValueError(f"{gen_type} is not a valid generation type.")
 
     # Identify the load zones that correspond to the specified area and area_type
-    returned_zones = area_to_loadzone(grid.grid_model, area, area_type)
+    returned_zones = grid.model_immutables.area_to_loadzone(area, area_type=area_type)
 
     # Trim the DataFrame to only be of the desired area and generation type
     supply_data = supply_data.loc[supply_data.zone_name.isin(returned_zones)]

--- a/powersimdata/design/transmission/upgrade.py
+++ b/powersimdata/design/transmission/upgrade.py
@@ -2,7 +2,6 @@ import pandas as pd
 
 from powersimdata.design.investment.investment_costs import _calculate_ac_inv_costs
 from powersimdata.input.grid import Grid
-from powersimdata.network.model import area_to_loadzone
 from powersimdata.utility.distance import haversine
 
 
@@ -151,7 +150,7 @@ def get_branches_by_area(grid, area_names, method="either"):
 
     :param powersimdata.input.grid.Grid grid: Grid to query for topology.
     :param list/set/tuple area_names: an iterable of area names, used to look
-        up zone names via :func:`powersimdata.network.model.area_to_loadzone`.
+        up zone names.
     :param str method: whether to include branches which span zones. Options:
         - 'internal': only select branches which are to/from the same area.
         - 'bridging': only select branches which connect area to another.
@@ -177,7 +176,7 @@ def get_branches_by_area(grid, area_names, method="either"):
     branch = grid.branch
     selected_branches = set()
     for a in area_names:
-        load_zone_names = area_to_loadzone(grid.grid_model, a)
+        load_zone_names = grid.model_immutables.area_to_loadzone(a)
         to_bus_in_area = branch.to_zone_name.isin(load_zone_names)
         from_bus_in_area = branch.from_zone_name.isin(load_zone_names)
         if method in ("internal", "either"):

--- a/powersimdata/input/helpers.py
+++ b/powersimdata/input/helpers.py
@@ -10,7 +10,6 @@ from powersimdata.input.check import (
     _check_plants_are_in_grid,
     _check_resources_are_in_grid_and_format,
 )
-from powersimdata.network.model import area_to_loadzone
 
 
 def csv_to_data_frame(data_loc, filename):
@@ -416,9 +415,7 @@ def get_plant_id_for_resources_in_area(scenario, area, resources, area_type=None
     """
     resource_set = set([resources]) if isinstance(resources, str) else set(resources)
     grid = scenario.state.get_grid()
-    loadzone_set = area_to_loadzone(
-        scenario.info["grid_model"], area, area_type=area_type
-    )
+    loadzone_set = grid.model_immutables.area_to_loadzone(area, area_type=area_type)
     plant_id = grid.plant[
         (grid.plant["zone_name"].isin(loadzone_set))
         & (grid.plant["type"].isin(resource_set))
@@ -438,9 +435,7 @@ def get_storage_id_in_area(scenario, area, area_type=None):
     :return: (*list*) -- list of storage id
     """
     grid = scenario.state.get_grid()
-    loadzone_set = area_to_loadzone(
-        scenario.info["grid_model"], area, area_type=area_type
-    )
+    loadzone_set = grid.model_immutables.area_to_loadzone(area, area_type=area_type)
     loadzone_id_set = {grid.zone2id[lz] for lz in loadzone_set if lz in grid.zone2id}
 
     gen = grid.storage["gen"]


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
Use the `model_immutables` attribute of the `Grid` object to invoke `area_to_loadzone`. This is a step towards a larger refactoring for non USA grid models. 

### What the code is doing
* Remove import statement
* Use `grid.model_immutables.area_to_loadzone(area, area_type=area_type)` in place of `area_to_loadzone(grid.mode, area, area_type=area_type)`

### Testing
Run existing tests

### Where to look
Several modules are impacted but changes are minor. 

### Usage Example/Visuals
How the code can be used and/or images of any graphs, tables or other visuals (not always applicable). 

### Time estimate
5min
