### PR TITLE
docs: add packages to requirements.txt, to fix import errors in sphinx

### DIFF
--- a/powersimdata/input/exporter/export_to_pypsa.py
+++ b/powersimdata/input/exporter/export_to_pypsa.py
@@ -144,7 +144,7 @@ def export_to_pypsa(
     .. note::
         This function does not export storages yet.
 
-    :param powersimdata.scenario.scenario.Scenario/
+    :param powersimdata.scenario.scenario.Scenario /\
         powersimdata.input.grid.Grid scenario_or_grid: input object. If a Grid instance
         is passed, operational values will be used for the single snapshot "now".
         If a Scenario instance is passed, all available time-series will be
@@ -175,7 +175,7 @@ def export_to_pypsa(
     else:
         raise TypeError(
             "Expected type powersimdata.Grid or powersimdata.Scenario, "
-            f"get {type(scenario)}."
+            f"got {type(scenario_or_grid)}."
         )
 
     drop_cols = []

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,10 +5,12 @@ paramiko==2.7.2
 scipy~=1.5
 tqdm==4.29.1
 requests~=2.25
+fs==2.4.14
+fs.sshfs
+fs-azureblob>=0.2.1
 black
 pytest
 coverage
 pytest-cov
-fs==2.4.14
-fs.sshfs
-fs-azureblob>=0.2.1
+pypsa
+zenodo_get


### PR DESCRIPTION
### Purpose
Generating docs for a given module requires importing it, so we need to install any packages it uses at the top level. E.g. the [docs for europe_tub](https://breakthrough-energy.github.io/docs/powersimdata.network.europe_tub.html#module-powersimdata.network.europe_tub) is missing for this reason.

### What the code is doing
Add packages to requirements.txt and fix one place where the newline causes docs to not render properly ([this one](https://breakthrough-energy.github.io/docs/powersimdata.input.exporter.html#powersimdata.input.exporter.export_to_pypsa.export_to_pypsa))

### Testing
Built the docs locally.

### Time estimate
1 min
