### PR TITLE
Change constants of grid models 

### DIFF
--- a/powersimdata/network/constants/carrier/resource.py
+++ b/powersimdata/network/constants/carrier/resource.py
@@ -48,7 +48,7 @@ class USAResource:
             "coal": None,
             "dfo": 0,
             "geothermal": 0.95,
-            "hydro": 0.9,
+            "hydro": 1,
             "ng": 0,
             "nuclear": 0.95,
             "other": 0,

--- a/powersimdata/network/constants/carrier/resource.py
+++ b/powersimdata/network/constants/carrier/resource.py
@@ -111,6 +111,7 @@ class EUResource:
             "offwind-ac",
             "offwind-dc",
             "onwind",
+            "PHS",
             "ror",
             "solar",
         }

--- a/powersimdata/network/constants/carrier/resource.py
+++ b/powersimdata/network/constants/carrier/resource.py
@@ -132,7 +132,7 @@ class EUResource:
             "CCGT": None,
             "coal": None,
             "geothermal": None,
-            "hydro": 0.9,
+            "hydro": 0,
             "lignite": None,
             "nuclear": None,
             "OCGT": None,
@@ -140,8 +140,8 @@ class EUResource:
             "offwind-ac": 0,
             "offwind-dc": 0,
             "onwind": 0,
-            "PHS": 0.9,
-            "ror": None,
+            "PHS": 0,
+            "ror": 0,
             "solar": 0,
         }
 


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
Update constants of grid models. To be able to reproduce the previous scenarios with the `usa_tamu` model, the default value for `pmin_as_share_of_pmax` is set to 1 (i.e. `Pmin` is equal to the power output given in the profile each hour) for hydro. As discussed in other channels, the value for `ror` is set to 0 (fully curtailable) in the `europe_tub` model. Finally, PHS is added to the list of clean resources.

### What the code is doing
Change some constants value and update a dictionary

### Testing
Current unit tests

### Where to look
It is pretty minimal. The changes has been discussed during meetings and chat conversations.

### Usage Example/Visuals
N/A

### Time estimate
5min
