### PR TITLE
fix: save correct data to case_storage.mat

### DIFF
--- a/powersimdata/scenario/execute.py
+++ b/powersimdata/scenario/execute.py
@@ -217,7 +217,7 @@ class SimulationInput:
 
         if mpc_storage is not None:
             with self._data_access.write(storage_file_path, save_local=False) as f:
-                savemat(f, mpc, appendmat=False)
+                savemat(f, mpc_storage, appendmat=False)
 
     def prepare_profile(self, kind, profile_as=None, slice=False):
         """Prepares profile for simulation.


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
Fix obvious typo affecting scenarios that include storage in the change table.

### What the code is doing
Save the right content to the mat file.

### Testing
Ran it in docker.

### Time estimate
1 min
