### PR TITLE
Update link to PyPSA-Eur files

### DIFF
--- a/powersimdata/network/europe_tub/model.py
+++ b/powersimdata/network/europe_tub/model.py
@@ -56,11 +56,11 @@ class TUB:
 
     def build(self):
         """Build network"""
-        path = os.path.join(self.data_loc, "networks")
+        path = os.path.join(self.data_loc, "networks", "elec_s")
         if self.reduction is None:
-            network = pypsa.Network(os.path.join(path, "elec_s.nc"))
-        elif os.path.exists(os.path.join(path, f"elec_s_{self.reduction}.nc")):
-            network = pypsa.Network(os.path.join(path, f"elec_s_{self.reduction}.nc"))
+            network = pypsa.Network(path + ".nc")
+        elif os.path.exists(path + f"_{self.reduction}_ec.nc"):
+            network = pypsa.Network(path + f"_{self.reduction}_ec.nc")
         else:
             raise ValueError(
                 "Invalid Resolution. Choose among: None | 1024 | 512 | 256 | 128 | 37"


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
Use PyPSA-Eur extra components files. These ones include, among other things, `stores`
### What the code is doing
N/A

### Testing
Before:
```
(PowerSimData) [~/CEM/PowerSimData] (ben/import) brdo$ python
Python 3.9.11 (main, May  4 2022, 12:39:41) 
[Clang 12.0.0 (clang-1200.0.26.2)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from powersimdata.network.europe_tub.model import TUB
>>> tub = TUB("Europe", reduction=1024)
Title: PyPSA-Eur: An Open Optimisation Model of the European Transmission System (Dataset)
Keywords: power system model, capacity expansion model, energy system model, electricity system model, python
Publication date: 2021-09-22
DOI: 10.5281/zenodo.5521712
Total size: 1767.1 MB

Link: https://zenodo.org/api/files/6e58c6dc-083b-46c8-8255-8516e3eb0ed8/networks.zip   size: 1767.1 MB
networks.zip is already downloaded correctly.
All files have been downloaded.
>>> tub.build()
WARNING:pypsa.io:
Importing PyPSA from older version of PyPSA than current version.
Please read the release notes at https://pypsa.readthedocs.io/en/latest/release_notes.html
carefully to prepare your network for import.
Currently used PyPSA version [0, 19, 3], imported network file PyPSA version [0, 18, 0].

INFO:pypsa.io:Imported network elec_s_1024.nc has buses, carriers, generators, lines, links, loads, storage_units
>>> tub.network.stores
Empty DataFrame
Columns: [bus, type, carrier, e_nom, e_nom_extendable, e_nom_min, e_nom_max, e_min_pu, e_max_pu, e_initial, e_initial_per_period, e_cyclic, e_cyclic_per_period, p_set, q_set, sign, marginal_cost, capital_cost, standing_loss, build_year, lifetime, e_nom_opt]
Index: []
```
After:
```
(PowerSimData) [~/CEM/PowerSimData] (ben/import) brdo$ git checkout ben/tub
Switched to branch 'ben/tub'
Your branch is up to date with 'origin/ben/tub'.
(PowerSimData) [~/CEM/PowerSimData] (ben/tub) brdo$ python
Python 3.9.11 (main, May  4 2022, 12:39:41) 
[Clang 12.0.0 (clang-1200.0.26.2)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from powersimdata.network.europe_tub.model import TUB
>>> tub = TUB("Europe", reduction=1024)
Title: PyPSA-Eur: An Open Optimisation Model of the European Transmission System (Dataset)
Keywords: power system model, capacity expansion model, energy system model, electricity system model, python
Publication date: 2021-09-22
DOI: 10.5281/zenodo.5521712
Total size: 1767.1 MB

Link: https://zenodo.org/api/files/6e58c6dc-083b-46c8-8255-8516e3eb0ed8/networks.zip   size: 1767.1 MB
networks.zip is already downloaded correctly.
All files have been downloaded.
>>> tub.build()
WARNING:pypsa.io:
Importing PyPSA from older version of PyPSA than current version.
Please read the release notes at https://pypsa.readthedocs.io/en/latest/release_notes.html
carefully to prepare your network for import.
Currently used PyPSA version [0, 19, 3], imported network file PyPSA version [0, 18, 0].

INFO:pypsa.io:Imported network elec_s_1024_ec.nc has buses, carriers, generators, lines, links, loads, storage_units, stores
>>> tub.network.stores
                         bus  carrier  e_nom_extendable  e_cyclic  capital_cost type  ...  sign  marginal_cost  standing_loss  build_year  lifetime  e_nom_opt
Store                                                                                 ...                                                                     
AL0 0 H2            AL0 0 H2       H2              True      True    796.283619       ...   1.0            0.0            0.0           0       inf        0.0
AT0 0 H2            AT0 0 H2       H2              True      True    796.283619       ...   1.0            0.0            0.0           0       inf        0.0
AT0 1 H2            AT0 1 H2       H2              True      True    796.283619       ...   1.0            0.0            0.0           0       inf        0.0
AT0 10 H2          AT0 10 H2       H2              True      True    796.283619       ...   1.0            0.0            0.0           0       inf        0.0
AT0 11 H2          AT0 11 H2       H2              True      True    796.283619       ...   1.0            0.0            0.0           0       inf        0.0
...                      ...      ...               ...       ...           ...  ...  ...   ...            ...            ...         ...       ...        ...
SK0 4 battery  SK0 4 battery  battery              True      True  15877.883774       ...   1.0            0.0            0.0           0       inf        0.0
SK0 5 battery  SK0 5 battery  battery              True      True  15877.883774       ...   1.0            0.0            0.0           0       inf        0.0
SK0 6 battery  SK0 6 battery  battery              True      True  15877.883774       ...   1.0            0.0            0.0           0       inf        0.0
SK0 7 battery  SK0 7 battery  battery              True      True  15877.883774       ...   1.0            0.0            0.0           0       inf        0.0
SK0 8 battery  SK0 8 battery  battery              True      True  15877.883774       ...   1.0            0.0            0.0           0       inf        0.0

[2048 rows x 22 columns]
```

### Where to look
The link to the files on Zenodo has been updated

### Usage Example/Visuals
N/A

### Time estimate
2min
