### PR TITLE
chore: add data folder to dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,3 +11,4 @@ build
 .venv
 .dockerignore
 config.ini
+powersimdata/network/europe_tub/data


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
Reduce docker build time and image size by excluding cached network objects.

### What the code is doing
See above. Note this is probably only relevant for local builds. Also, once we standardize on downloading grid data from zenodo, this could be generalized to `powersimdata/network/**/data`.

### Testing
Observed the reduction in build time and image size.

### Time estimate
10 sec
