### PR TITLE
Refactor Grid object

### DIFF
--- a/powersimdata/input/abstract_grid.py
+++ b/powersimdata/input/abstract_grid.py
@@ -30,6 +30,8 @@ class AbstractGrid:
         self.bus = pd.DataFrame()
         self.branch = pd.DataFrame()
         self.storage = storage_template()
+        self.grid_model = ""
+        self.model_immutables = None
 
 
 class AbstractGridCSV(AbstractGrid):

--- a/powersimdata/input/abstract_grid.py
+++ b/powersimdata/input/abstract_grid.py
@@ -10,7 +10,6 @@ from powersimdata.input.helpers import (
 )
 from powersimdata.network.constants.model import model2region
 from powersimdata.network.csv_reader import CSVReader
-from powersimdata.network.helpers import check_and_format_interconnect
 
 
 class AbstractGrid:
@@ -49,10 +48,10 @@ class AbstractGridCSV(AbstractGrid):
         else:
             self.data_loc = data_loc
 
-    def _build_network(self, interconnect, grid_model):
+    def _build(self, interconnect, grid_model):
         """Build network.
 
-        :param str/iterable interconnect: interconnect name(s).
+        :param list interconnect: interconnect name(s).
         :param str model: the grid model.
         """
         reader = CSVReader(self.data_loc)
@@ -62,11 +61,10 @@ class AbstractGridCSV(AbstractGrid):
         self.dcline = reader.dcline
         self.gencost["after"] = self.gencost["before"] = reader.gencost
 
-        self.interconnect = check_and_format_interconnect(interconnect, grid_model)
         self._add_information_to_model()
 
-        if model2region[grid_model] not in self.interconnect:
-            self._drop_interconnect()
+        if model2region[grid_model] not in interconnect:
+            self._drop_interconnect(interconnect)
 
     def _add_information_to_model(self):
         self.sub = csv_to_data_frame(self.data_loc, "sub.csv")
@@ -77,22 +75,21 @@ class AbstractGridCSV(AbstractGrid):
         add_zone_to_grid_data_frames(self)
         add_coord_to_grid_data_frames(self)
 
-    def _drop_interconnect(self):
+    def _drop_interconnect(self, interconnect):
         """Trim data frames to only keep information pertaining to the user
         defined interconnect(s).
 
+        :param list interconnect: interconnect name(s).
         """
         for key, value in self.__dict__.items():
             if key in ["sub", "bus2sub", "bus", "plant", "branch"]:
-                value.query("interconnect == @self.interconnect", inplace=True)
+                value.query("interconnect == @interconnect", inplace=True)
             elif key == "gencost":
-                value["before"].query(
-                    "interconnect == @self.interconnect", inplace=True
-                )
+                value["before"].query("interconnect == @interconnect", inplace=True)
             elif key == "dcline":
                 value.query(
-                    "from_interconnect == @self.interconnect &"
-                    "to_interconnect == @self.interconnect",
+                    "from_interconnect == @interconnect &"
+                    "to_interconnect == @interconnect",
                     inplace=True,
                 )
         self.id2zone = {k: self.id2zone[k] for k in self.bus.zone_id.unique()}

--- a/powersimdata/input/scenario_grid.py
+++ b/powersimdata/input/scenario_grid.py
@@ -4,6 +4,8 @@ import numpy as np
 import pandas as pd
 from scipy.io import loadmat
 
+from powersimdata.data_access.context import Context
+from powersimdata.data_access.scenario_list import ScenarioListManager
 from powersimdata.input import const
 from powersimdata.input.abstract_grid import AbstractGrid
 from powersimdata.input.helpers import (
@@ -11,6 +13,7 @@ from powersimdata.input.helpers import (
     add_interconnect_to_grid_data_frames,
     add_zone_to_grid_data_frames,
 )
+from powersimdata.network.model import ModelImmutables
 
 
 class ScenarioGrid(AbstractGrid):
@@ -21,21 +24,22 @@ class ScenarioGrid(AbstractGrid):
 
         :param str filename: path to file.
         """
-        self.filename = filename
         super().__init__()
+        self._set_data_loc(filename)
+        self.grid_model = _get_grid_model_from_scenario_list(filename)
 
-    def _set_data_loc(self):
+    def _set_data_loc(self, filename):
         """Sets data location.
 
         :param str filename: path to file
         :raises FileNotFoundError: if file does not exist.
         """
-        if os.path.isfile(self.filename) is False:
-            raise FileNotFoundError("%s file not found" % self.filename)
+        if os.path.isfile(filename) is False:
+            raise FileNotFoundError("%s file not found" % filename)
         else:
-            self.data_loc = self.filename
+            self.data_loc = filename
 
-    def _read_network(self):
+    def _read(self):
         data = loadmat(self.data_loc, squeeze_me=True, struct_as_record=False)
         mpc = data["mdi"].mpc
         try:
@@ -118,18 +122,29 @@ class ScenarioGrid(AbstractGrid):
         # interconnect
         self.interconnect = self.sub.interconnect.unique().tolist()
 
-    def _build_network(self):
-        """Defines how to interpret the MAT file data to build a network.
-        Not implemented for ScenarioGrid, but must be defined for subclasses.
-        """
-        pass
+        # model immutables
+        if self.grid_model in ["usa_tamu", "hifld"]:
+            self.model_immutables = ModelImmutables(
+                self.grid_model, interconnect=self.interconnect
+            )
+
+
+def _get_grid_model_from_scenario_list(source):
+    """Get grid model for a scenario listed in the scenario list.
+
+    :param str source: path to MAT-file enclosing the grid data.
+    :return: (*str*) -- the grid model.
+    """
+    scenario_number = int(os.path.basename(source).split("_")[0])
+    slm = ScenarioListManager(Context.get_data_access())
+    return slm.get_scenario(scenario_number)["grid_model"]
 
 
 class FromREISE(ScenarioGrid):
     """MATLAB file reader, for MAT files created by REISE/MATPOWER"""
 
-    def _build_network(self):
-        self._read_network()
+    def build(self):
+        self._read()
         reindex_model(self)
         add_information_to_model(self)
 
@@ -137,8 +152,8 @@ class FromREISE(ScenarioGrid):
 class FromREISEjl(ScenarioGrid):
     """MATLAB file reader, for MAT files created (& converted) by REISE.jl"""
 
-    def _build_network(self):
-        self._read_network()
+    def build(self):
+        self._read()
         add_information_to_model(self)
 
 

--- a/powersimdata/network/constants/region/usa.py
+++ b/powersimdata/network/constants/region/usa.py
@@ -173,6 +173,7 @@ def get_state_mapping(zone):
 
     mapping["state"] = set(zone["state"])
     mapping["abv"] = set(zone["abv"])
+    mapping["state_abbr"] = set(zone["abv"])
     mapping["state2loadzone"] = {
         k: set(v)
         for k, v in zone.groupby("state")["zone_name"].unique().to_dict().items()

--- a/powersimdata/network/constants/region/usa.py
+++ b/powersimdata/network/constants/region/usa.py
@@ -204,7 +204,9 @@ def get_loadzone_mapping(zone):
     mapping["timezone2id"] = {
         t: set(i) for t, i in zone.groupby("time_zone").groups.items()
     }
-    mapping["loadzone2id"] = {l: i for l, i in zone.groupby("zone_name").groups.items()}
+    mapping["loadzone2id"] = {
+        l: i[0] for l, i in zone.groupby("zone_name").groups.items()
+    }
     mapping["loadzone2state"] = dict(zip(zone["zone_name"], zone["state"]))
     mapping["loadzone2abv"] = dict(zip(zone["zone_name"], zone["abv"]))
     mapping["loadzone2interconnect"] = dict(

--- a/powersimdata/network/constants/region/usa.py
+++ b/powersimdata/network/constants/region/usa.py
@@ -153,13 +153,13 @@ def get_interconnect_mapping(zone, model):
     mapping["interconnect2timezone"] = _substitute(interconnect2timezone)
     mapping["interconnect2abv"] = _substitute(interconnect2abv)
     mapping["interconnect2loadzone"] = {
-        i: set(zone.set_index("abv")["zone_name"].loc[list(a)])
-        for i, a in mapping["interconnect2abv"].items()
+        i: set(l)
+        for i, l in zone.set_index("zone_name").groupby("interconnect").groups.items()
     }
     mapping["interconnect2id"] = {
-        i: set(zone.reset_index().set_index("abv")["zone_id"].loc[list(a)])
-        for i, a in mapping["interconnect2abv"].items()
+        i: set(id) for i, id in zone.groupby("interconnect").groups.items()
     }
+
     return mapping
 
 

--- a/powersimdata/network/constants/region/usa.py
+++ b/powersimdata/network/constants/region/usa.py
@@ -144,12 +144,10 @@ def get_interconnect_mapping(zone, model):
     mapping = dict()
     sub = "Texas" if model == "usa_tamu" else "ERCOT"
 
-    name = interconnect_to_name(zone["interconnect"].replace(sub, "ERCOT").unique())
-
+    name = interconnect_to_name(zone["interconnect"].unique(), model=model)
     mapping["interconnect"] = ast.literal_eval(
-        repr(name2component[name]).replace("ERCOT", sub)
-    ) | {name}
-
+        repr(name2component).replace("ERCOT", sub)
+    )[name] | {name}
     mapping["name2interconnect"] = _substitute(name2interconnect)
     mapping["name2component"] = _substitute(name2component)
     mapping["interconnect2timezone"] = _substitute(interconnect2timezone)

--- a/powersimdata/network/hifld/model.py
+++ b/powersimdata/network/hifld/model.py
@@ -2,6 +2,8 @@ import os
 
 from powersimdata.input.abstract_grid import AbstractGridCSV
 from powersimdata.network.constants.storage import get_storage
+from powersimdata.network.helpers import check_and_format_interconnect
+from powersimdata.network.model import ModelImmutables
 
 
 class HIFLD(AbstractGridCSV):
@@ -12,9 +14,18 @@ class HIFLD(AbstractGridCSV):
 
     def __init__(self, interconnect):
         """Constructor."""
-        model = "hifld"
         super().__init__()
 
+        self.grid_model = "hifld"
+        self.interconnect = check_and_format_interconnect(
+            interconnect, model=self.grid_model
+        )
+        self.model_immutables = ModelImmutables(
+            self.grid_model, interconnect=interconnect
+        )
         self._set_data_loc(os.path.dirname(__file__))
-        self._build_network(interconnect, model)
-        self.storage.update(get_storage(model))
+
+    def build(self):
+        """Build network"""
+        self._build(self.interconnect, self.grid_model)
+        self.storage.update(get_storage(self.grid_model))

--- a/powersimdata/network/tests/test_helpers.py
+++ b/powersimdata/network/tests/test_helpers.py
@@ -71,12 +71,14 @@ def _assert_interconnect_missing(interconnect, model):
 
 def test_drop_one_interconnect():
     model = TAMU(["Western", "Texas"])
+    model.build()
     _assert_lists_equal(["Western", "Texas"], model.interconnect)
     _assert_interconnect_missing("Eastern", model)
 
 
 def test_drop_two_interconnect():
     model = TAMU(["Western"])
+    model.build()
     _assert_lists_equal(["Western"], model.interconnect)
     for interconnect in ["Eastern", "Texas"]:
         _assert_interconnect_missing(interconnect, model)

--- a/powersimdata/network/usa_tamu/model.py
+++ b/powersimdata/network/usa_tamu/model.py
@@ -2,6 +2,8 @@ import os
 
 from powersimdata.input.abstract_grid import AbstractGridCSV
 from powersimdata.network.constants.storage import get_storage
+from powersimdata.network.helpers import check_and_format_interconnect
+from powersimdata.network.model import ModelImmutables
 
 
 class TAMU(AbstractGridCSV):
@@ -12,9 +14,18 @@ class TAMU(AbstractGridCSV):
 
     def __init__(self, interconnect):
         """Constructor."""
-        model = "usa_tamu"
         super().__init__()
 
+        self.grid_model = "usa_tamu"
+        self.interconnect = check_and_format_interconnect(
+            interconnect, model=self.grid_model
+        )
+        self.model_immutables = ModelImmutables(
+            self.grid_model, interconnect=interconnect
+        )
         self._set_data_loc(os.path.dirname(__file__))
-        self._build_network(interconnect, model)
-        self.storage.update(get_storage(model))
+
+    def build(self):
+        """Build network"""
+        self._build(self.interconnect, self.grid_model)
+        self.storage.update(get_storage(self.grid_model))

--- a/powersimdata/scenario/create.py
+++ b/powersimdata/scenario/create.py
@@ -13,7 +13,7 @@ from powersimdata.input.input_data import (
 from powersimdata.input.profile_input import ProfileInput
 from powersimdata.input.transform_grid import TransformGrid
 from powersimdata.input.transform_profile import TransformProfile
-from powersimdata.network.model import ModelImmutables
+from powersimdata.network.helpers import check_model, interconnect_to_name
 from powersimdata.scenario.execute import Execute
 from powersimdata.scenario.state import State
 
@@ -205,14 +205,12 @@ class _Builder:
 
     def __init__(self, grid_model, interconnect, table):
         """Constructor."""
-        mi = ModelImmutables(grid_model)
+        check_model(grid_model)
 
-        self.grid_model = mi.model
-        self.interconnect = mi.interconnect_to_name(interconnect, self.grid_model)
-
+        self.grid_model = grid_model
         self.base_grid = Grid(interconnect, source=grid_model)
         self.change_table = ChangeTable(self.base_grid)
-
+        self.interconnect = interconnect_to_name(interconnect, grid_model)
         self.existing = table[table.interconnect == self.interconnect]
 
     def get_ct(self):


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
Set the `grid_model` and `model_immutables` attributes of the `Grid` class within their respective model. The model immutables  will no longer be a static object for Europe. The loadzone are the buses and it is necessary to instantiate a PyPSA `Network` object to access the bus table. Moreover the number of loadzone will depend on the spatial reduction. 

### What the code is doing
The `model_immtables` attributes is now set in the  `TAMU`, `HIFLD`, `FromREISE` and `FromREISEjl`. This will set the ground for Europe. To avoid to build the network if we just want to access the model immutables, a `build` method is added to the `TAMU` and `HIFLD` class. One change too is that the `model_immutables` of a `Grid` object now only encloses the mapping for the specified interconnect(s) and not the full USA as previously.

### Testing
Run `tox` successfully

### Where to look
* I would start with `AbstractGrid` -> `AbstractGridCSV` and `ScenarioGrid` -> `TAMU`, `HIFLD`, `FromREISE` and `FromREISEjl` --> `Grid`
* I have removed the dependency on the model immutables in the `powersimdata.scenario.create` module
* I have fixed a bug in the `powersimdata.network.constants.region.usa` module that impacted state/nterconnect(s) with Texas and cast some single element `Int64Index` from `pandas` to `int`.

### Usage Example/Visuals
N/A

### Time estimate
20min
