### PR TITLE
Perf improvements for tests and minor fixes

### DIFF
--- a/powersimdata/input/change_table.py
+++ b/powersimdata/input/change_table.py
@@ -16,6 +16,7 @@ from powersimdata.input.changes import (
     remove_plant,
     scale_plant_pmin,
 )
+from powersimdata.input.profile_input import ProfileInput
 from powersimdata.input.transform_grid import TransformGrid
 
 _resources = (
@@ -148,6 +149,7 @@ class ChangeTable:
                 "demand_flexibility",
             }
         }
+        self._profile_input = None
 
     @staticmethod
     def _check_resource(resource):
@@ -478,6 +480,8 @@ class ChangeTable:
 
         See :func:`powersimdata.input.changes.demand_flex.add_demand_flexibility`
         """
+        if self._profile_input is None:
+            self._profile_input = ProfileInput()
         add_demand_flexibility(self, info)
 
     def add_electrification(self, kind, info):

--- a/powersimdata/input/changes/demand_flex.py
+++ b/powersimdata/input/changes/demand_flex.py
@@ -1,7 +1,5 @@
 import copy
 
-from powersimdata.input.profile_input import ProfileInput
-
 
 def add_demand_flexibility(obj, info):
     """Adds demand flexibility to the system.
@@ -46,7 +44,7 @@ def add_demand_flexibility(obj, info):
             obj.ct["demand_flexibility"][k] = info[k]
         else:
             # Determine the available profile versions
-            possible = ProfileInput().get_profile_version(obj.grid.grid_model, k)
+            possible = obj._profile_input.get_profile_version(obj.grid.grid_model, k)
 
             # Add the profile to the change table
             if len(possible) == 0:

--- a/powersimdata/input/check.py
+++ b/powersimdata/input/check.py
@@ -299,7 +299,7 @@ def _check_grid_type(grid):
         raise TypeError(f"grid must be a {_grid.Grid} object")
 
 
-def _check_areas_and_format(areas, mi=ModelImmutables("usa_tamu")):
+def _check_areas_and_format(areas, mi=None):
     """Ensure that areas are valid. Duplicates are removed and state abbreviations are
     converted to their actual name.
 
@@ -311,6 +311,8 @@ def _check_areas_and_format(areas, mi=ModelImmutables("usa_tamu")):
     :return: (*set*) -- areas as a set. State/Country abbreviations are converted to
         state/country names.
     """
+    if mi is None:
+        mi = ModelImmutables("usa_tamu")
     if isinstance(areas, str):
         areas = {areas}
     elif isinstance(areas, (list, set, tuple)):
@@ -334,7 +336,7 @@ def _check_areas_and_format(areas, mi=ModelImmutables("usa_tamu")):
     return areas
 
 
-def _check_resources_and_format(resources, mi=ModelImmutables("usa_tamu")):
+def _check_resources_and_format(resources, mi=None):
     """Ensure that resources are valid and convert variable to a set.
 
     :param str/list/tuple/set resources: resource(s) to check.
@@ -343,6 +345,8 @@ def _check_resources_and_format(resources, mi=ModelImmutables("usa_tamu")):
     :raises ValueError: if resources is empty or not valid.
     :return: (*set*) -- resources as a set.
     """
+    if mi is None:
+        mi = ModelImmutables("usa_tamu")
     if isinstance(resources, str):
         resources = {resources}
     elif isinstance(resources, (list, set, tuple)):
@@ -359,9 +363,7 @@ def _check_resources_and_format(resources, mi=ModelImmutables("usa_tamu")):
     return resources
 
 
-def _check_resources_are_renewable_and_format(
-    resources, mi=ModelImmutables("usa_tamu")
-):
+def _check_resources_are_renewable_and_format(resources, mi=None):
     """Ensure that resources are valid renewable resources and convert variable to
     a set.
     :param powersimdata.network.model.ModelImmutables mi: immutables of a grid model.
@@ -369,6 +371,8 @@ def _check_resources_are_renewable_and_format(
     :raises ValueError: if resources are not renewables.
     return: (*set*) -- resources as a set
     """
+    if mi is None:
+        mi = ModelImmutables("usa_tamu")
     resources = _check_resources_and_format(resources, mi=mi)
     if not resources <= mi.plants["renewable_resources"]:
         diff = resources - mi.plants["all_resources"]

--- a/powersimdata/input/check.py
+++ b/powersimdata/input/check.py
@@ -408,7 +408,7 @@ def _check_areas_are_in_grid_and_format(areas, grid):
         if not isinstance(k, str):
             raise TypeError("area type must be a str")
         elif k == "interconnect":
-            interconnects = _check_areas_and_format(v)
+            interconnects = _check_areas_and_format(v, mi)
             for i in interconnects:
                 try:
                     all_loadzones.update(mi.zones["interconnect2loadzone"][i])
@@ -416,7 +416,7 @@ def _check_areas_are_in_grid_and_format(areas, grid):
                     raise ValueError("invalid interconnect: %s" % i)
             areas_formatted["interconnect"].update(interconnects)
         elif k == "state":
-            states = _check_areas_and_format(v)
+            states = _check_areas_and_format(v, mi)
             for s in states:
                 try:
                     all_loadzones.update(mi.zones["state2loadzone"][s])
@@ -424,7 +424,7 @@ def _check_areas_are_in_grid_and_format(areas, grid):
                     raise ValueError("invalid state: %s" % s)
             areas_formatted["state"].update(states)
         elif k == "loadzone":
-            loadzones = _check_areas_and_format(v)
+            loadzones = _check_areas_and_format(v, mi)
             for l in loadzones:
                 if l not in mi.zones["loadzone"]:
                     raise ValueError("invalid load zone: %s" % l)
@@ -451,7 +451,7 @@ def _check_resources_are_in_grid_and_format(resources, grid):
     :raises ValueError: if resources is not used in scenario.
     """
     _check_grid_type(grid)
-    resources = _check_resources_and_format(resources)
+    resources = _check_resources_and_format(resources, grid.model_immutables)
     valid_resources = set(grid.plant["type"].unique())
     if not resources <= valid_resources:
         diff = resources - valid_resources

--- a/powersimdata/input/tests/test_change_table.py
+++ b/powersimdata/input/tests/test_change_table.py
@@ -510,7 +510,11 @@ def test_remove_bus(ct):
     ct.remove_bus({845})
 
 
-def test_add_demand_flexibility(ct, monkeypatch):
+def test_add_demand_flexibility(monkeypatch):
+    monkeypatch.setattr(Context, "get_data_access", MockContext().get_data_access)
+    data_access = Context.get_data_access()
+    ct = ChangeTable(grid)
+
     with pytest.raises(ValueError):
         # Fails because "demand_flexibility_dn", a required key, is not included
         ct.add_demand_flexibility(
@@ -537,9 +541,6 @@ def test_add_demand_flexibility(ct, monkeypatch):
                 "demand_flexibility_duration": 6,
             }
         )
-
-    monkeypatch.setattr(Context, "get_data_access", MockContext().get_data_access)
-    data_access = Context.get_data_access()
 
     # Create fake files in the expected directory path
     exp_path = f"raw/{grid.grid_model}"

--- a/powersimdata/input/tests/test_change_table.py
+++ b/powersimdata/input/tests/test_change_table.py
@@ -513,6 +513,7 @@ def test_remove_bus(ct):
 def test_add_demand_flexibility(monkeypatch):
     monkeypatch.setattr(Context, "get_data_access", MockContext().get_data_access)
     data_access = Context.get_data_access()
+    grid = Grid("Texas")
     ct = ChangeTable(grid)
 
     with pytest.raises(ValueError):

--- a/powersimdata/input/tests/test_check.py
+++ b/powersimdata/input/tests/test_check.py
@@ -227,6 +227,7 @@ def test_check_areas_and_format_argument_value():
             _check_areas_and_format(a)
 
 
+@pytest.mark.skip
 def test_check_areas_and_format(europe):
     _check_areas_and_format(["Western", "NY", "El Paso", "Arizona"])
     assert _check_areas_and_format(["California", "CA", "NY", "TX", "MT", "WA"]) == {
@@ -428,7 +429,7 @@ def test_check_epsilon_argument_type():
     arg = ("1e-3", [0.0001])
     for a in arg:
         with pytest.raises(TypeError):
-            _check_epsilon()
+            _check_epsilon(a)
 
 
 def test_check_epsilon_argument_value():

--- a/powersimdata/input/tests/test_check.py
+++ b/powersimdata/input/tests/test_check.py
@@ -217,7 +217,7 @@ def test_check_areas_and_format_argument_type():
     )
     for a in arg:
         with pytest.raises(TypeError):
-            _check_areas_and_format()
+            _check_areas_and_format(a)
 
 
 def test_check_areas_and_format_argument_value():

--- a/powersimdata/input/tests/test_input_data.py
+++ b/powersimdata/input/tests/test_input_data.py
@@ -2,17 +2,19 @@ import pytest
 
 from powersimdata.input.input_data import InputData
 
+_input_data = InputData()
+
 
 def test_get_file_components():
     s_info = {"id": "123"}
-    ct_file = InputData()._get_file_path(s_info, "ct")
-    grid_file = InputData()._get_file_path(s_info, "grid")
+    ct_file = _input_data._get_file_path(s_info, "ct")
+    grid_file = _input_data._get_file_path(s_info, "grid")
     assert "data/input/123_ct.pkl" == ct_file
     assert "data/input/123_grid.mat" == grid_file
 
 
 def test_check_field():
-    _check_field = InputData()._check_field
+    _check_field = _input_data._check_field
     _check_field("grid")
     _check_field("ct")
     with pytest.raises(ValueError):

--- a/powersimdata/scenario/analyze.py
+++ b/powersimdata/scenario/analyze.py
@@ -38,8 +38,8 @@ class Analyze(Ready):
     def __init__(self, scenario):
         """Constructor."""
         super().__init__(scenario)
-
         self.refresh(scenario)
+        self._output_data = OutputData()
 
     def refresh(self, scenario):
         print(
@@ -112,7 +112,7 @@ class Analyze(Ready):
                 )
 
     def _get_data(self, field):
-        return OutputData().get_data(self._scenario_info["id"], field)
+        return self._output_data.get_data(self._scenario_info["id"], field)
 
     def get_pg(self):
         """Returns PG data frame.

--- a/powersimdata/scenario/create.py
+++ b/powersimdata/scenario/create.py
@@ -361,6 +361,7 @@ class FromCSV(_Builder):
 
         self.exported_methods |= {"set_base_profile", "get_base_profile"}
 
+        self._profile_input = ProfileInput()
         self.print_existing_study()
         self.print_available_profile()
 
@@ -390,7 +391,7 @@ class FromCSV(_Builder):
         :param str kind: one of *'demand'*, *'hydro'*, *'solar'*, *'wind'*.
         :return: (*list*) -- available version for selected profile kind.
         """
-        return ProfileInput().get_profile_version(self.grid_model, kind)
+        return self._profile_input.get_profile_version(self.grid_model, kind)
 
     def set_base_profile(self, kind, version):
         """Set base profile.

--- a/powersimdata/tests/mock_context.py
+++ b/powersimdata/tests/mock_context.py
@@ -1,6 +1,7 @@
 import os
 
-from powersimdata.data_access.data_access import TempDataAccess, get_blob_fs
+from powersimdata.data_access.data_access import TempDataAccess
+from powersimdata.data_access.fs_helper import get_blob_fs
 from powersimdata.utility import templates
 
 


### PR DESCRIPTION
### Purpose
Reduce test duration by reusing objects that don't really need to be recreated. 

### What the code is doing
* Create fewer instances of `OutputData`, `InputData`, and `ProfileInput`.
* Use texas grid for demand flexibility test instead of usa
* use `None` as default argument
* skip test that downloads from zenodo 

### Testing
Running the tests locally shows a small but not totally insignificant reduction in test duration. 

### Time estimate
2 min
