### PR TITLE
chore: remove hifld from list of supported model

### DIFF
--- a/powersimdata/input/grid.py
+++ b/powersimdata/input/grid.py
@@ -11,7 +11,7 @@ _cache = MemoryCache()
 
 class Grid:
 
-    SUPPORTED_MODELS = {"hifld", "usa_tamu"}
+    SUPPORTED_MODELS = {"usa_tamu"}
     SUPPORTED_ENGINES = {"REISE", "REISE.jl"}
 
     """Grid


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
Remove `hifld` from list of supported models since we will likely merge the `hifld` branch into `develop` before we have the HIFLD grid model ready.

### What the code is doing
If a user tries to instantiate the `Grid` class with the source parameter set to `hifld` a `ValueError` will be raised. Also, the `set_grid` method of the `Create` class will throw the same error. 

### Testing
```
>>> from powersimdata import Grid
>>> g = Grid("ERCOT", source="hifld")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/brdo/CEM/PowerSimData/powersimdata/input/grid.py", line 35, in __init__
    raise ValueError(
ValueError: Source must be one of usa_tamu or the path to a .mat file that represents a grid 
```

### Where to look
The `powersimdata.input.grid` module

### Usage Example/Visuals
N/A

### Time estimate
2min
