### PR TITLE
fix: add conversion factor for co2 emissions when exporting to pypsa

### DIFF
--- a/powersimdata/input/exporter/export_to_pypsa.py
+++ b/powersimdata/input/exporter/export_to_pypsa.py
@@ -254,7 +254,11 @@ def export_to_pypsa(
     constants = grid.model_immutables.plants
     carriers["color"] = pd.Series(constants["type2color"]).reindex(cars)
     carriers["nice_name"] = pd.Series(constants["type2label"]).reindex(cars)
-    carriers["co2_emissions"] = pd.Series(constants["carbon_per_mwh"]).reindex(cars)
+    carriers["co2_emissions"] = (
+        pd.Series(constants["carbon_per_mwh"]).div(1e3)
+        * pd.Series(constants["efficiency"])
+    ).reindex(cars, fill_value=0)
+    generators["efficiency"] = generators.carrier.map(constants["efficiency"]).fillna(0)
 
     # now time-dependent
     if scenario:

--- a/powersimdata/network/constants/plants.py
+++ b/powersimdata/network/constants/plants.py
@@ -60,6 +60,16 @@ carbon_per_mwh = {
     "ng": 469,
 }
 
+# MWh_electric to MWh_thermal
+# Source: Danish Energy Agency, "Technology Data - Generation of Energy and District Heating",
+# https://ens.dk/sites/ens.dk/files/Analyser/technology_data_catalogue_for_el_and_dh.pdf
+efficiency = {
+    "coal": 0.33,
+    "dfo": 0.35,
+    "ng": 0.41,  # referring to OCGT values from DEA
+}
+
+
 # MMBTu of fuel per hour to kilograms of CO2 per hour
 # Source: https://www.epa.gov/energy/greenhouse-gases-equivalencies-calculator-calculations-and-references
 # = (Heat rate MMBTu/h) * (kg C/mmbtu) * (mass ratio CO2/C)
@@ -101,6 +111,7 @@ def get_plants(model):
         "carbon_resources",
         "renewable_resources",
         "clean_resources",
+        "efficiency",
         "carbon_per_mwh",
         "carbon_per_mmbtu",
         "nox_per_mwh",


### PR DESCRIPTION
### Purpose
Fix the unit conversion when exporting co2 emission rates to pypsa networks. Pypsa specifies co2 emissions in tonnes per MWh_thermal, powersimdata in kg per MWh_electric. A new dictionary was added to `plants.py` specifying the type dependent efficiencies. These are necessary for the conversion and are taken from the Danish Energy Agency.   

### Testing
No tests added

### Time estimate
2 min
