### PR TITLE
add data structure for expansion candidates

### DIFF
--- a/powersimdata/input/expansion_candidates.py
+++ b/powersimdata/input/expansion_candidates.py
@@ -99,6 +99,17 @@ class ExpansionCandidates:
         self.storage = pd.DataFrame(columns=_columns["storage"])
         self.grid = grid
 
+    def __repr__(self):
+        name = self.__class__.__name__
+
+        def _short_description(df, name):
+            return f"{name}: cols={list(df.columns)}, rows={df.shape[0]}"
+
+        branch = _short_description(self.branch, "branch")
+        plant = _short_description(self.plant, "plant")
+        storage = _short_description(self.storage, "storage")
+        return f"{name}({branch}\n{plant}\n{storage})"
+
     def _validate_df(self, name, df):
         assert name in ("branch", "plant", "storage")
         if not isinstance(df, pd.DataFrame):

--- a/powersimdata/input/expansion_candidates.py
+++ b/powersimdata/input/expansion_candidates.py
@@ -1,0 +1,53 @@
+from dataclasses import dataclass
+
+import pandas as pd
+
+_columns = {
+    "branch": ("from_bus", "to_bus", "inv_cost", "max_capacity"),
+    "plant": ("bus_id", "type", "marginal_cost", "inv_cost", "max_capacity"),
+    "storage": (
+        "bus_id",
+        "inv_cost_power",
+        "inv_cost_energy",
+        "max_capacity_energy",
+        "max_capacity_power",
+    ),
+}
+_required_columns = {
+    "branch": ("from_bus", "to_bus"),
+    "plant": ("bus_id", "type", "marginal_cost"),
+    "storage": ("bus_id"),
+}
+
+
+@dataclass
+class ExpansionCandidates:
+    """Instantiate a data structure to hold candidates for expansion in a capacity
+    expansion model.
+    """
+
+    branch: pd.DataFrame
+    plant: pd.DataFrame
+    storage: pd.DataFrame
+
+    def __init__(self):
+        self.branch = pd.DataFrame(columns=_columns["branch"])
+        self.plant = pd.DataFrame(columns=_columns["plant"])
+        self.storage = pd.DataFrame(columns=_columns["storage"])
+
+    def _assign(self, name, df):
+        assert name in ("branch", "plant", "storage")
+        if not isinstance(df, pd.DataFrame):
+            raise TypeError(f"{name} must be a data frame")
+        if not set(_required_columns[name]) <= set(df.columns):
+            raise TypeError(f"{name} must have columns {_required_columns[name]}")
+        setattr(self, name, df.reindex(_columns[name], axis=1))
+
+    def set_branch(self, branch):
+        self._assign("branch", branch)
+
+    def set_plant(self, plant):
+        self._assign("plant", plant)
+
+    def set_storage(self, storage):
+        self._assign("storage", storage)

--- a/powersimdata/input/expansion_candidates.py
+++ b/powersimdata/input/expansion_candidates.py
@@ -3,7 +3,14 @@ from dataclasses import dataclass
 import pandas as pd
 
 
-def check_branch(branch, grid):
+def check_bus_id(bus_id, grid):
+    valid = bus_id.isin(grid.bus.index)
+    if not valid.all():
+        msg = f"Invalid bus id = {list(bus_id[~valid])}"
+        raise ValueError(msg)
+
+
+def check_branch_voltage(branch, grid):
     basekv = grid.bus.loc[:, "baseKV"]
     v1 = basekv[branch["from_bus"]].reset_index(drop=True)
     v2 = basekv[branch["to_bus"]].reset_index(drop=True)
@@ -13,6 +20,16 @@ def check_branch(branch, grid):
         raise ValueError(
             f"from_bus and to_bus must have the same baseKV. rows={mismatch}"
         )
+
+
+def check_branch(branch, grid):
+    check_branch_voltage(branch, grid)
+    check_bus_id(branch.from_bus, grid)
+    check_bus_id(branch.to_bus, grid)
+
+
+def check_plant(plant, grid):
+    check_bus_id(plant.bus_id, grid)
 
 
 _columns = {

--- a/powersimdata/input/expansion_candidates.py
+++ b/powersimdata/input/expansion_candidates.py
@@ -68,7 +68,7 @@ def _validate_df(name, df):
     if not isinstance(df, pd.DataFrame):
         raise TypeError(f"{name} must be a data frame")
     if not set(_required_columns[name]) <= set(df.columns):
-        raise TypeError(f"{name} must have columns {_required_columns[name]}")
+        raise ValueError(f"{name} must have columns {_required_columns[name]}")
     return df.reindex(_columns[name], axis=1)
 
 

--- a/powersimdata/input/expansion_candidates.py
+++ b/powersimdata/input/expansion_candidates.py
@@ -4,6 +4,12 @@ import pandas as pd
 
 
 def check_bus_id(bus_id, grid):
+    """Check that buses are within the given grid
+
+    :param pd.Series bus_id: the bus ids to check
+    :param powersimdata.input.grid.Grid grid: reference grid
+    :raises ValueError: if any buses are not in the grid
+    """
     valid = bus_id.isin(grid.bus.index)
     if not valid.all():
         msg = f"Invalid bus id = {list(bus_id[~valid])}"
@@ -11,6 +17,12 @@ def check_bus_id(bus_id, grid):
 
 
 def check_branch_voltage(branch, grid):
+    """Check that branches are attached to buses with the same voltage
+
+    :param pd.DataFrame branch: dataframe with from_bus and to_bus columns
+    :param powersimdata.input.grid.Grid grid: reference grid
+    :raises ValueError: if any branches have mismatched voltage
+    """
     basekv = grid.bus.loc[:, "baseKV"]
     v1 = basekv[branch["from_bus"]].reset_index(drop=True)
     v2 = basekv[branch["to_bus"]].reset_index(drop=True)
@@ -23,16 +35,31 @@ def check_branch_voltage(branch, grid):
 
 
 def check_branch(branch, grid):
-    check_branch_voltage(branch, grid)
+    """Check branch expansion candidates relative to a specific grid
+
+    :param pd.DataFrame branch: dataframe of branch candidates
+    :param powersimdata.input.grid.Grid grid: reference grid
+    """
     check_bus_id(branch.from_bus, grid)
     check_bus_id(branch.to_bus, grid)
+    check_branch_voltage(branch, grid)
 
 
 def check_plant(plant, grid):
+    """Check plant expansion candidates relative to a specific grid
+
+    :param pd.DataFrame plant: dataframe of plant candidates
+    :param powersimdata.input.grid.Grid grid: reference grid
+    """
     check_bus_id(plant.bus_id, grid)
 
 
 def check_storage(storage, grid):
+    """Check storage expansion candidates relative to a specific grid
+
+    :param pd.DataFrame storage: dataframe of storage candidates
+    :param powersimdata.input.grid.Grid grid: reference grid
+    """
     check_bus_id(storage.bus_id, grid)
 
 
@@ -58,6 +85,8 @@ _required_columns = {
 class ExpansionCandidates:
     """Instantiate a data structure to hold candidates for expansion in a capacity
     expansion model.
+
+    :param powersimdata.input.grid.Grid grid: reference grid
     """
 
     branch: pd.DataFrame
@@ -76,20 +105,31 @@ class ExpansionCandidates:
             raise TypeError(f"{name} must be a data frame")
         if not set(_required_columns[name]) <= set(df.columns):
             raise TypeError(f"{name} must have columns {_required_columns[name]}")
-        # setattr(self, name, df.reindex(_columns[name], axis=1))
         return df.reindex(_columns[name], axis=1)
 
     def set_branch(self, branch):
+        """Validate and assign branch candidates
+
+        :param pd.DataFrame branch: branch dataframe
+        """
         branch = self._validate_df("branch", branch)
         check_branch(branch, self.grid)
         self.branch = branch
 
     def set_plant(self, plant):
+        """Validate and assign plant candidates
+
+        :param pd.DataFrame plant: plant dataframe
+        """
         plant = self._validate_df("plant", plant)
         check_plant(plant, self.grid)
         self.plant = plant
 
     def set_storage(self, storage):
+        """Validate and assign storage candidates
+
+        :param pd.DataFrame storage: storage dataframe
+        """
         storage = self._validate_df("storage", storage)
         check_storage(storage, self.grid)
         self.storage = storage

--- a/powersimdata/input/expansion_candidates.py
+++ b/powersimdata/input/expansion_candidates.py
@@ -2,6 +2,19 @@ from dataclasses import dataclass
 
 import pandas as pd
 
+
+def check_branch(branch, grid):
+    basekv = grid.bus.loc[:, "baseKV"]
+    v1 = basekv[branch["from_bus"]].reset_index(drop=True)
+    v2 = basekv[branch["to_bus"]].reset_index(drop=True)
+    cmp = v1.compare(v2)
+    if not cmp.empty:
+        mismatch = list(cmp.index)
+        raise ValueError(
+            f"from_bus and to_bus must have the same baseKV. rows={mismatch}"
+        )
+
+
 _columns = {
     "branch": ("from_bus", "to_bus", "inv_cost", "max_capacity"),
     "plant": ("bus_id", "type", "marginal_cost", "inv_cost", "max_capacity"),

--- a/powersimdata/input/expansion_candidates.py
+++ b/powersimdata/input/expansion_candidates.py
@@ -77,7 +77,7 @@ _columns = {
 _required_columns = {
     "branch": ("from_bus", "to_bus"),
     "plant": ("bus_id", "type", "marginal_cost"),
-    "storage": ("bus_id"),
+    "storage": ("bus_id",),
 }
 
 

--- a/powersimdata/input/tests/test_expansion_candidates.py
+++ b/powersimdata/input/tests/test_expansion_candidates.py
@@ -19,6 +19,11 @@ def test_column_types():
 
 
 def test_check_branch_voltage():
+    # baseKV = 230
+    branch = pd.DataFrame({"from_bus": [3001004], "to_bus": [3008159]})
+    check_branch_voltage(branch, grid)
+
+    # baseKV = 115, 230
     branch = pd.DataFrame({"from_bus": [3001001], "to_bus": [3008156]})
     with pytest.raises(ValueError):
         check_branch_voltage(branch, grid)
@@ -51,5 +56,5 @@ def test_set_candidates():
     plant["marginal_cost"] = 4
     ec.set_plant(plant)
 
-    storage = grid.bus.head().reset_index().loc[:, ["bus_id"]]
+    storage = plant.loc[:, ["bus_id"]].copy()
     ec.set_storage(storage)

--- a/powersimdata/input/tests/test_expansion_candidates.py
+++ b/powersimdata/input/tests/test_expansion_candidates.py
@@ -14,8 +14,14 @@ grid = Grid("Texas")
 def test_column_types():
     ec = ExpansionCandidates(grid)
     with pytest.raises(TypeError):
-        branch = pd.DataFrame()
+        branch = {"branch_id": [1, 2]}
         ec.set_branch(branch)
+    with pytest.raises(ValueError):
+        plant = pd.DataFrame({"plant_id": [42]})
+        ec.set_plant(plant)
+    with pytest.raises(ValueError):
+        storage = pd.DataFrame({"bus_id": [1, 2], "foo": [3, 4]})
+        ec.set_storage(storage)
 
 
 def test_check_branch_voltage():

--- a/powersimdata/input/tests/test_expansion_candidates.py
+++ b/powersimdata/input/tests/test_expansion_candidates.py
@@ -1,0 +1,19 @@
+import pandas as pd
+import pytest
+
+from powersimdata.input.expansion_candidates import ExpansionCandidates, check_branch
+from powersimdata.input.grid import Grid
+
+
+def test_column_types():
+    ec = ExpansionCandidates()
+    with pytest.raises(TypeError):
+        branch = pd.DataFrame()
+        ec.set_branch(branch)
+
+
+def test_check_branch():
+    grid = Grid("Texas")
+    branch = pd.DataFrame({"from_bus": [3001001], "to_bus": [3008156]})
+    with pytest.raises(ValueError):
+        check_branch(branch, grid)

--- a/powersimdata/input/tests/test_expansion_candidates.py
+++ b/powersimdata/input/tests/test_expansion_candidates.py
@@ -1,20 +1,55 @@
 import pandas as pd
 import pytest
 
-from powersimdata.input.expansion_candidates import ExpansionCandidates, check_branch
+from powersimdata.input.expansion_candidates import (
+    ExpansionCandidates,
+    check_branch_voltage,
+    check_bus_id,
+)
 from powersimdata.input.grid import Grid
+
+grid = Grid("Texas")
 
 
 def test_column_types():
-    grid = Grid("Texas")
     ec = ExpansionCandidates(grid)
     with pytest.raises(TypeError):
         branch = pd.DataFrame()
         ec.set_branch(branch)
 
 
-def test_check_branch():
-    grid = Grid("Texas")
+def test_check_branch_voltage():
     branch = pd.DataFrame({"from_bus": [3001001], "to_bus": [3008156]})
     with pytest.raises(ValueError):
-        check_branch(branch, grid)
+        check_branch_voltage(branch, grid)
+
+
+def test_check_bus_id():
+    bus_id = pd.Series([3001001])
+    check_bus_id(bus_id, grid)
+
+    with pytest.raises(ValueError):
+        check_bus_id(bus_id, Grid("Western"))
+
+    bus_id = pd.Series([-1])
+    with pytest.raises(ValueError):
+        check_bus_id(bus_id, grid)
+
+
+def test_set_candidates():
+    ec = ExpansionCandidates(grid)
+    branch = grid.branch.head().loc[:, ["from_bus_id", "to_bus_id"]]
+    branch = branch.rename(
+        columns={
+            "from_bus_id": "from_bus",
+            "to_bus_id": "to_bus",
+        }
+    )
+    ec.set_branch(branch)
+
+    plant = grid.plant.head().loc[:, ["bus_id", "type"]]
+    plant["marginal_cost"] = 4
+    ec.set_plant(plant)
+
+    storage = grid.bus.head().reset_index().loc[:, ["bus_id"]]
+    ec.set_storage(storage)

--- a/powersimdata/input/tests/test_expansion_candidates.py
+++ b/powersimdata/input/tests/test_expansion_candidates.py
@@ -6,7 +6,8 @@ from powersimdata.input.grid import Grid
 
 
 def test_column_types():
-    ec = ExpansionCandidates()
+    grid = Grid("Texas")
+    ec = ExpansionCandidates(grid)
     with pytest.raises(TypeError):
         branch = pd.DataFrame()
         ec.set_branch(branch)


### PR DESCRIPTION
### Purpose
Define a new data structure for expansion candidates and some preliminary validation based on the current grid. The schema is the same as in https://github.com/Breakthrough-Energy/PowerSimData/pull/641 but I refactored it a bit.

### What the code is doing
Add the new class, which can have candidates for branches, plants, and storage. Each one has a set of allowed columns and required columns. When assigning a given type of candidate, there are some basic checks - e.g. buses are in the grid. I imagine more checks could be done in subsequent PRs. 

We've discussed expanding the costs over multiple years to account for inflation - this isn't accounted for yet, and I suspect it might be done during the preparation phase, after a user has defined the investment years/time span. 

In general there is probably a lot from the original epic that isn't implemented yet. E.g. defining branch candidates by substation instead of buses. This is just meant to be a usable subset of the possible/desired schema.

### Testing
New unit tests

### Usage Example/Visuals
Create an instance:
```
from powersimdata import Grid
from powersimdata.input.expansion_candidates import ExpansionCandidates
grid = Grid("Texas")
ec = ExpansionCandidates(grid)
```
After assigning some values (using the example from the unit test), we can inspect it using the custom `repr`
```
In [10]: ec
Out[10]:
ExpansionCandidates(branch: cols=['from_bus', 'to_bus', 'inv_cost', 'max_capacity'], rows=5
plant: cols=['bus_id', 'type', 'marginal_cost', 'inv_cost', 'max_capacity'], rows=5
storage: cols=['bus_id', 'inv_cost_power', 'inv_cost_energy', 'max_capacity_energy', 'max_capacity_power'], rows=0)
```
Or look at the data frames directly (similar for storage). Note the indexes are not required, that's an artifact of using the existing grid as an example:
```
In [11]: ec.plant
Out[11]:
           bus_id   type  marginal_cost  inv_cost  max_capacity
plant_id
12875     3001004   wind              4       NaN           NaN
12876     3001006   wind              4       NaN           NaN
12877     3001009   wind              4       NaN           NaN
12878     3001011  solar              4       NaN           NaN
12879     3001021   wind              4       NaN           NaN

In [12]: ec.branch
Out[12]:
           from_bus   to_bus  inv_cost  max_capacity
branch_id
100915      3001001  3001064       NaN           NaN
100916      3001001  3001064       NaN           NaN
100917      3001001  3001071       NaN           NaN
100918      3001001  3001071       NaN           NaN
100919      3001002  3001007       NaN           NaN
```

### Time estimate
30 min
