### PR TITLE
Extract profiles from PyPSA's Network objects 

### DIFF
--- a/powersimdata/input/converter/pypsa_to_profiles.py
+++ b/powersimdata/input/converter/pypsa_to_profiles.py
@@ -1,4 +1,3 @@
-import numpy as np
 import pandas as pd
 import pypsa
 
@@ -43,18 +42,7 @@ def get_pypsa_gen_profile(network, profile2carrier):
                         if not ts.empty:
                             id_ts = set(ts.columns)
                             idx = list(id_carrier.intersection(id_ts))
-                            norm = (
-                                (
-                                    ts[idx]
-                                    .max()
-                                    .combine(
-                                        carrier_in_component.loc[idx, "p_nom"],
-                                        np.maximum,
-                                    )
-                                )
-                                if t == "inflow"
-                                else 1
-                            )
+                            norm = ts[idx].max() if t == "inflow" else 1
                             profile[p] = pd.concat([profile[p], ts[idx] / norm], axis=1)
                 if len(set(c) - set(carrier_in_component.carrier.unique())):
                     continue

--- a/powersimdata/input/converter/pypsa_to_profiles.py
+++ b/powersimdata/input/converter/pypsa_to_profiles.py
@@ -1,33 +1,81 @@
+import numpy as np
 import pandas as pd
-from pypsa.descriptors import get_switchable_as_dense
+import pypsa
 
 
-def get_pypsa_gen_profile(network, kind):
+def get_pypsa_gen_profile(network, profile2carrier):
     """Return hydro, solar or wind profile enclosed in a PyPSA network.
 
     :param pypsa.Network network: the Network object.
-    :param str kind: either *'hydro'*, *'solar'*, *'wind'*.
-    :return: (*pandas.DataFrame*) -- profile.
+    :param dict profile2carrier: a dictionary mapping profile type to carrier type.
+        *'hydro'*, *'solar'* and *'wind'* are valid keys. Values is a corresponding
+        set of carriers as found in the Network object.
+    :return: (*dict*) -- keys are the same ones than in ``profile2carrier``. Values
+        are profiles as data frame.
+    :raises TypeError:
+        if ``network`` is not a pypsa.components.Network object.
+        if ``profile2carrier`` is not a dict.
+        if values of ``profile2carrier`` are not an iterable.
+    :raises ValueError:
+        if keys of ``profile2carrier`` are invalid.
     """
-    p_max_pu = get_switchable_as_dense(network, "Generator", "p_max_pu")
-    p_max_pu.columns = pd.to_numeric(p_max_pu.columns, errors="ignore")
-    p_max_pu.columns.name = None
-    p_max_pu.index.name = "UTC"
+    if not isinstance(network, pypsa.components.Network):
+        raise TypeError("network must be a Network object")
+    if not isinstance(profile2carrier, dict):
+        raise TypeError("profile2carrier must be a dict")
+    if not all(isinstance(v, (list, set, tuple)) for v in profile2carrier.values()):
+        raise TypeError("values of profile2carrier must be an iterable")
+    if not set(profile2carrier).issubset({"hydro", "solar", "wind"}):
+        raise ValueError(
+            "keys of profile2carrier must be a subset of ['hydro', 'solar', 'wind']"
+        )
 
-    all_gen = network.generators.copy()
-    all_gen.index = pd.to_numeric(all_gen.index, errors="ignore")
-    all_gen.index.name = None
+    profile = {}
+    for p, c in profile2carrier.items():
+        profile[p] = pd.DataFrame()
+        for component in ["generators", "storage_units", "stores"]:
+            if hasattr(network, component):
+                carrier_in_component = getattr(network, component)
+                id_carrier = set(carrier_in_component.query("carrier==list(@c)").index)
+                for t in ["inflow", "p_max_pu"]:
+                    if t in getattr(network, component + "_t"):
+                        ts = getattr(network, component + "_t")[t]
+                        if not ts.empty:
+                            id_ts = set(ts.columns)
+                            idx = list(id_carrier.intersection(id_ts))
+                            norm = (
+                                (
+                                    ts[idx]
+                                    .max()
+                                    .combine(
+                                        carrier_in_component.loc[idx, "p_nom"],
+                                        np.maximum,
+                                    )
+                                )
+                                if t == "inflow"
+                                else 1
+                            )
+                            profile[p] = pd.concat([profile[p], ts[idx] / norm], axis=1)
+                if len(set(c) - set(carrier_in_component.carrier.unique())):
+                    continue
+                else:
+                    break
+        profile[p].rename_axis(index="UTC", columns=None, inplace=True)
 
-    gen = all_gen.query("@kind in carrier").index
-    return p_max_pu[gen] * all_gen.p_nom[gen]
+    return profile
 
 
 def get_pypsa_demand_profile(network):
     """Return demand profile enclosed in a PyPSA network.
 
     :param pypsa.Network network: the Network object.
-    :return: (*pandas.DataFrame*) -- profile.
+    :return: (*pandas.DataFrame*) -- demand profile.
+    :raises TypeError:
+        if ``network`` is not a pypsa.components.Network object.
     """
+    if not isinstance(network, pypsa.components.Network):
+        raise TypeError("network must be a Network object")
+
     if not network.loads_t.p.empty:
         demand = network.loads_t.p.copy()
     else:
@@ -38,7 +86,6 @@ def get_pypsa_demand_profile(network):
             network.buses.zone_id.dropna().astype(int), axis=1
         ).sum()
     demand.columns = pd.to_numeric(demand.columns, errors="ignore")
-    demand.columns.name = None
-    demand.index.name = "UTC"
+    demand.rename_axis(index="UTC", columns=None, inplace=True)
 
     return demand

--- a/powersimdata/input/converter/pypsa_to_profiles.py
+++ b/powersimdata/input/converter/pypsa_to_profiles.py
@@ -41,7 +41,12 @@ def get_pypsa_gen_profile(network, profile2carrier):
             id_carrier = network.df(component).query("carrier==list(@c)").index
             ts_carrier = get_switchable_as_dense(network, component, ts)[id_carrier]
             if not ts_carrier.empty:
-                norm = ts_carrier.max().replace(0, 1) if ts == "inflow" else 1
+                if ts == "inflow":
+                    has_inflow = ts_carrier.any().index[ts_carrier.any()]
+                    ts_carrier = ts_carrier[has_inflow].add_suffix(" inflow")
+                    norm = ts_carrier.max().replace(0, 1)
+                else:
+                    norm = 1
                 profile[p] = pd.concat([profile[p], ts_carrier / norm], axis=1)
 
         profile[p].rename_axis(index="UTC", columns=None, inplace=True)

--- a/powersimdata/input/converter/tests/test_pypsa_to_profiles.py
+++ b/powersimdata/input/converter/tests/test_pypsa_to_profiles.py
@@ -2,34 +2,85 @@ from importlib.util import find_spec
 
 import pytest
 
-from powersimdata.input.converter.pypsa_to_grid import FromPyPSA
 from powersimdata.input.converter.pypsa_to_profiles import (
     get_pypsa_demand_profile,
     get_pypsa_gen_profile,
 )
 
-
-@pytest.mark.skipif(find_spec("pypsa") is None, reason="Package PyPSA not available.")
-def test_extract_wind():
+if find_spec("pypsa"):
     import pypsa
 
-    n = pypsa.examples.ac_dc_meshed()
-    profile = get_pypsa_gen_profile(n, "wind")
-    grid = FromPyPSA(n)
+    @pytest.fixture
+    def network():
+        return pypsa.examples.ac_dc_meshed()
 
-    assert profile.index.name == "UTC"
-    assert (
-        grid.plant.loc[profile.columns]["Pmax"].sum() * len(profile)
-        >= profile.sum().sum()
+
+def _assert_error(err_msg, error_type, func, *args, **kwargs):
+    with pytest.raises(error_type) as excinfo:
+        func(*args, **kwargs)
+    assert err_msg in str(excinfo.value)
+
+
+@pytest.mark.skipif(find_spec("pypsa") is None, reason="Package PyPSA not available.")
+def test_get_pypsa_gen_profile_argument_type(network):
+    _assert_error(
+        "network must be a Network object",
+        TypeError,
+        get_pypsa_gen_profile,
+        "network",
+        {"wind": "onwind"},
+    )
+    _assert_error(
+        "profile2carrier must be a dict",
+        TypeError,
+        get_pypsa_gen_profile,
+        network,
+        "onwind",
+    )
+    _assert_error(
+        "values of profile2carrier must be an iterable",
+        TypeError,
+        get_pypsa_gen_profile,
+        network,
+        {"solar": "PV"},
     )
 
 
 @pytest.mark.skipif(find_spec("pypsa") is None, reason="Package PyPSA not available.")
-def test_extract_demand():
-    import pypsa
+def test_get_pypsa_gen_profile_argument_value(network):
+    _assert_error(
+        "keys of profile2carrier must be a subset of ['hydro', 'solar', 'wind']",
+        ValueError,
+        get_pypsa_gen_profile,
+        network,
+        {"offwind": ["offwind-ac", "offwind-dc"]},
+    )
 
-    n = pypsa.examples.ac_dc_meshed()
-    profile = get_pypsa_demand_profile(n)
 
-    assert profile.index.name == "UTC"
-    assert profile.sum().sum() >= 0
+@pytest.mark.skipif(find_spec("pypsa") is None, reason="Package PyPSA not available.")
+def test_extract_wind(network):
+    gen_profile = get_pypsa_gen_profile(network, {"wind": ["wind"]})
+    wind_profile = gen_profile["wind"]
+
+    assert wind_profile.index.name == "UTC"
+    assert wind_profile.columns.name is None
+    assert wind_profile.sum().apply(bool).all()
+    assert wind_profile.max().max() <= 1
+
+
+def test_get_pypsa_demand_profile_argument_type():
+    _assert_error(
+        "network must be a Network object",
+        TypeError,
+        get_pypsa_demand_profile,
+        "network",
+    )
+
+
+@pytest.mark.skipif(find_spec("pypsa") is None, reason="Package PyPSA not available.")
+def test_extract_demand(network):
+    demand_profile = get_pypsa_demand_profile(network)
+
+    assert demand_profile.index.name == "UTC"
+    assert demand_profile.columns.name is None
+    assert demand_profile.sum().sum() >= 0


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
Extract generator and demand profiles from a PyPSA `Network` object

### What the code is doing
Loop through the `Generator` and `StorageUnit` components of a `Network` object and build user specified profiles through a dictionary mapping profile type (hydro, solar, wind) to carriers (onwind, solar, ror, etc). Inflow profiles are normalized such that the maximum inflow is 1

### Testing
New unit tests

### Where to look
 The `get_pypsa_gen_profile` function

### Usage Example/Visuals
```
>>> from powersimdata.input.converter.pypsa_to_profiles import get_pypsa_gen_profile
>>> from powersimdata.network.europe_tub.model import TUB
>>> profile2carrier = {'hydro': {'hydro', 'ror', 'PHS'}, 'solar': {'solar'}, 'wind': {'onwind', 'offwind-ac', 'offwind-dc'}}
>>> tub = TUB("Europe", reduction=128)
Title: PyPSA-Eur: An Open Optimisation Model of the European Transmission System (Dataset)
Keywords: power system model, capacity expansion model, energy system model, electricity system model, python
Publication date: 2022-09-20
DOI: 10.5281/zenodo.7251657
Total size: 1702.1 MB

Link: https://zenodo.org/api/files/44276d06-8d1e-4dd7-bed7-57f8fbf9f4d5/networks.zip   size: 1702.1 MB
networks.zip is already downloaded correctly.
All files have been downloaded.
>>> tub.build()
INFO:pypsa.io:Imported network elec_s_128_ec.nc has buses, carriers, generators, lines, links, loads, storage_units, stores
>>> profile = get_pypsa_gen_profile(tub.network, profile2carrier)
>>> profile["hydro"]
                     AL1 0 ror  AT1 0 ror  AT1 1 ror  BE1 0 ror  ...  SE2 3 hydro inflow  SE2 4 hydro inflow  SI1 0 hydro inflow  SK1 0 hydro inflow
UTC                                                              ...                                                                                
2013-01-01 00:00:00   0.274540   0.300145   0.300145   0.995894  ...            0.656168            0.656168            0.265311            0.087945
2013-01-01 01:00:00   0.274515   0.300029   0.300029   1.000000  ...            0.654647            0.654647            0.265273            0.087792
2013-01-01 02:00:00   0.274505   0.299936   0.299936   1.000000  ...            0.653922            0.653922            0.265214            0.087755
2013-01-01 03:00:00   0.274627   0.299868   0.299868   1.000000  ...            0.652859            0.652859            0.265212            0.087960
2013-01-01 04:00:00   0.274700   0.299820   0.299820   1.000000  ...            0.652117            0.652117            0.265189            0.088083
...                        ...        ...        ...        ...  ...                 ...                 ...                 ...                 ...
2013-12-31 19:00:00   0.250162   0.368205   0.368205   0.579924  ...            0.491466            0.491466            0.470877            0.130620
2013-12-31 20:00:00   0.250062   0.367945   0.367945   0.577514  ...            0.491266            0.491266            0.470428            0.130693
2013-12-31 21:00:00   0.250067   0.367699   0.367699   0.575495  ...            0.491070            0.491070            0.469969            0.130761
2013-12-31 22:00:00   0.250018   0.367444   0.367444   0.572038  ...            0.490882            0.490882            0.469443            0.130799
2013-12-31 23:00:00   0.250010   0.367188   0.367188   0.567667  ...            0.490702            0.490702            0.468825            0.130814

[8760 rows x 152 columns]
>>> profile["hydro"].max()
AL1 0 ror             1.0
AT1 0 ror             1.0
AT1 1 ror             1.0
BE1 0 ror             1.0
BE1 2 ror             1.0
                     ... 
SE2 2 hydro inflow    1.0
SE2 3 hydro inflow    1.0
SE2 4 hydro inflow    1.0
SI1 0 hydro inflow    1.0
SK1 0 hydro inflow    1.0
Length: 152, dtype: float64
>>> profile["wind"]
                     AL1 0 offwind-ac  AL1 0 onwind  AT1 0 onwind  AT1 1 onwind  ...  SE2 4 onwind  SI1 0 offwind-ac  SI1 0 onwind  SK1 0 onwind
UTC                                                                              ...                                                            
2013-01-01 00:00:00          0.002930      0.001468      0.024682      0.180255  ...      0.648024          0.000000      0.055151      0.361028
2013-01-01 01:00:00          0.001872      0.000000      0.016699      0.190325  ...      0.654533          0.000000      0.052604      0.368898
2013-01-01 02:00:00          0.000000      0.000000      0.012459      0.190493  ...      0.659420          0.000000      0.052227      0.382934
2013-01-01 03:00:00          0.000000      0.000000      0.012660      0.188959  ...      0.680052          0.000000      0.050760      0.388341
2013-01-01 04:00:00          0.000000      0.000000      0.013591      0.177692  ...      0.719678          0.000000      0.047294      0.409304
...                               ...           ...           ...           ...  ...           ...               ...           ...           ...
2013-12-31 19:00:00          0.026572      0.024328      0.034577      0.118275  ...      0.670652          0.025049      0.001707      0.125728
2013-12-31 20:00:00          0.029891      0.031360      0.042418      0.130074  ...      0.584858          0.021100      0.000000      0.142435
2013-12-31 21:00:00          0.032750      0.034518      0.036139      0.139478  ...      0.489739          0.000000      0.004894      0.153933
2013-12-31 22:00:00          0.028040      0.027423      0.036657      0.135560  ...      0.438377          0.000000      0.009091      0.163441
2013-12-31 23:00:00          0.018277      0.020763      0.012115      0.140614  ...      0.368146          0.000000      0.013550      0.183303

[8760 rows x 266 columns]
>>> profile["wind"].max()
AL1 0 offwind-ac    0.885396
AL1 0 onwind        0.640752
AT1 0 onwind        0.612467
AT1 1 onwind        0.921961
BA1 0 onwind        0.863360
                      ...   
SE2 4 offwind-dc    0.885500
SE2 4 onwind        0.999895
SI1 0 offwind-ac    0.885500
SI1 0 onwind        0.926825
SK1 0 onwind        0.941593
Length: 266, dtype: float64
>>> profile["solar"]
                     AL1 0 solar  AT1 0 solar  AT1 1 solar  BA1 0 solar  BE1 0 solar  ...  SE2 1 solar  SE2 2 solar  SE2 4 solar  SI1 0 solar  SK1 0 solar
UTC                                                                                   ...                                                                 
2013-01-01 00:00:00          0.0          0.0          0.0          0.0          0.0  ...          0.0          0.0          0.0          0.0          0.0
2013-01-01 01:00:00          0.0          0.0          0.0          0.0          0.0  ...          0.0          0.0          0.0          0.0          0.0
2013-01-01 02:00:00          0.0          0.0          0.0          0.0          0.0  ...          0.0          0.0          0.0          0.0          0.0
2013-01-01 03:00:00          0.0          0.0          0.0          0.0          0.0  ...          0.0          0.0          0.0          0.0          0.0
2013-01-01 04:00:00          0.0          0.0          0.0          0.0          0.0  ...          0.0          0.0          0.0          0.0          0.0
...                          ...          ...          ...          ...          ...  ...          ...          ...          ...          ...          ...
2013-12-31 19:00:00          0.0          0.0          0.0          0.0          0.0  ...          0.0          0.0          0.0          0.0          0.0
2013-12-31 20:00:00          0.0          0.0          0.0          0.0          0.0  ...          0.0          0.0          0.0          0.0          0.0
2013-12-31 21:00:00          0.0          0.0          0.0          0.0          0.0  ...          0.0          0.0          0.0          0.0          0.0
2013-12-31 22:00:00          0.0          0.0          0.0          0.0          0.0  ...          0.0          0.0          0.0          0.0          0.0
2013-12-31 23:00:00          0.0          0.0          0.0          0.0          0.0  ...          0.0          0.0          0.0          0.0          0.0

[8760 rows x 126 columns]
>>> profile["solar"].max()
AL1 0 solar    0.808040
AT1 0 solar    0.815206
AT1 1 solar    0.766280
BA1 0 solar    0.786220
BE1 0 solar    0.827806
                 ...   
SE2 1 solar    0.800421
SE2 2 solar    0.782425
SE2 4 solar    0.793002
SI1 0 solar    0.815808
SK1 0 solar    0.782587
Length: 126, dtype: float64
```
Note also that PHS does not have inflow profile.
```
>>> sum(tub.network.storage_units_t["inflow"].columns.str.contains("PHS"))
0
>>> sum(tub.network.storage_units_t["inflow"].columns.str.contains("hydro"))
73
```

### Time estimate
15min