### PR TITLE
Fix PyPSA exporter

### DIFF
--- a/powersimdata/export/export_to_pypsa.py
+++ b/powersimdata/export/export_to_pypsa.py
@@ -70,6 +70,7 @@ pypsa_const = {
         "rename": {
             "startup": "startup_cost",
             "shutdown": "shutdown_cost",
+            "c1": "marginal_cost",
         }
     },
     "branch": {


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
Add missing rename value when converting a `Grid` object to a `Network` object. I forgot to include it when I updated the `export_to_pypsa` function from changes made in #608. As a result, the `c1` column will not be renamed to `marginal cost` as expected by PyPSA

### What the code is doing
N/A

### Testing
I found the bug in the `ben/import` branch when trying to convert back to a `Grid` object a `Network` object previously created from a `Grid` object.

### Where to look
You can compare what is done in #608 (see [here](https://github.com/Breakthrough-Energy/PowerSimData/blob/fab8f67d3c02b797b778bcc0a8b4c7603d0e2767/powersimdata/input/export_data.py#L80))

### Usage Example/Visuals
N/A

### Time estimate
2min
