### PR TITLE
fix: pass grid instead of grid.dcline

### DIFF
--- a/powersimdata/design/investment/investment_costs.py
+++ b/powersimdata/design/investment/investment_costs.py
@@ -291,9 +291,7 @@ def calculate_dc_inv_costs(scenario, sum_results=True, base_grid=None):
         _check_grid_models_match(base_grid, grid_differences)
 
     # find upgraded DC lines
-    capacity_difference = calculate_dcline_difference(
-        base_grid.dcline, grid_differences.dcline
-    )
+    capacity_difference = calculate_dcline_difference(base_grid, grid_differences)
     grid_differences.dcline = grid_differences.dcline.assign(
         Pmax=capacity_difference["diff"].to_numpy()
     )


### PR DESCRIPTION
### Purpose
I got an error using `calculate_dcline_difference` since it checks that the parameters are `Grid` instances. We use other grid attributes within that function, so we simply pass the grid object (instead of removing the type check). 

### What the code is doing
Pass full grid object.

### Testing
Manually in a container. I ended up with a different error due to having an empty `grid.dcline` but that is not surprising. 


### Time estimate
2 min
