### PR TITLE
Aggregate demand profiles during scenario preparation

### DIFF
--- a/powersimdata/input/tests/test_transform_demand.py
+++ b/powersimdata/input/tests/test_transform_demand.py
@@ -1,0 +1,55 @@
+import pandas as pd
+
+from powersimdata.input.change_table import ChangeTable
+from powersimdata.input.grid import Grid
+from powersimdata.input.transform_demand import TransformDemand
+from powersimdata.tests.mock_profile_input import MockProfileInput
+
+
+def test_profile_to_zone():
+    grid = Grid("Texas")
+    ct = ChangeTable(grid)
+    info = {
+        "East": {"res_cooking": {"advanced_heat_pump_v2": 0.7}},
+        "Coast": {
+            "com_hot_water": {
+                "standard_heat_pump_v1": 0.6,
+                "advanced_heat_pump_v2": 0.4,
+            }
+        },
+        "Far West": {
+            "res_cooking": {"standard_heat_pump_v1": 0.2, "advanced_heat_pump_v2": 0.3}
+        },
+    }
+
+    kind = "building"
+    ct.add_electrification(kind, {"zone": info})
+    td = TransformDemand(grid, ct, kind)
+    actual = td._get_profile_to_zone()
+
+    expected = {
+        "res_cooking_advanced_heat_pump_v2.csv": [(308, 0.7), (301, 0.3)],
+        "com_hot_water_standard_heat_pump_v1.csv": [(307, 0.6)],
+        "com_hot_water_advanced_heat_pump_v2.csv": [(307, 0.4)],
+        "res_cooking_standard_heat_pump_v1.csv": [(301, 0.2)],
+    }
+
+    assert expected == actual
+
+
+def test_aggregate_demand():
+    grid = Grid("Texas")
+    ct = ChangeTable(grid)
+    kind = "building"
+    info = {"East": {"res_cooking": {"advanced_heat_pump_v2": 0.7}}}
+    ct.add_electrification(kind, {"zone": info})
+
+    mock_input = MockProfileInput(grid)
+    demand = mock_input.get_data(None, "demand")
+
+    td = TransformDemand(grid, ct, kind)
+    td._profile_input = mock_input
+    result = td.value()
+
+    pd.testing.assert_series_equal(0.7 * demand.loc[:, 308], result.loc[:, 308])
+    pd.testing.assert_frame_equal(demand.loc[:, :307], result.loc[:, :307])

--- a/powersimdata/input/tests/test_transform_demand.py
+++ b/powersimdata/input/tests/test_transform_demand.py
@@ -46,9 +46,10 @@ def test_aggregate_demand():
 
     mock_input = MockProfileInput(grid)
     demand = mock_input.get_data(None, "demand")
+    mock_input.get_profile = lambda *args: demand
 
     td = TransformDemand(grid, ct, kind)
-    td._profile_input = mock_input
+    td._profile_data = mock_input
     result = td.value()
 
     pd.testing.assert_series_equal(0.7 * demand.loc[:, 308], result.loc[:, 308])

--- a/powersimdata/input/transform_demand.py
+++ b/powersimdata/input/transform_demand.py
@@ -2,6 +2,13 @@ from powersimdata.input.electrified_demand_input import ElectrifiedDemand
 
 
 class TransformDemand:
+    """Aggregate demand from electrified sources.
+
+    :param powersimdata.input.grid.Grid grid: a grid object
+    :param powersimdata.input.change_table.ChangeTable: a change table object
+    :param str kind: the class of electrification, e.g. building, transportation
+    """
+
     def __init__(self, grid, ct, kind):
         self.grid = grid
         self.ct = ct.ct
@@ -11,6 +18,11 @@ class TransformDemand:
         self._set_scale_factors()
 
     def _get_base_profile(self, profile):
+        """Return the base profile from local or blob storage
+
+        :return: (*pandas.DataFrame*) -- profile data frame, filtered to zones within
+            the current grid
+        """
         zone_id = sorted(self.grid.bus.zone_id.unique())
         model = self.grid.grid_model
         demand = self._profile_data.get_profile(model, self.kind, profile).loc[
@@ -19,6 +31,11 @@ class TransformDemand:
         return demand
 
     def _get_profile_to_zone(self):
+        """Maps profile name to scale factors for each zone
+
+        :return: (*dict*) -- a dictionary mapping str to list of tuples of (zone_id,
+                scale_factor)
+        """
         info = self.info
         p2z = {}
         for zone_name in info["zone"].keys():
@@ -33,6 +50,10 @@ class TransformDemand:
         return p2z
 
     def _get_profile_to_grid(self):
+        """Maps profile name to scale factor, which is applied to all zones in the grid
+
+        :return: (*dict*) -- a dictionary mapping str to float
+        """
         info = self.info
         p2g = {}
         for end_use in info["grid"].keys():
@@ -43,10 +64,17 @@ class TransformDemand:
         return p2g
 
     def _set_scale_factors(self):
+        """Populate mappings of profile names to scaling info"""
         self.p2z = self._get_profile_to_zone()
         self.p2g = self._get_profile_to_grid()
 
     def get_profile(self, profile):
+        """Get transformed profile
+
+        :param str profile: the profile name, without file extension
+        :return: (*pandas.DataFrame*) -- the scaled profile, filtered to the zones
+            within the current grid
+        """
         p2z, p2g = self.p2z, self.p2g
         df = self._get_base_profile(profile)
 
@@ -64,5 +92,10 @@ class TransformDemand:
         return df
 
     def value(self):
+        """Return the combined electrified demand
+
+        :return: (*pandas.DataFrame*) -- data frame with hourly index and zone columns,
+            where the values are demand (in MWh)
+        """
         profiles = set(self.p2z.keys()) | set(self.p2g.keys())
         return sum(self.get_profile(p) for p in profiles)

--- a/powersimdata/input/transform_demand.py
+++ b/powersimdata/input/transform_demand.py
@@ -23,7 +23,7 @@ class TransformDemand:
         :return: (*pandas.DataFrame*) -- profile data frame, filtered to zones within
             the current grid
         """
-        zone_id = sorted(self.grid.bus.zone_id.unique())
+        zone_id = sorted(self.grid.id2zone)
         model = self.grid.grid_model
         demand = self._profile_data.get_profile(model, self.kind, profile).loc[
             :, zone_id
@@ -34,7 +34,7 @@ class TransformDemand:
         """Maps profile name to scale factors for each zone
 
         :return: (*dict*) -- a dictionary mapping str to list of tuples of (zone_id,
-                scale_factor)
+            scale_factor)
         """
         info = self.info
         p2z = {}

--- a/powersimdata/input/transform_demand.py
+++ b/powersimdata/input/transform_demand.py
@@ -1,0 +1,42 @@
+from powersimdata.input.profile_input import ProfileInput
+
+
+class TransformDemand:
+    def __init__(self, grid, ct, kind):
+        self.grid = grid
+        self.ct = ct.ct
+        self.info = self.ct[kind]
+        self._profile_input = ProfileInput()
+        self.scenario_info = {"base_demand": "vJan2021", "grid_model": grid.grid_model}
+
+    def _get_profile(self, profile):
+        print(f"temporarily ignoring {profile}")
+        zone_id = sorted(self.grid.bus.zone_id.unique())
+        demand = self._profile_input.get_data(self.scenario_info, "demand").loc[
+            :, zone_id
+        ]
+        return demand
+
+    def _get_profile_to_zone(self):
+        info = self.info
+        p2z = {}
+        for zone_name in info["zone"].keys():
+            zone_id = self.grid.zone2id[zone_name]
+            for end_use in info["zone"][zone_name].keys():
+                for tech in info["zone"][zone_name][end_use].keys():
+                    profile = f"{end_use}_{tech}.csv"
+                    if profile not in p2z:
+                        p2z[profile] = []
+                    scale_factor = info["zone"][zone_name][end_use][tech]
+                    p2z[profile].append((zone_id, scale_factor))
+        return p2z
+
+    def _scale_profile(self, profile, p2z):
+        df = self._get_profile(profile)
+        for zone_id, scale_factor in p2z[profile]:
+            df.loc[:, zone_id] *= scale_factor
+        return df
+
+    def value(self):
+        p2z = self._get_profile_to_zone()
+        return sum(self._scale_profile(profile, p2z) for profile in p2z)

--- a/powersimdata/input/transform_demand.py
+++ b/powersimdata/input/transform_demand.py
@@ -1,4 +1,4 @@
-from powersimdata.input.profile_input import ProfileInput
+from powersimdata.input.electrified_demand_input import ElectrifiedDemand
 
 
 class TransformDemand:
@@ -6,14 +6,14 @@ class TransformDemand:
         self.grid = grid
         self.ct = ct.ct
         self.info = self.ct[kind]
-        self._profile_input = ProfileInput()
-        self.scenario_info = {"base_demand": "vJan2021", "grid_model": grid.grid_model}
+        self.kind = kind
+        self._profile_data = ElectrifiedDemand()
         self._set_scale_factors()
 
     def _get_base_profile(self, profile):
-        print(f"temporarily ignoring {profile}")
         zone_id = sorted(self.grid.bus.zone_id.unique())
-        demand = self._profile_input.get_data(self.scenario_info, "demand").loc[
+        model = self.grid.grid_model
+        demand = self._profile_data.get_profile(model, self.kind, profile).loc[
             :, zone_id
         ]
         return demand

--- a/powersimdata/input/transform_demand.py
+++ b/powersimdata/input/transform_demand.py
@@ -38,10 +38,8 @@ class TransformDemand:
         for end_use in info["grid"].keys():
             for tech in info["grid"][end_use].keys():
                 profile = f"{end_use}_{tech}.csv"
-                if profile not in p2g:
-                    p2g[profile] = []
                 scale_factor = info["grid"][end_use][tech]
-                p2g[profile].append(scale_factor)
+                p2g[profile] = scale_factor
         return p2g
 
     def _set_scale_factors(self):

--- a/powersimdata/input/transform_profile.py
+++ b/powersimdata/input/transform_profile.py
@@ -163,6 +163,11 @@ class TransformProfile:
         return df
 
     def _get_electrified_demand(self):
+        """Return the aggregate demand profile, including base demand and electrified
+        demand.
+
+        :return: (*pandas.DataFrame*) -- the full demand profile
+        """
         result = self._get_demand_profile()
         for kind in ("building", "transportation"):
             if kind in self.ct:

--- a/powersimdata/input/transform_profile.py
+++ b/powersimdata/input/transform_profile.py
@@ -1,6 +1,7 @@
 import copy
 
 from powersimdata.input.profile_input import ProfileInput
+from powersimdata.input.transform_demand import TransformDemand
 
 
 class TransformProfile:
@@ -161,6 +162,13 @@ class TransformProfile:
         # Return the pruned data frame
         return df
 
+    def _get_electrified_demand(self):
+        result = self._get_demand_profile()
+        for kind in ("building", "transportation"):
+            if kind in self.ct:
+                result += TransformDemand(self.grid, self.ct, kind).value()
+        return result
+
     def _slice_df(self, df):
         """Return dataframe, sliced by the times specified in scenario_info if and only
         if ``self.slice`` = True.
@@ -196,7 +204,7 @@ class TransformProfile:
         if name not in possible:
             raise ValueError("Choose from %s" % " | ".join(possible))
         elif name == "demand":
-            return self._slice_df(self._get_demand_profile())
+            return self._slice_df(self._get_electrified_demand())
         elif "demand_flexibility" in name:
             return self._slice_df(self._get_demand_flexibility_profile(name))
         else:

--- a/powersimdata/input/transform_profile.py
+++ b/powersimdata/input/transform_profile.py
@@ -107,7 +107,7 @@ class TransformProfile:
 
         :return: (*pandas.DataFrame*) -- data frame of demand.
         """
-        zone_id = sorted(self.grid.bus.zone_id.unique())
+        zone_id = sorted(self.grid.id2zone)
         demand = self._profile_input.get_data(self.scenario_info, "demand").loc[
             :, zone_id
         ]
@@ -139,7 +139,7 @@ class TransformProfile:
         area_ids = []
         if sum(area_indicator) > 0:
             # Demand flexibility profile contains zone IDs
-            zone_id = sorted(self.grid.bus.zone_id.unique())
+            zone_id = sorted(self.grid.id2zone)
             zone_id = [f"zone.{x}" for x in zone_id]
             area_ids += zone_id
         if sum(area_indicator) < len(area_indicator):


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
Apply the change table scaling for electrification profiles, and combine that with scaled demand profile when preparing a scenario.

### What the code is doing
Add new class `TransformDemand`, where we use the `.value()` method to get the demand profile for a given grid, and given class of electrification. In `TransformProfile`, we add that to the base demand, for each kind of electrification specified in the change table.

Most of the logic in `TransformDemand` is to kind of invert the change table mapping, which makes the transformation logic simpler, as we just fetch one profile at a time, scale it, and sum the results.  

### Testing
Haven't done integration tests yet, but we have a new unit test that combines grid and zone scaling, which checks that the zone scaling is applied correctly, and the rest of the grid is scaled as defined in the `ct["building"]["grid"]` entry (in the case of building electrification). 


### Time estimate
20 mins 
