### PR TITLE
Fix resource name resource name

### DIFF
--- a/powersimdata/network/constants/resource.py
+++ b/powersimdata/network/constants/resource.py
@@ -67,18 +67,18 @@ class EUResource:
             "offwind-ac",
             "offwind-dc",
             "onwind",
-            "phs",
+            "PHS",
             "ror",
             "solar",
         }
         self.group_profile_resources = {
-            "hydro": {"hydro", "phs", "ror"},
+            "hydro": {"hydro", "PHS", "ror"},
             "solar": {"solar"},
             "wind": {"onwind", "offwind-ac", "offwind-dc"},
         }
         self.curtailable_resources = {
             "hydro",
-            "phs",
+            "PHS",
             "ror",
             "solar",
             "offwind-ac",
@@ -118,7 +118,7 @@ class EUResource:
             "biomass": {"biomass"},
             "coal": {"coal", "lignite"},
             "geothermal": {"geothermal"},
-            "hydro": {"hydro", "phs", "ror"},
+            "hydro": {"hydro", "PHS", "ror"},
             "ng": {"CCGT", "OCGT"},
             "nuclear": {"nuclear"},
             "oil": {"oil"},
@@ -139,7 +139,7 @@ class EUResource:
             "offwind-ac": 0,
             "offwind-dc": 0,
             "onwind": 0,
-            "phs": 0.9,
+            "PHS": 0.9,
             "ror": None,
             "solar": 0,
         }


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
Use `PHS` instead of `phs` as resource name. 

### What the code is doing
No code

### Testing
Existing unit tests

### Where to look
The modification takes place in the attributes of the `EUResource` class in the `powersimdata.network.constants.resource` module.

### Usage Example/Visuals
PyPSA-Eur uses `PHS` (upper case) for pumped hydro storage as illustrated below:
```
>>> from powersimdata.network.europe_tub.model import TUB
>>> tub = TUB("Europe", reduction=1024)
Title: PyPSA-Eur: An Open Optimisation Model of the European Transmission System (Dataset)
Keywords: power system model, capacity expansion model, energy system model, electricity system model, python
Publication date: 2022-09-10
DOI: 10.5281/zenodo.6913032
Total size: 2075.6 MB

Link: https://zenodo.org/api/files/7528030f-2993-4f54-83e4-9fdd223b9ba5/networks.zip   size: 2075.6 MB
networks.zip is already downloaded correctly.
All files have been downloaded.
>>> tub.build()
>>> tub.network.storage_units["carrier"].unique()
array(['hydro', 'PHS'], dtype=object)
```

### Time estimate
1min
