### PR TITLE
Enable loading any scenario from blob storage

### DIFF
--- a/powersimdata/data_access/context.py
+++ b/powersimdata/data_access/context.py
@@ -8,18 +8,20 @@ class Context:
     """Factory for data access instances"""
 
     @staticmethod
-    def get_data_access(_fs=None):
+    def get_data_access(make_fs=None):
         """Return a data access instance appropriate for the current
         environment.
 
-        :param fs.base.FS _fs: a filesystem instance, or None to use a class specific
-            default
+        :param callable make_fs: a function that returns a filesystem instance, or
+            None to use a default
         :return: (:class:`powersimdata.data_access.data_access.DataAccess`) -- a data access
             instance
         """
         if server_setup.DEPLOYMENT_MODE == DeploymentMode.Server:
-            return SSHDataAccess(_fs)
-        return LocalDataAccess(_fs)
+            if make_fs is None:
+                make_fs = lambda: None  # noqa: E731
+            return SSHDataAccess(make_fs())
+        return LocalDataAccess()
 
     @staticmethod
     def get_launcher(scenario):

--- a/powersimdata/data_access/context.py
+++ b/powersimdata/data_access/context.py
@@ -8,18 +8,18 @@ class Context:
     """Factory for data access instances"""
 
     @staticmethod
-    def get_data_access():
+    def get_data_access(_fs=None):
         """Return a data access instance appropriate for the current
         environment.
 
+        :param fs.base.FS _fs: a filesystem instance, or None to use a class specific
+            default
         :return: (:class:`powersimdata.data_access.data_access.DataAccess`) -- a data access
             instance
         """
-        root = server_setup.DATA_ROOT_DIR
-
         if server_setup.DEPLOYMENT_MODE == DeploymentMode.Server:
-            return SSHDataAccess(root)
-        return LocalDataAccess(root)
+            return SSHDataAccess(_fs)
+        return LocalDataAccess(_fs)
 
     @staticmethod
     def get_launcher(scenario):

--- a/powersimdata/data_access/data_access.py
+++ b/powersimdata/data_access/data_access.py
@@ -16,9 +16,8 @@ from powersimdata.utility import server_setup
 class DataAccess:
     """Interface to a local or remote data store."""
 
-    def __init__(self, root):
+    def __init__(self):
         """Constructor"""
-        self.root = root
         self.join = fs.path.join
         self.local_fs = None
 
@@ -163,10 +162,10 @@ class DataAccess:
 class LocalDataAccess(DataAccess):
     """Interface to shared data volume"""
 
-    def __init__(self, root=server_setup.LOCAL_DIR):
-        super().__init__(root)
-        self.local_fs = fs.open_fs(root)
-        self.fs = self._get_fs()
+    def __init__(self, _fs=None):
+        super().__init__()
+        self.local_fs = fs.open_fs(server_setup.LOCAL_DIR)
+        self.fs = _fs if _fs is not None else self._get_fs()
 
     def _get_fs(self):
         mfs = MultiFS()
@@ -193,22 +192,12 @@ class LocalDataAccess(DataAccess):
 class SSHDataAccess(DataAccess):
     """Interface to a remote data store, accessed via SSH."""
 
-    def __init__(self, root=server_setup.DATA_ROOT_DIR):
+    def __init__(self, _fs=None):
         """Constructor"""
-        super().__init__(root)
-        self._fs = None
+        super().__init__()
+        self.root = server_setup.DATA_ROOT_DIR
+        self.fs = _fs if _fs is not None else get_multi_fs(self.root)
         self.local_fs = fs.open_fs(server_setup.LOCAL_DIR)
-
-    @property
-    def fs(self):
-        """Get or create the filesystem object
-
-        :raises IOError: if connection failed or still within retry window
-        :return: (*fs.multifs.MultiFS*) -- filesystem instance
-        """
-        if self._fs is None:
-            self._fs = get_multi_fs(self.root)
-        return self._fs
 
     def exec_command(self, command):
         ssh_fs = self.fs.get_fs("ssh_fs")
@@ -285,7 +274,7 @@ class _DataAccessTemplate(SSHDataAccess):
 
     def __init__(self, fs_url):
         self.local_fs = fs.open_fs(fs_url)
-        self._fs = self._get_fs(fs_url)
+        self.fs = self._get_fs(fs_url)
         self.root = "foo"
         self.join = fs.path.join
 

--- a/powersimdata/data_access/data_access.py
+++ b/powersimdata/data_access/data_access.py
@@ -196,8 +196,14 @@ class SSHDataAccess(DataAccess):
         """Constructor"""
         super().__init__()
         self.root = server_setup.DATA_ROOT_DIR
-        self.fs = _fs if _fs is not None else get_multi_fs(self.root)
+        self._fs = _fs
         self.local_fs = fs.open_fs(server_setup.LOCAL_DIR)
+
+    @property
+    def fs(self):
+        if self._fs is None:
+            self._fs = get_multi_fs(self.root)
+        return self._fs
 
     def exec_command(self, command):
         ssh_fs = self.fs.get_fs("ssh_fs")
@@ -274,7 +280,7 @@ class _DataAccessTemplate(SSHDataAccess):
 
     def __init__(self, fs_url):
         self.local_fs = fs.open_fs(fs_url)
-        self.fs = self._get_fs(fs_url)
+        self._fs = self._get_fs(fs_url)
         self.root = "foo"
         self.join = fs.path.join
 

--- a/powersimdata/data_access/fs_helper.py
+++ b/powersimdata/data_access/fs_helper.py
@@ -49,3 +49,22 @@ def get_multi_fs(root):
     remotes = ",".join([f[0] for f in mfs.iterate_fs()])
     print(f"Initialized remote filesystem with {remotes}")
     return mfs
+
+
+def get_scenario_fs():
+    """Create filesystem combining the server (if connected) with blob storage,
+        prioritizing the server if connected.
+
+    :return: (*fs.base.FS*) -- filesystem instance
+    """
+    scenario_data = get_blob_fs("scenariodata")
+    mfs = MultiFS()
+    try:
+        ssh_fs = get_ssh_fs(server_setup.DATA_ROOT_DIR)
+        mfs.add_fs("ssh_fs", ssh_fs, write=True, priority=2)
+    except:  # noqa
+        print("Could not connect to ssh server")
+    mfs.add_fs("scenario_fs", scenario_data, priority=1)
+    remotes = ",".join([f[0] for f in mfs.iterate_fs()])
+    print(f"Initialized remote filesystem with {remotes}")
+    return mfs

--- a/powersimdata/data_access/fs_helper.py
+++ b/powersimdata/data_access/fs_helper.py
@@ -11,8 +11,9 @@ def get_blob_fs(container):
     :param str container: the container name
     :return: (*fs.base.FS*) -- filesystem instance
     """
-    account = "besciences"
-    return fs.open_fs(f"azblob://{account}@{container}")
+    account = "esmi"
+    sas_token = server_setup.BLOB_TOKEN_RO
+    return fs.open_fs(f"azblobv2://{account}:{sas_token}@{container}")
 
 
 def get_ssh_fs(root=""):

--- a/powersimdata/input/input_base.py
+++ b/powersimdata/input/input_base.py
@@ -1,4 +1,3 @@
-from powersimdata.data_access.context import Context
 from powersimdata.utility.helpers import MemoryCache, cache_key
 
 _cache = MemoryCache()
@@ -11,7 +10,7 @@ class InputBase:
 
     def __init__(self):
         """Constructor."""
-        self.data_access = Context.get_data_access()
+        self.data_access = None
         self._file_extension = {}
 
     def _check_field(self, field_name):

--- a/powersimdata/input/input_data.py
+++ b/powersimdata/input/input_data.py
@@ -3,6 +3,8 @@ import pickle
 
 import pandas as pd
 
+from powersimdata.data_access.context import Context
+from powersimdata.data_access.fs_helper import get_scenario_fs
 from powersimdata.input.input_base import InputBase
 from powersimdata.utility import server_setup
 
@@ -13,6 +15,7 @@ class InputData(InputBase):
     def __init__(self):
         super().__init__()
         self._file_extension = {"ct": "pkl", "grid": "mat"}
+        self.data_access = Context.get_data_access(get_scenario_fs)
 
     def _get_file_path(self, scenario_info, field_name):
         """Get the path to either grid or ct for the scenario

--- a/powersimdata/input/profile_input.py
+++ b/powersimdata/input/profile_input.py
@@ -1,5 +1,7 @@
 import pandas as pd
 
+from powersimdata.data_access.context import Context
+from powersimdata.data_access.fs_helper import get_blob_fs
 from powersimdata.input.input_base import InputBase
 
 profile_kind = {
@@ -39,6 +41,7 @@ class ProfileInput(InputBase):
     def __init__(self):
         super().__init__()
         self._file_extension = {k: "csv" for k in profile_kind}
+        self.data_access = Context.get_data_access(lambda: get_blob_fs("profiles"))
 
     def _get_file_path(self, scenario_info, field_name):
         """Get the path to the specified profile

--- a/powersimdata/output/output_data.py
+++ b/powersimdata/output/output_data.py
@@ -14,7 +14,7 @@ class OutputData:
 
     def __init__(self):
         """Constructor"""
-        self.data_access = Context.get_data_access(get_scenario_fs)
+        self._data_access = Context.get_data_access(get_scenario_fs)
 
     def get_data(self, scenario_id, field_name):
         """Returns data either from server or from local directory.

--- a/powersimdata/output/output_data.py
+++ b/powersimdata/output/output_data.py
@@ -3,6 +3,7 @@ import pandas as pd
 from scipy.sparse import coo_matrix
 
 from powersimdata.data_access.context import Context
+from powersimdata.data_access.fs_helper import get_scenario_fs
 from powersimdata.input.input_data import distribute_demand_from_zones_to_buses
 from powersimdata.input.transform_profile import TransformProfile
 from powersimdata.utility import server_setup
@@ -13,7 +14,7 @@ class OutputData:
 
     def __init__(self):
         """Constructor"""
-        self._data_access = Context.get_data_access()
+        self.data_access = Context.get_data_access(get_scenario_fs)
 
     def get_data(self, scenario_id, field_name):
         """Returns data either from server or from local directory.

--- a/powersimdata/scenario/scenario.py
+++ b/powersimdata/scenario/scenario.py
@@ -4,6 +4,7 @@ import pandas as pd
 
 from powersimdata.data_access.context import Context
 from powersimdata.data_access.execute_list import ExecuteListManager
+from powersimdata.data_access.fs_helper import get_scenario_fs
 from powersimdata.data_access.scenario_list import ScenarioListManager
 from powersimdata.scenario.analyze import Analyze
 from powersimdata.scenario.create import Create, _Builder
@@ -52,7 +53,7 @@ class Scenario:
         if descriptor is not None and not isinstance(descriptor, str):
             raise TypeError("Descriptor must be a string or int (for a Scenario ID)")
 
-        self.data_access = Context.get_data_access()
+        self.data_access = Context.get_data_access(get_scenario_fs)
         self._scenario_list_manager = ScenarioListManager(self.data_access)
         self._execute_list_manager = ExecuteListManager(self.data_access)
 

--- a/powersimdata/utility/server_setup.py
+++ b/powersimdata/utility/server_setup.py
@@ -14,6 +14,7 @@ LOCAL_DIR = config.LOCAL_DIR
 MODEL_DIR = config.MODEL_DIR
 ENGINE_DIR = config.ENGINE_DIR
 DEPLOYMENT_MODE = get_deployment_mode()
+BLOB_TOKEN_RO = "?sv=2021-06-08&ss=b&srt=co&sp=rl&se=2050-08-06T01:31:08Z&st=2022-08-05T17:31:08Z&spr=https&sig=ORHiRQQCocyaHXV2phhSN92GFhRnaHuGOecskxsmG3U%3D"
 
 os.makedirs(LOCAL_DIR, exist_ok=True)
 


### PR DESCRIPTION
### Purpose
Switch to the new esmi blob storage account which is populated with existing scenario data. This is represented as one of a few filesystems which are combined into a single `MultiFS` which acts as a "remote" data store. 

### What the code is doing
* Point to the new storage account, keeping priority the same. We still use the server as the source of truth, but if a user isn't connected to the vpn when the multi filesystem is instantiated, we do not repeatedly attempt to connect (no different than before, just adding context)
* Create smaller multi-filesystems depending on context. E.g. when we are using `InputData`, there is no need to get profiles, so there is no need to add the profiles container as a possible location to check. This is done by passing the `make_fs` parameter in `context.py.`
* Add a read only [shared access signature](https://docs.microsoft.com/en-us/azure/storage/common/storage-sas-overview) to `server_setup.py`. This is defined (as you can kind of tell by the query params) to allow read and list access on blobs and containers only (not queues, tables, etc). The reason for this is that it turns out anonymous directory listing is not supported for gen2 HNS accounts (as opposed to the original blob storage accounts). See the [issue](https://github.com/Azure/azure-sdk-for-python/issues/25476) I submitted with azure for more context. The workaround suggested there does work, but it's just as safe to use a SAS instead and is more likely to be stable over time, as it's an officially supported use case.

### Testing
Ran a scenario in docker container, after deleting existing volumes and containers. Also loaded a scenario that did not exist locally yet and checked that the files are cached locally.


### Usage Example/Visuals
Loading a scenario from blob storage.
```
In [1]: from powersimdata import Scenario

In [2]: scl = Scenario().get_scenario_table()
/Users/jenhagg/.local/share/virtualenvs/PowerSimData-9jRUr7-X/lib/python3.9/site-packages/paramiko/transport.py:236: CryptographyDeprecationWarning: Blowfish has been deprecated
  "class": algorithms.Blowfish,
Could not connect to ssh server
Initialized remote filesystem with scenario_fs
Transferring ScenarioList.csv.2 from scenario_fs

In [3]: scl.head().index
Out[3]: Int64Index([398, 400, 403, 404, 405], dtype='int64', name='id')

In [4]: s404 = Scenario(404)
Could not connect to ssh server
Initialized remote filesystem with scenario_fs
Transferring ScenarioList.csv.2 from scenario_fs
Transferring ExecuteList.csv.2 from scenario_fs
SCENARIO: test | EasternBase_2020_two_day_test

--> State
analyze
Could not connect to ssh server
Initialized remote filesystem with scenario_fs
--> Loading grid
Could not connect to ssh server
Initialized remote filesystem with profile_fs,scenario_fs
Transferring ScenarioList.csv.2 from scenario_fs
Loading bus
Loading plant
Loading heat_rate_curve
Loading gencost_before
Loading gencost_after
Loading branch
Loading dcline
Loading sub
Loading bus2sub
--> Loading ct
```
At this point, if I `cd ScenarioData` and `ls -la data/output | grep 404` there are no results.

So we can load some outputs

```
In [5]: avg_cong = s404.get_averaged_cong()
Could not connect to ssh server
Initialized remote filesystem with scenario_fs
--> Loading AVERAGED_CONG
data/output/404_AVERAGED_CONG.pkl not found on local machine
Transferring 404_AVERAGED_CONG.pkl from scenario_fs

In [6]: dcline_pf = s404.get_dcline_pf()
Could not connect to ssh server
Initialized remote filesystem with scenario_fs
--> Loading PF_DCLINE
data/output/404_PF_DCLINE.pkl not found on local machine
Transferring 404_PF_DCLINE.pkl from scenario_fs
```
And confirm that the files have been downloaded

```
❯ ls data/output | grep 404
404_AVERAGED_CONG.pkl
404_PF_DCLINE.pkl
~/ScenarioData ❯                                                                                      

```

Note that this example would have worked essentially the same way before, but only for a handful of scenarios, instead of the full set of existing ones.


### Time estimate
20 min - I don't think this breaks anything or is super risky
