### PR TITLE
Combine scenario list from different sources

### DIFF
--- a/powersimdata/data_access/data_access.py
+++ b/powersimdata/data_access/data_access.py
@@ -93,17 +93,6 @@ class DataAccess:
         """
         return self.join(server_setup.EXECUTE_DIR, f"scenario_{scenario_id}")
 
-    def copy(self, src, dest):
-        """Copy file to new location
-
-        :param str src: path to file
-        :param str dest: destination folder
-        """
-        if self.fs.isdir(dest):
-            dest = self.join(dest, fs.path.basename(src))
-
-        self.fs.copy(src, dest)
-
     def remove(self, base_dir, pattern, confirm=True):
         """Delete files in current environment
 

--- a/powersimdata/scenario/execute.py
+++ b/powersimdata/scenario/execute.py
@@ -229,18 +229,17 @@ class SimulationInput:
         :param bool slice: whether to slice the profiles by the Scenario's time range.
         """
         file_name = f"{kind}.csv"
+        dest_path = "/".join([self.REL_TMP_DIR, file_name])
         if profile_as is None:
-            filepath = "/".join([self.REL_TMP_DIR, file_name])
-
             tp = TransformProfile(self._scenario_info, self.grid, self.ct, slice)
             profile = tp.get_profile(kind)
-            print(f"Writing scaled {kind} profile to {filepath}")
-            with self._data_access.write(filepath, save_local=False) as f:
+            print(f"Writing scaled {kind} profile to {dest_path}")
+            with self._data_access.write(dest_path, save_local=False) as f:
                 profile.to_csv(f)
         else:
             from_dir = self._data_access.tmp_folder(profile_as)
             src = "/".join([from_dir, file_name])
-            self._data_access.copy(src, self.REL_TMP_DIR)
+            self._data_access.fs.copy(src, dest_path)
 
     def prepare_demand_flexibility_parameters_file(self):
         """Creates the demand_flexibility_parameters file."""


### PR DESCRIPTION
### Purpose
Fix the issue where a user won't get a scenario list with existing local scenarios if not connected to the server. 

### What the code is doing
Best effort to download and use any possible copies of scenario or execute list csv. The local copies are updated with the latest version if possible (always for blob storage, and server copy if connected). Then the results are combined, since we might as well handle a case where the local copy hasn't been updated since the last time we add scenarios to blob storage. 

Unrelated: noticed that the `.copy()` data access method is only used in one place, so removed it from the interface. 

### Testing
Manual testing: load `Scenario(824)` which is not in blob storage, but is in my local ScenarioList.csv. If not connected to the server, it will load as much as possible but fails since I don't have the grid.mat, as expected.

### Time estimate
10 min
