### PR TITLE
Relocate functions exporting data

### DIFF
--- a/powersimdata/export/export_scenario_inputs.py
+++ b/powersimdata/export/export_scenario_inputs.py
@@ -1,0 +1,152 @@
+import copy
+
+import numpy as np
+from scipy.io import savemat
+
+from powersimdata.input.transform_profile import TransformProfile
+
+
+def export_case_mat(grid, filepath=None, storage_filepath=None):
+    """Export a grid to a format suitable for loading into simulation engine.
+    If optional filepath arguments are used, the results will also be saved to
+    the filepaths provided
+
+    :param powersimdata.input.grid.Grid grid: Grid instance.
+    :param str filepath: path where main grid file will be saved, if present
+    :param str storage_filepath: path where storage data file will be saved, if present.
+    :return: (*tuple*) -- the mpc data as a dictionary and the mpc storage data
+        as a dictionary, if present. The storage data will be None if not present.
+    """
+    grid = copy.deepcopy(grid)
+
+    mpc = {"mpc": {"version": "2", "baseMVA": 100.0}}
+
+    # zone
+    mpc["mpc"]["zone"] = np.array(list(grid.id2zone.items()), dtype=object)
+
+    # sub
+    sub = grid.sub.copy()
+    subid = sub.index.values[np.newaxis].T
+    mpc["mpc"]["sub"] = sub.values
+    mpc["mpc"]["subid"] = subid
+
+    # bus
+    bus = grid.bus.copy()
+    busid = bus.index.values[np.newaxis].T
+    bus.reset_index(level=0, inplace=True)
+    bus.drop(columns=["interconnect", "lat", "lon"], inplace=True)
+    mpc["mpc"]["bus"] = bus.values
+    mpc["mpc"]["busid"] = busid
+
+    # bus2sub
+    bus2sub = grid.bus2sub.copy()
+    mpc["mpc"]["bus2sub"] = bus2sub.values
+
+    # plant
+    gen = grid.plant.copy()
+    genid = gen.index.values[np.newaxis].T
+    genfuel = gen.type.values[np.newaxis].T
+    genfuelcost = gen.GenFuelCost.values[np.newaxis].T
+    heatratecurve = gen[["GenIOB", "GenIOC", "GenIOD"]].values
+    gen.reset_index(inplace=True, drop=True)
+    gen.drop(
+        columns=[
+            "type",
+            "interconnect",
+            "lat",
+            "lon",
+            "zone_id",
+            "zone_name",
+            "GenFuelCost",
+            "GenIOB",
+            "GenIOC",
+            "GenIOD",
+        ],
+        inplace=True,
+    )
+    mpc["mpc"]["gen"] = gen.values
+    mpc["mpc"]["genid"] = genid
+    mpc["mpc"]["genfuel"] = genfuel
+    mpc["mpc"]["genfuelcost"] = genfuelcost
+    mpc["mpc"]["heatratecurve"] = heatratecurve
+    # branch
+    branch = grid.branch.copy()
+    branchid = branch.index.values[np.newaxis].T
+    branchdevicetype = branch.branch_device_type.values[np.newaxis].T
+    branch.reset_index(inplace=True, drop=True)
+    branch.drop(
+        columns=[
+            "interconnect",
+            "from_lat",
+            "from_lon",
+            "to_lat",
+            "to_lon",
+            "from_zone_id",
+            "to_zone_id",
+            "from_zone_name",
+            "to_zone_name",
+            "branch_device_type",
+        ],
+        inplace=True,
+    )
+    mpc["mpc"]["branch"] = branch.values
+    mpc["mpc"]["branchid"] = branchid
+    mpc["mpc"]["branchdevicetype"] = branchdevicetype
+
+    # generation cost
+    gencost = grid.gencost.copy()
+    gencost["before"].reset_index(inplace=True, drop=True)
+    gencost["before"].drop(columns=["interconnect"], inplace=True)
+    mpc["mpc"]["gencost"] = gencost["before"].values
+
+    # DC line
+    if len(grid.dcline) > 0:
+        dcline = grid.dcline.copy()
+        dclineid = dcline.index.values[np.newaxis].T
+        dcline.reset_index(inplace=True, drop=True)
+        dcline.drop(columns=["from_interconnect", "to_interconnect"], inplace=True)
+        mpc["mpc"]["dcline"] = dcline.values
+        mpc["mpc"]["dclineid"] = dclineid
+
+    # energy storage
+    mpc_storage = None
+
+    if len(grid.storage["gen"]) > 0:
+        storage = grid.storage.copy()
+
+        mpc_storage = {
+            "storage": {
+                "xgd_table": np.array([]),
+                "gen": np.array(storage["gen"].values, dtype=np.float64),
+                "sd_table": {
+                    "colnames": storage["StorageData"].columns.values[np.newaxis],
+                    "data": storage["StorageData"].values,
+                },
+            }
+        }
+
+    if filepath is not None:
+        savemat(filepath, mpc, appendmat=False)
+        if mpc_storage is not None:
+            savemat(storage_filepath, mpc_storage, appendmat=False)
+
+    return mpc, mpc_storage
+
+
+def export_transformed_profile(kind, scenario_info, grid, ct, filepath, slice=True):
+    """Apply transformation to the given kind of profile and save the result locally.
+
+    :param str kind: which profile to export. This parameter is passed to
+        :meth:`TransformProfile.get_profile`.
+    :param dict scenario_info: a dict containing the profile version, with
+        key in the form base_{kind}
+    :param powersimdata.input.grid.Grid grid: a Grid object previously
+        transformed.
+    :param dict ct: change table.
+    :param str filepath: path to save the result, including the filename
+    :param bool slice: whether to slice the profiles by the Scenario's time range.
+    """
+    tp = TransformProfile(scenario_info, grid, ct, slice)
+    profile = tp.get_profile(kind)
+    print(f"Writing scaled {kind} profile to {filepath} on local machine")
+    profile.to_csv(filepath)

--- a/powersimdata/export/export_to_pypsa.py
+++ b/powersimdata/export/export_to_pypsa.py
@@ -1,19 +1,11 @@
-import copy
 import warnings
 
 import numpy as np
 import pandas as pd
-from scipy.io import savemat
 
-from powersimdata import Grid
-from powersimdata.input.transform_profile import TransformProfile
-
-PYPSA_AVAILABLE = True
-try:
-    import pypsa
-except ImportError:
-    PYPSA_AVAILABLE = False
-
+from powersimdata.input.grid import Grid
+from powersimdata.scenario.scenario import Scenario
+from powersimdata.utility.helpers import _check_import
 
 pypsa_const = {
     "bus": {
@@ -140,152 +132,6 @@ pypsa_const = {
 }
 
 
-def export_case_mat(grid, filepath=None, storage_filepath=None):
-    """Export a grid to a format suitable for loading into simulation engine.
-    If optional filepath arguments are used, the results will also be saved to
-    the filepaths provided
-
-    :param powersimdata.input.grid.Grid grid: Grid instance.
-    :param str filepath: path where main grid file will be saved, if present
-    :param str storage_filepath: path where storage data file will be saved, if present.
-    :return: (*tuple*) -- the mpc data as a dictionary and the mpc storage data
-        as a dictionary, if present. The storage data will be None if not present.
-    """
-    grid = copy.deepcopy(grid)
-
-    mpc = {"mpc": {"version": "2", "baseMVA": 100.0}}
-
-    # zone
-    mpc["mpc"]["zone"] = np.array(list(grid.id2zone.items()), dtype=object)
-
-    # sub
-    sub = grid.sub.copy()
-    subid = sub.index.values[np.newaxis].T
-    mpc["mpc"]["sub"] = sub.values
-    mpc["mpc"]["subid"] = subid
-
-    # bus
-    bus = grid.bus.copy()
-    busid = bus.index.values[np.newaxis].T
-    bus.reset_index(level=0, inplace=True)
-    bus.drop(columns=["interconnect", "lat", "lon"], inplace=True)
-    mpc["mpc"]["bus"] = bus.values
-    mpc["mpc"]["busid"] = busid
-
-    # bus2sub
-    bus2sub = grid.bus2sub.copy()
-    mpc["mpc"]["bus2sub"] = bus2sub.values
-
-    # plant
-    gen = grid.plant.copy()
-    genid = gen.index.values[np.newaxis].T
-    genfuel = gen.type.values[np.newaxis].T
-    genfuelcost = gen.GenFuelCost.values[np.newaxis].T
-    heatratecurve = gen[["GenIOB", "GenIOC", "GenIOD"]].values
-    gen.reset_index(inplace=True, drop=True)
-    gen.drop(
-        columns=[
-            "type",
-            "interconnect",
-            "lat",
-            "lon",
-            "zone_id",
-            "zone_name",
-            "GenFuelCost",
-            "GenIOB",
-            "GenIOC",
-            "GenIOD",
-        ],
-        inplace=True,
-    )
-    mpc["mpc"]["gen"] = gen.values
-    mpc["mpc"]["genid"] = genid
-    mpc["mpc"]["genfuel"] = genfuel
-    mpc["mpc"]["genfuelcost"] = genfuelcost
-    mpc["mpc"]["heatratecurve"] = heatratecurve
-    # branch
-    branch = grid.branch.copy()
-    branchid = branch.index.values[np.newaxis].T
-    branchdevicetype = branch.branch_device_type.values[np.newaxis].T
-    branch.reset_index(inplace=True, drop=True)
-    branch.drop(
-        columns=[
-            "interconnect",
-            "from_lat",
-            "from_lon",
-            "to_lat",
-            "to_lon",
-            "from_zone_id",
-            "to_zone_id",
-            "from_zone_name",
-            "to_zone_name",
-            "branch_device_type",
-        ],
-        inplace=True,
-    )
-    mpc["mpc"]["branch"] = branch.values
-    mpc["mpc"]["branchid"] = branchid
-    mpc["mpc"]["branchdevicetype"] = branchdevicetype
-
-    # generation cost
-    gencost = grid.gencost.copy()
-    gencost["before"].reset_index(inplace=True, drop=True)
-    gencost["before"].drop(columns=["interconnect"], inplace=True)
-    mpc["mpc"]["gencost"] = gencost["before"].values
-
-    # DC line
-    if len(grid.dcline) > 0:
-        dcline = grid.dcline.copy()
-        dclineid = dcline.index.values[np.newaxis].T
-        dcline.reset_index(inplace=True, drop=True)
-        dcline.drop(columns=["from_interconnect", "to_interconnect"], inplace=True)
-        mpc["mpc"]["dcline"] = dcline.values
-        mpc["mpc"]["dclineid"] = dclineid
-
-    # energy storage
-    mpc_storage = None
-
-    if len(grid.storage["gen"]) > 0:
-        storage = grid.storage.copy()
-
-        mpc_storage = {
-            "storage": {
-                "xgd_table": np.array([]),
-                "gen": np.array(storage["gen"].values, dtype=np.float64),
-                "sd_table": {
-                    "colnames": storage["StorageData"].columns.values[np.newaxis],
-                    "data": storage["StorageData"].values,
-                },
-            }
-        }
-
-    if filepath is not None:
-        savemat(filepath, mpc, appendmat=False)
-        if mpc_storage is not None:
-            savemat(storage_filepath, mpc_storage, appendmat=False)
-
-    return mpc, mpc_storage
-
-
-def export_transformed_profile(kind, scenario_info, grid, ct, filepath, slice=True):
-    """Apply transformation to the given kind of profile and save the result locally.
-
-    :param str kind: which profile to export. This parameter is passed to
-        :meth:`TransformProfile.get_profile`.
-    :param dict scenario_info: a dict containing the profile version, with
-        key in the form base_{kind}
-    :param powersimdata.input.grid.Grid grid: a Grid object previously
-        transformed.
-    :param dict ct: change table.
-    :param str filepath: path to save the result, including the filename
-    :param bool slice: whether to slice the profiles by the Scenario's time range.
-    """
-    tp = TransformProfile(scenario_info, grid, ct, slice)
-    profile = tp.get_profile(kind)
-    print(f"Writing scaled {kind} profile to {filepath} on local machine")
-    profile.to_csv(filepath)
-
-
 def export_to_pypsa(
     scenario_or_grid,
     add_all_columns=False,
@@ -317,10 +163,7 @@ def export_to_pypsa(
         generators to the exported pypsa network. This ensures feasibility when
         optimizing the exported pypsa network as is. The default is True.
     """
-    from powersimdata.scenario.scenario import Scenario  # avoid circular import
-
-    if not PYPSA_AVAILABLE:
-        raise ImportError("PyPSA is not installed.")
+    pypsa = _check_import("pypsa")
 
     if isinstance(scenario_or_grid, Grid):
         grid = scenario_or_grid
@@ -394,14 +237,14 @@ def export_to_pypsa(
     generators["ramp_limit_up"] = generators.ramp_limit.replace(0, np.nan)
     generators.drop(columns=drop_cols + ["ramp_limit"], inplace=True)
 
-    gencost = grid.gencost["before"]
-    gencost = gencost.rename(columns=pypsa_const["cost"]["rename"])
+    gencost = grid.gencost["before"].copy()
     # Linearize quadratic curves as applicable
     fixed = grid.plant["Pmin"] == grid.plant["Pmax"]
     linearized = gencost.loc[~fixed, "c1"] + gencost.loc[~fixed, "c2"] * (
         grid.plant.loc[~fixed, "Pmax"] + grid.plant.loc[~fixed, "Pmin"]
     )
-    gencost["marginal_cost"] = linearized.combine_first(gencost["c1"])
+    gencost["c1"] = linearized.combine_first(gencost["c1"])
+    gencost = gencost.rename(columns=pypsa_const["cost"]["rename"])
     gencost = gencost[pypsa_const["cost"]["rename"].values()]
 
     carriers = pd.DataFrame(index=generators.carrier.unique(), dtype=object)
@@ -450,7 +293,6 @@ def export_to_pypsa(
     transformers = branches.query(
         "branch_device_type in ['TransformerWinding', 'Transformer']"
     )
-    transformers = transformers.drop(columns="branch_device_type")
 
     if scenario:
         lines_t = {}
@@ -524,4 +366,5 @@ def export_to_pypsa(
         )
         n.add("Carrier", "load", nice_name="Load Shedding", color="red")
 
+    n.name = ", ".join([grid.data_loc] + grid.interconnect)
     return n

--- a/powersimdata/export/tests/test_export_to_pypsa.py
+++ b/powersimdata/export/tests/test_export_to_pypsa.py
@@ -1,6 +1,8 @@
+from importlib.util import find_spec
+
 import pytest
 
-from powersimdata.input.export_data import PYPSA_AVAILABLE, export_to_pypsa
+from powersimdata.export.export_to_pypsa import export_to_pypsa
 from powersimdata.input.grid import Grid
 
 
@@ -18,7 +20,7 @@ def assert_columns_deleted(n):
     assert "QminF" not in n.links
 
 
-@pytest.mark.skipif(not PYPSA_AVAILABLE, reason="Package PyPSA not available.")
+@pytest.mark.skipif(find_spec("pypsa") is None, reason="Package PyPSA not available.")
 def test_export_grid_to_pypsa():
     grid = Grid("USA")
 

--- a/powersimdata/scenario/execute.py
+++ b/powersimdata/scenario/execute.py
@@ -2,7 +2,7 @@ import pandas as pd
 from scipy.io import savemat
 
 from powersimdata.data_access.context import Context
-from powersimdata.input.export_data import export_case_mat
+from powersimdata.export.export_scenario_inputs import export_case_mat
 from powersimdata.input.grid import Grid
 from powersimdata.input.input_data import InputData
 from powersimdata.input.transform_grid import TransformGrid


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
Relocate functions taking care of exporting data to files or other objects  

### What the code is doing
New modules are created:
* `powersimdata.export.export_scenario_inputs` enclosing the functions that create the case mat file and the CSVs of the transformed profiles
* `powersimdata.export.export_to_pypsa` enclosing the function that translate a `Grid` or a `Scenario` object to PyPSA `Network` object
* Removed the logic around the import of the `pypsa` package (check for it in the test though to avoid failure) since the `export_to_pypsa` function is now in its own module, an `ImportError` won't affect  import of any other function anymore. 

### Testing
Run existing unit tests

### Where to look
In the new **PowerSimData/powersimdata/export/** directory

### Usage Example/Visuals
N/A

### Time estimate
10min
