### PR TITLE
fix: replace "energy_price" by "energy_value" in storage template

### DIFF
--- a/powersimdata/input/abstract_grid.py
+++ b/powersimdata/input/abstract_grid.py
@@ -40,7 +40,7 @@ def storage_template():
         "InEff": None,
         "OutEff": None,
         "LossFactor": None,  # stored energy fraction / hour
-        "energy_price": None,  # $/MWh
+        "energy_value": None,  # $/MWh
         "terminal_min": None,
         "terminal_max": None,
     }

--- a/powersimdata/scenario/demo/scenario_and_grid_cheatsheet.ipynb
+++ b/powersimdata/scenario/demo/scenario_and_grid_cheatsheet.ipynb
@@ -16,7 +16,7 @@
     "import pandas as pd\n",
     "\n",
     "from pprint import pprint\n",
-    "from powersimdata.scenario.scenario import Scenario"
+    "from powersimdata import Scenario"
    ]
   },
   {
@@ -52,11 +52,72 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "Initialized remote filesystem with ssh_fs,profile_fs,scenario_fs\n",
+      "Transferring ScenarioList.csv from ssh_fs\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|##########| 669k/669k [00:01<00:00, 153kb/s]  \n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Transferring ScenarioList.csv.2 from scenario_fs\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "0.00b [00:00, ?b/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Transferring ExecuteList.csv from ssh_fs\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|##########| 50.5k/50.5k [00:00<00:00, 76.7kb/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Transferring ExecuteList.csv.2 from scenario_fs\n",
       "SCENARIO: Julia | USABase_2020_Anchor_profile_fix_1\n",
       "\n",
       "--> State\n",
       "analyze\n",
       "--> Loading grid\n",
+      "Initialized remote filesystem with ssh_fs,profile_fs,scenario_fs\n",
+      "Transferring ScenarioList.csv from ssh_fs\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|##########| 669k/669k [00:01<00:00, 153kb/s]  \n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Transferring ScenarioList.csv.2 from scenario_fs\n",
       "Loading bus\n",
       "Loading plant\n",
       "Loading heat_rate_curve\n",
@@ -83,20 +144,64 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'_execute_list_manager': <powersimdata.data_access.execute_list.ExecuteListManager object at 0x125008c10>,\n",
-      " '_scenario_list_manager': <powersimdata.data_access.scenario_list.ScenarioListManager object at 0x125008ac0>,\n",
+      "{'_default_info': [('plan', ''),\n",
+      "                   ('name', ''),\n",
+      "                   ('state', 'create'),\n",
+      "                   ('grid_model', ''),\n",
+      "                   ('interconnect', ''),\n",
+      "                   ('base_demand', ''),\n",
+      "                   ('base_hydro', ''),\n",
+      "                   ('base_solar', ''),\n",
+      "                   ('base_wind', ''),\n",
+      "                   ('change_table', ''),\n",
+      "                   ('start_date', ''),\n",
+      "                   ('end_date', ''),\n",
+      "                   ('interval', ''),\n",
+      "                   ('engine', '')],\n",
+      " '_execute_list_manager': <powersimdata.data_access.execute_list.ExecuteListManager object at 0x11ff90640>,\n",
+      " '_scenario_list_manager': <powersimdata.data_access.scenario_list.ScenarioListManager object at 0x11ff905e0>,\n",
       " '_set_info': 'function',\n",
       " '_set_status': 'function',\n",
+      " '_setattr_allowlist': {'_execute_list_manager',\n",
+      "                        '_scenario_list_manager',\n",
+      "                        'data_access',\n",
+      "                        'info',\n",
+      "                        'state',\n",
+      "                        'status'},\n",
       " 'change': 'function',\n",
+      " 'data_access': <powersimdata.data_access.data_access.SSHDataAccess object at 0x10a61ddc0>,\n",
+      " 'get_averaged_cong': 'function',\n",
+      " 'get_base_grid': 'function',\n",
+      " 'get_bus_demand': 'function',\n",
+      " 'get_congl': 'function',\n",
+      " 'get_congu': 'function',\n",
+      " 'get_ct': 'function',\n",
+      " 'get_dcline_pf': 'function',\n",
+      " 'get_demand': 'function',\n",
+      " 'get_grid': 'function',\n",
+      " 'get_hydro': 'function',\n",
+      " 'get_lmp': 'function',\n",
+      " 'get_load_shed': 'function',\n",
+      " 'get_load_shift_dn': 'function',\n",
+      " 'get_load_shift_up': 'function',\n",
+      " 'get_pf': 'function',\n",
+      " 'get_pg': 'function',\n",
+      " 'get_scenario_table': 'function',\n",
+      " 'get_solar': 'function',\n",
+      " 'get_storage_e': 'function',\n",
+      " 'get_storage_pg': 'function',\n",
+      " 'get_wind': 'function',\n",
+      " 'get_wind_offshore': 'function',\n",
       " 'info': OrderedDict([('id', '824'),\n",
       "                      ('plan', 'Julia'),\n",
       "                      ('name', 'USABase_2020_Anchor_profile_fix_1'),\n",
       "                      ('state', 'analyze'),\n",
+      "                      ('grid_model', 'usa_tamu'),\n",
       "                      ('interconnect', 'USA'),\n",
-      "                      ('base_demand', 'v6'),\n",
-      "                      ('base_hydro', 'v4'),\n",
-      "                      ('base_solar', 'v4.3.1'),\n",
-      "                      ('base_wind', 'v5.4'),\n",
+      "                      ('base_demand', 'vJan2021'),\n",
+      "                      ('base_hydro', 'vJan2021'),\n",
+      "                      ('base_solar', 'vJan2021'),\n",
+      "                      ('base_wind', 'vJan2021'),\n",
       "                      ('change_table', 'Yes'),\n",
       "                      ('start_date', '2016-01-01 00:00:00'),\n",
       "                      ('end_date', '2016-12-31 23:00:00'),\n",
@@ -104,9 +209,9 @@
       "                      ('engine', 'REISE.jl'),\n",
       "                      ('runtime', '22:10'),\n",
       "                      ('infeasibilities', '')]),\n",
+      " 'print_infeasibilities': 'function',\n",
       " 'print_scenario_info': 'function',\n",
-      " 'ssh': <paramiko.client.SSHClient object at 0x124fdd760>,\n",
-      " 'state': <powersimdata.scenario.analyze.Analyze object at 0x124ff5040>,\n",
+      " 'state': <powersimdata.scenario.analyze.Analyze object at 0x11fffd1f0>,\n",
       " 'status': 'extracted'}\n"
      ]
     }
@@ -132,7 +237,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "grid = s.state.get_grid()"
+    "grid = s.get_grid()"
    ]
   },
   {
@@ -144,14 +249,18 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "['branch',\n",
+      "['SUPPORTED_ENGINES',\n",
+      " 'SUPPORTED_MODELS',\n",
+      " 'branch',\n",
       " 'bus',\n",
       " 'bus2sub',\n",
       " 'data_loc',\n",
       " 'dcline',\n",
       " 'gencost',\n",
+      " 'grid_model',\n",
       " 'id2zone',\n",
       " 'interconnect',\n",
+      " 'model_immutables',\n",
       " 'plant',\n",
       " 'storage',\n",
       " 'sub',\n",
@@ -445,23 +554,26 @@
      "output_type": "stream",
      "text": [
       "{'InEff': None,\n",
+      " 'LossFactor': None,\n",
       " 'OutEff': None,\n",
       " 'StorageData': Empty DataFrame\n",
-      "Columns: [UnitIdx, InitialStorage, InitialStorageLowerBound, InitialStorageUpperBound, InitialStorageCost, TerminalStoragePrice, MinStorageLevel, MaxStorageLevel, OutEff, InEff, LossFactor, rho]\n",
+      "Columns: [UnitIdx, InitialStorage, InitialStorageLowerBound, InitialStorageUpperBound, InitialStorageCost, TerminalStoragePrice, MinStorageLevel, MaxStorageLevel, OutEff, InEff, LossFactor, rho, ExpectedTerminalStorageMax, ExpectedTerminalStorageMin]\n",
       "Index: [],\n",
       " 'duration': None,\n",
-      " 'energy_price': None,\n",
+      " 'energy_value': None,\n",
       " 'gen': Empty DataFrame\n",
-      "Columns: [bus_id, Pg, Qg, Qmax, Qmin, Vg, mBase, status, Pmax, Pmin, Pc1, Pc2, Qc1min, Qc1max, Qc2min, Qc2max, ramp_agc, ramp_10, ramp_30, ramp_q, apf]\n",
+      "Columns: [bus_id, Pg, Qg, Qmax, Qmin, Vg, mBase, status, Pmax, Pmin, Pc1, Pc2, Qc1min, Qc1max, Qc2min, Qc2max, ramp_agc, ramp_10, ramp_30, ramp_q, apf, mu_Pmax, mu_Pmin, mu_Qmax, mu_Qmin]\n",
       "Index: []\n",
       "\n",
-      "[0 rows x 21 columns],\n",
+      "[0 rows x 25 columns],\n",
       " 'gencost': Empty DataFrame\n",
       "Columns: [type, startup, shutdown, n, c2, c1, c0]\n",
       "Index: [],\n",
       " 'genfuel': [],\n",
       " 'max_stor': None,\n",
-      " 'min_stor': None}\n"
+      " 'min_stor': None,\n",
+      " 'terminal_max': None,\n",
+      " 'terminal_min': None}\n"
      ]
     }
    ],
@@ -539,19 +651,23 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'_enter': 'function',\n",
-      " '_execute_list_manager': <powersimdata.data_access.execute_list.ExecuteListManager object at 0x125008df0>,\n",
+      "{'_data_access': <powersimdata.data_access.data_access.SSHDataAccess object at 0x10a61ddc0>,\n",
+      " '_enter': 'function',\n",
+      " '_execute_list_manager': <powersimdata.data_access.execute_list.ExecuteListManager object at 0x11ff90640>,\n",
+      " '_get_data': 'function',\n",
       " '_leave': 'function',\n",
       " '_parse_infeasibilities': 'function',\n",
+      " '_scenario': <powersimdata.scenario.scenario.Scenario object at 0x10a61dd60>,\n",
       " '_scenario_info': OrderedDict([('id', '824'),\n",
       "                                ('plan', 'Julia'),\n",
       "                                ('name', 'USABase_2020_Anchor_profile_fix_1'),\n",
       "                                ('state', 'analyze'),\n",
+      "                                ('grid_model', 'usa_tamu'),\n",
       "                                ('interconnect', 'USA'),\n",
-      "                                ('base_demand', 'v6'),\n",
-      "                                ('base_hydro', 'v4'),\n",
-      "                                ('base_solar', 'v4.3.1'),\n",
-      "                                ('base_wind', 'v5.4'),\n",
+      "                                ('base_demand', 'vJan2021'),\n",
+      "                                ('base_hydro', 'vJan2021'),\n",
+      "                                ('base_solar', 'vJan2021'),\n",
+      "                                ('base_wind', 'vJan2021'),\n",
       "                                ('change_table', 'Yes'),\n",
       "                                ('start_date', '2016-01-01 00:00:00'),\n",
       "                                ('end_date', '2016-12-31 23:00:00'),\n",
@@ -559,11 +675,11 @@
       "                                ('engine', 'REISE.jl'),\n",
       "                                ('runtime', '22:10'),\n",
       "                                ('infeasibilities', '')]),\n",
-      " '_scenario_list_manager': <powersimdata.data_access.scenario_list.ScenarioListManager object at 0x124fdda00>,\n",
+      " '_scenario_list_manager': <powersimdata.data_access.scenario_list.ScenarioListManager object at 0x11ff905e0>,\n",
       " '_scenario_status': 'extracted',\n",
       " '_set_allowed_state': 'function',\n",
       " '_set_ct_and_grid': 'function',\n",
-      " '_ssh': <paramiko.client.SSHClient object at 0x124fdd760>,\n",
+      " '_update_scenario_info': 'function',\n",
       " 'allowed': ['delete', 'move'],\n",
       " 'ct': {'branch': {'branch_id': {6648: 1.1977118341079729,\n",
       "                                 16204: 2.0797364138406134,\n",
@@ -1116,7 +1232,13 @@
       "                            11705: 0,\n",
       "                            11764: 0,\n",
       "                            11780: 0,\n",
-      "                            11781: 0,\n",
+      "                            11781: 0,\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "                            11782: 0,\n",
       "                            11783: 0,\n",
       "                            11801: 0,\n",
@@ -1358,7 +1480,13 @@
       "                              48: 10.0,\n",
       "                              49: 3.079365079365079,\n",
       "                              50: 1.0,\n",
-      "                              51: 1.0,\n",
+      "                              51: 1.0,\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "                              52: 1.0,\n",
       "                              201: 0.04051051349101375,\n",
       "                              202: 0.8319519856828816,\n",
@@ -1421,13 +1549,7 @@
       "                             39: 1.0580403343030635,\n",
       "                             40: 1.0,\n",
       "                             41: 1.0,\n",
-      "                             42: 1.0,\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "                             42: 1.0,\n",
       "                             43: 1.0,\n",
       "                             44: 1.0248192158483063,\n",
       "                             45: 1.0248192158483063,\n",
@@ -1528,8 +1650,31 @@
       "                                       13932: 0,\n",
       "                                       13933: 0,\n",
       "                                       13934: 0}}},\n",
-      " 'data_loc': None,\n",
+      " 'exported_methods': {'get_averaged_cong',\n",
+      "                      'get_base_grid',\n",
+      "                      'get_bus_demand',\n",
+      "                      'get_congl',\n",
+      "                      'get_congu',\n",
+      "                      'get_ct',\n",
+      "                      'get_dcline_pf',\n",
+      "                      'get_demand',\n",
+      "                      'get_grid',\n",
+      "                      'get_hydro',\n",
+      "                      'get_lmp',\n",
+      "                      'get_load_shed',\n",
+      "                      'get_load_shift_dn',\n",
+      "                      'get_load_shift_up',\n",
+      "                      'get_pf',\n",
+      "                      'get_pg',\n",
+      "                      'get_solar',\n",
+      "                      'get_storage_e',\n",
+      "                      'get_storage_pg',\n",
+      "                      'get_wind',\n",
+      "                      'get_wind_offshore',\n",
+      "                      'print_infeasibilities',\n",
+      "                      'print_scenario_info'},\n",
       " 'get_averaged_cong': 'function',\n",
+      " 'get_base_grid': 'function',\n",
       " 'get_bus_demand': 'function',\n",
       " 'get_congl': 'function',\n",
       " 'get_congu': 'function',\n",
@@ -1540,16 +1685,22 @@
       " 'get_hydro': 'function',\n",
       " 'get_lmp': 'function',\n",
       " 'get_load_shed': 'function',\n",
+      " 'get_load_shift_dn': 'function',\n",
+      " 'get_load_shift_up': 'function',\n",
       " 'get_pf': 'function',\n",
       " 'get_pg': 'function',\n",
+      " 'get_profile': 'function',\n",
       " 'get_solar': 'function',\n",
       " 'get_storage_e': 'function',\n",
       " 'get_storage_pg': 'function',\n",
       " 'get_wind': 'function',\n",
-      " 'grid': <powersimdata.input.grid.Grid object at 0x124ff5ca0>,\n",
+      " 'get_wind_offshore': 'function',\n",
+      " 'get_wind_onshore': 'function',\n",
+      " 'grid': <powersimdata.input.grid.Grid object at 0x120be8c70>,\n",
       " 'name': 'analyze',\n",
       " 'print_infeasibilities': 'function',\n",
       " 'print_scenario_info': 'function',\n",
+      " 'refresh': 'function',\n",
       " 'switch': 'function'}\n"
      ]
     }
@@ -1581,14 +1732,6 @@
      "text": [
       "--> Loading CONGL\n",
       "--> Loading CONGU\n",
-      "Reading bus.csv\n",
-      "Reading plant.csv\n",
-      "Reading gencost.csv\n",
-      "Reading branch.csv\n",
-      "Reading dcline.csv\n",
-      "Reading sub.csv\n",
-      "Reading bus2sub.csv\n",
-      "Reading zone.csv\n",
       "--> Loading demand\n",
       "Multiply demand in Maine (#1) by 0.98\n",
       "Multiply demand in New Hampshire (#2) by 0.98\n",
@@ -1673,13 +1816,13 @@
     }
    ],
    "source": [
-    "congl = s.state.get_congl()   # congestion lower limit, time x branch in $/MWh\n",
-    "congu = s.state.get_congu()   # congestion upper limit, time x branch in $/MWh\n",
+    "congl = s.get_congl()   # congestion lower limit, time x branch in $/MWh\n",
+    "congu = s.get_congu()   # congestion upper limit, time x branch in $/MWh\n",
     "\n",
-    "demand = s.state.get_demand() # demand, time x loadzone in MWh\n",
-    "lmp = s.state.get_lmp()       # locational marginal price, time x busId in $/MWh\n",
-    "pf = s.state.get_pf()         # power flow, time x branch in MWh\n",
-    "pg = s.state.get_pg()         # power generated, time x plant in MWh"
+    "demand = s.get_demand() # demand, time x loadzone in MWh\n",
+    "lmp = s.get_lmp()       # locational marginal price, time x busId in $/MWh\n",
+    "pf = s.get_pf()         # power flow, time x branch in MWh\n",
+    "pg = s.get_pg()         # power generated, time x plant in MWh"
    ]
   },
   {
@@ -1710,9 +1853,9 @@
     }
    ],
    "source": [
-    "hydro = s.state.get_hydro() # hydro profile, time x plant in MWh\n",
-    "solar = s.state.get_solar() # solar profile, time x plant in MWh\n",
-    "wind = s.state.get_wind()   # wind profile, time x plant in MWh"
+    "hydro = s.get_hydro() # hydro profile, time x plant in MWh\n",
+    "solar = s.get_solar() # solar profile, time x plant in MWh\n",
+    "wind = s.get_wind()   # wind profile, time x plant in MWh"
    ]
   },
   {
@@ -1728,59 +1871,59 @@
      "text": [
       "                        5         6         7         8         9      \\\n",
       "UTC                                                                     \n",
-      "2016-01-01 00:00:00  0.478793  0.478793  0.478793  0.478793  0.478793   \n",
-      "2016-01-01 01:00:00  0.476795  0.476795  0.476795  0.476795  0.476795   \n",
+      "2016-01-01 00:00:00  0.478794  0.478794  0.478794  0.478794  0.478794   \n",
+      "2016-01-01 01:00:00  0.476794  0.476794  0.476794  0.476794  0.476794   \n",
       "2016-01-01 02:00:00  0.500844  0.500844  0.500844  0.500844  0.500844   \n",
-      "2016-01-01 03:00:00  0.513546  0.513546  0.513546  0.513546  0.513546   \n",
-      "2016-01-01 04:00:00  0.535974  0.535974  0.535974  0.535974  0.535974   \n",
+      "2016-01-01 03:00:00  0.513545  0.513545  0.513545  0.513545  0.513545   \n",
+      "2016-01-01 04:00:00  0.535973  0.535973  0.535973  0.535973  0.535973   \n",
       "...                       ...       ...       ...       ...       ...   \n",
       "2016-12-31 19:00:00  0.398887  0.398887  0.398887  0.398887  0.398887   \n",
-      "2016-12-31 20:00:00  0.371861  0.371861  0.371861  0.371861  0.371861   \n",
-      "2016-12-31 21:00:00  0.340429  0.340429  0.340429  0.340429  0.340429   \n",
+      "2016-12-31 20:00:00  0.371862  0.371862  0.371862  0.371862  0.371862   \n",
+      "2016-12-31 21:00:00  0.340430  0.340430  0.340430  0.340430  0.340430   \n",
       "2016-12-31 22:00:00  0.340107  0.340107  0.340107  0.340107  0.340107   \n",
       "2016-12-31 23:00:00  0.338237  0.338237  0.338237  0.338237  0.338237   \n",
       "\n",
       "                        10        12        13        14        15     ...  \\\n",
       "UTC                                                                    ...   \n",
-      "2016-01-01 00:00:00  0.478793  2.593464  2.593464  2.553565  2.553565  ...   \n",
-      "2016-01-01 01:00:00  0.476795  2.582638  2.582638  2.542905  2.542905  ...   \n",
+      "2016-01-01 00:00:00  0.478794  2.593461  2.593461  2.553565  2.553565  ...   \n",
+      "2016-01-01 01:00:00  0.476794  2.582639  2.582639  2.542903  2.542903  ...   \n",
       "2016-01-01 02:00:00  0.500844  2.712905  2.712905  2.671168  2.671168  ...   \n",
-      "2016-01-01 03:00:00  0.513546  2.781705  2.781705  2.738910  2.738910  ...   \n",
-      "2016-01-01 04:00:00  0.535974  2.903191  2.903191  2.858527  2.858527  ...   \n",
+      "2016-01-01 03:00:00  0.513545  2.781704  2.781704  2.738912  2.738912  ...   \n",
+      "2016-01-01 04:00:00  0.535973  2.903192  2.903192  2.858528  2.858528  ...   \n",
       "...                       ...       ...       ...       ...       ...  ...   \n",
-      "2016-12-31 19:00:00  0.398887  2.160638  2.160638  2.127398  2.127398  ...   \n",
-      "2016-12-31 20:00:00  0.371861  2.014248  2.014248  1.983260  1.983260  ...   \n",
-      "2016-12-31 21:00:00  0.340429  1.843993  1.843993  1.815624  1.815624  ...   \n",
-      "2016-12-31 22:00:00  0.340107  1.842247  1.842247  1.813904  1.813904  ...   \n",
-      "2016-12-31 23:00:00  0.338237  1.832119  1.832119  1.803932  1.803932  ...   \n",
+      "2016-12-31 19:00:00  0.398887  2.160640  2.160640  2.127396  2.127396  ...   \n",
+      "2016-12-31 20:00:00  0.371862  2.014245  2.014245  1.983257  1.983257  ...   \n",
+      "2016-12-31 21:00:00  0.340430  1.843993  1.843993  1.815623  1.815623  ...   \n",
+      "2016-12-31 22:00:00  0.340107  1.842248  1.842248  1.813905  1.813905  ...   \n",
+      "2016-12-31 23:00:00  0.338237  1.832120  1.832120  1.803933  1.803933  ...   \n",
       "\n",
       "                     13201  13202  13203  13204  13205  13206      13461  \\\n",
       "UTC                                                                        \n",
-      "2016-01-01 00:00:00    0.0    0.0    0.0    0.0    0.0    0.0  16.647811   \n",
-      "2016-01-01 01:00:00    0.0    0.0    0.0    0.0    0.0    0.0  14.497928   \n",
-      "2016-01-01 02:00:00    0.0    0.0    0.0    0.0    0.0    0.0   7.221402   \n",
+      "2016-01-01 00:00:00    0.0    0.0    0.0    0.0    0.0    0.0  16.647828   \n",
+      "2016-01-01 01:00:00    0.0    0.0    0.0    0.0    0.0    0.0  14.497974   \n",
+      "2016-01-01 02:00:00    0.0    0.0    0.0    0.0    0.0    0.0   7.221406   \n",
       "2016-01-01 03:00:00    0.0    0.0    0.0    0.0    0.0    0.0   3.234012   \n",
-      "2016-01-01 04:00:00    0.0    0.0    0.0    0.0    0.0    0.0   2.627635   \n",
+      "2016-01-01 04:00:00    0.0    0.0    0.0    0.0    0.0    0.0   2.627632   \n",
       "...                    ...    ...    ...    ...    ...    ...        ...   \n",
-      "2016-12-31 19:00:00    0.0    0.0    0.0    0.0    0.0    0.0  11.602635   \n",
-      "2016-12-31 20:00:00    0.0    0.0    0.0    0.0    0.0    0.0  11.643360   \n",
-      "2016-12-31 21:00:00    0.0    0.0    0.0    0.0    0.0    0.0  11.793778   \n",
-      "2016-12-31 22:00:00    0.0    0.0    0.0    0.0    0.0    0.0  17.905988   \n",
-      "2016-12-31 23:00:00    0.0    0.0    0.0    0.0    0.0    0.0  28.408159   \n",
+      "2016-12-31 19:00:00    0.0    0.0    0.0    0.0    0.0    0.0  11.602602   \n",
+      "2016-12-31 20:00:00    0.0    0.0    0.0    0.0    0.0    0.0  11.643402   \n",
+      "2016-12-31 21:00:00    0.0    0.0    0.0    0.0    0.0    0.0  11.793750   \n",
+      "2016-12-31 22:00:00    0.0    0.0    0.0    0.0    0.0    0.0  17.905998   \n",
+      "2016-12-31 23:00:00    0.0    0.0    0.0    0.0    0.0    0.0  28.408122   \n",
       "\n",
       "                         13462     13463      13464  \n",
       "UTC                                                  \n",
-      "2016-01-01 00:00:00  10.785048  3.892148   6.984034  \n",
-      "2016-01-01 01:00:00   9.392277  3.389520   6.082122  \n",
-      "2016-01-01 02:00:00   4.678282  1.688316   3.029498  \n",
+      "2016-01-01 00:00:00  10.785059  3.892152   6.984041  \n",
+      "2016-01-01 01:00:00   9.392306  3.389531   6.082141  \n",
+      "2016-01-01 02:00:00   4.678285  1.688317   3.029500  \n",
       "2016-01-01 03:00:00   2.095109  0.756091   1.356722  \n",
-      "2016-01-01 04:00:00   1.702276  0.614324   1.102336  \n",
+      "2016-01-01 04:00:00   1.702274  0.614323   1.102335  \n",
       "...                        ...       ...        ...  \n",
-      "2016-12-31 19:00:00   7.516602  2.712619   4.867499  \n",
-      "2016-12-31 20:00:00   7.542986  2.722141   4.884583  \n",
-      "2016-12-31 21:00:00   7.640431  2.757307   4.947686  \n",
-      "2016-12-31 22:00:00  11.600140  4.186302   7.511860  \n",
-      "2016-12-31 23:00:00  18.403822  6.641640  11.917695  \n",
+      "2016-12-31 19:00:00   7.516581  2.712612   4.867485  \n",
+      "2016-12-31 20:00:00   7.543013  2.722150   4.884601  \n",
+      "2016-12-31 21:00:00   7.640413  2.757301   4.947674  \n",
+      "2016-12-31 22:00:00  11.600146  4.186304   7.511864  \n",
+      "2016-12-31 23:00:00  18.403798  6.641631  11.917680  \n",
       "\n",
       "[8784 rows x 3043 columns]\n"
      ]
@@ -1789,6 +1932,13 @@
    "source": [
     "print(hydro)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
Change a key word in storage template to make it consistent with elsewhere, replace "energy_price" by "energy_value". 

Close #662 

### What the code is doing
Replace "energy_price" by "energy_value" in `storage_template` and rerun `scenario_and_grid_cheatsheet.ipynb` to reflect the change with the latest UI.

### Testing
The demo notebook prints the updated key word.

### Where to look
`powersimdata/input/abstract_grid.py`
`powersimdata/scenario/demo/scenario_and_grid_cheatsheet.ipynb`

### Usage Example/Visuals
See `scenario_and_grid_cheatsheet.ipynb`

### Time estimate
5 min