### PR TITLE
DRAFT: add data structure for expansion candidates

### DIFF
--- a/powersimdata/input/expansion_candidates.py
+++ b/powersimdata/input/expansion_candidates.py
@@ -1,0 +1,64 @@
+import pandas as pd
+
+
+class ExpansionCandidates:
+    """Instantiate a data structure to hold candidates for expansion in a capacity
+    expansion model.
+
+    :param pandas.DataFrame branch: branch candidate information.
+    :param pandas.DataFrame plant: plant candidate information.
+    :param pandas.DataFrame storage: storage candidate information.
+    """
+
+    columns = {
+        "branch": ("from_bus", "to_bus", "inv_cost", "max_capacity"),
+        "plant": ("bus_id", "type", "marginal_cost", "inv_cost", "max_capacity"),
+        "storage": (
+            "bus_id",
+            "inv_cost_power",
+            "inv_cost_energy",
+            "max_capacity_energy",
+            "max_capacity_power",
+        ),
+    }
+    required_columns = {
+        "branch": ("from_bus", "to_bus"),
+        "plant": ("bus_id", "type", "marginal_cost"),
+        "storage": ("bus_id"),
+    }
+
+    def __init__(self, branch=None, plant=None, storage=None):
+        """Constructor."""
+
+        if branch is None:
+            self.branch = pd.DataFrame(columns=self.columns["branch"])
+        else:
+            if not isinstance(branch, pd.DataFrame):
+                raise TypeError("branch must be a data frame")
+            if not set(self.required_columns["branch"]) <= set(branch.columns):
+                raise TypeError(
+                    f"branch must have columns {self.required_columns['branch']}"
+                )
+            self.branch = branch.reindex(self.columns["branch"], axis=1)
+
+        if plant is None:
+            self.plant = pd.DataFrame(columns=self.columns["plant"])
+        else:
+            if not isinstance(plant, pd.DataFrame):
+                raise TypeError("plant must be a data frame")
+            if not set(self.required_columns["plant"]) <= set(plant.columns):
+                raise TypeError(
+                    f"plant must have columns {self.required_columns['plant']}"
+                )
+            self.plant = plant.reindex(self.columns["plant"], axis=1)
+
+        if storage is None:
+            self.storage = pd.DataFrame(columns=self.columns["storage"])
+        else:
+            if not isinstance(storage, pd.DataFrame):
+                raise TypeError("storage must be a data frame")
+            if not set(self.required_columns["storage"]) <= set(storage.columns):
+                raise TypeError(
+                    f"storage must have columns {self.required_columns['storage']}"
+                )
+            self.storage = storage.reindex(self.columns["storage"], axis=1)


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
Add a thin data structure enclosing expansion candidate information for generation, transmission, and storage.

### What the code is doing
Basic column checking on `branch`, `plant`, `storage` parameters if they're passed, otherwise instantiating an empty dataframe with the appropriate columns.

### Usage Example/Visuals
```python
>>> from powersimdata.input.expansion_candidates import ExpansionCandidates
>>> import pandas as pd
>>> ec = ExpansionCandidates()
>>> ec.branch
Empty DataFrame
Columns: [from_bus, to_bus, inv_cost, max_capacity]
Index: []
>>> ec.plant
Empty DataFrame
Columns: [bus_id, type, marginal_cost, inv_cost, max_capacity]
Index: []
>>> ec.storage
Empty DataFrame
Columns: [bus_id, inv_cost_power, inv_cost_energy, max_capacity_energy, max_capacity_power]
Index: []
>>> plant = pd.DataFrame({"bus_id": [1, 10, 10, 100], "type": ["ng", "ng", "wind", "solar"], "marginal_cost": [40, 40, 0, 0]})
>>> ec = ExpansionCandidates(plant=plant)
>>> ec.branch
Empty DataFrame
Columns: [from_bus, to_bus, inv_cost, max_capacity]
Index: []
>>> ec.plant
   bus_id   type  marginal_cost  inv_cost  max_capacity
0       1     ng             40       NaN           NaN
1      10     ng             40       NaN           NaN
2      10   wind              0       NaN           NaN
3     100  solar              0       NaN           NaN
>>> ec.storage
Empty DataFrame
Columns: [bus_id, inv_cost_power, inv_cost_energy, max_capacity_energy, max_capacity_power]
Index: []
```

### Time estimate
?
