### PR TITLE
Create a single inflow carrier in model immutables for hydro and PHS

### DIFF
--- a/powersimdata/network/constants/carrier/resource.py
+++ b/powersimdata/network/constants/carrier/resource.py
@@ -63,27 +63,25 @@ class EUResource:
 
     def __init__(self):
         self.profile_resources = {
-            "hydro",
+            "inflow",
             "offwind-ac",
             "offwind-dc",
             "onwind",
-            "PHS",
             "ror",
             "solar",
         }
         self.group_profile_resources = {
-            "hydro": {"hydro", "PHS", "ror"},
+            "hydro": {"inflow", "ror"},
             "solar": {"solar"},
             "wind": {"onwind", "offwind-ac", "offwind-dc"},
         }
         self.curtailable_resources = {
-            "hydro",
-            "PHS",
-            "ror",
-            "solar",
+            "inflow",
             "offwind-ac",
             "offwind-dc",
             "onwind",
+            "ror",
+            "solar",
         }
         self.thermal_resources = {
             "biomass",
@@ -106,12 +104,11 @@ class EUResource:
         }
         self.clean_resources = {
             "geothermal",
-            "hydro",
+            "inflow",
             "nuclear",
             "offwind-ac",
             "offwind-dc",
             "onwind",
-            "PHS",
             "ror",
             "solar",
         }
@@ -119,7 +116,7 @@ class EUResource:
             "biomass": {"biomass"},
             "coal": {"coal", "lignite"},
             "geothermal": {"geothermal"},
-            "hydro": {"hydro", "PHS", "ror"},
+            "hydro": {"inflow", "ror"},
             "ng": {"CCGT", "OCGT"},
             "nuclear": {"nuclear"},
             "oil": {"oil"},
@@ -132,7 +129,7 @@ class EUResource:
             "CCGT": None,
             "coal": None,
             "geothermal": None,
-            "hydro": 0,
+            "inflow": 0,
             "lignite": None,
             "nuclear": None,
             "OCGT": None,
@@ -140,7 +137,6 @@ class EUResource:
             "offwind-ac": 0,
             "offwind-dc": 0,
             "onwind": 0,
-            "PHS": 0,
             "ror": 0,
             "solar": 0,
         }


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
Combine `hydro` and `PHS` into `inflow` for the `europe_tub` grid model following discussion [here](https://github.com/Breakthrough-Energy/PowerSimData/pull/691#issuecomment-1285989932).

### What the code is doing
Only dictionaries grouping generators are modified.

### Testing
Existing unit tests

### Where to look
Remove `hydro` and `PHS` in the various dictionaries in the `powersimdata.network.constants.carrier.resources` module and add `inflow`.


### Usage Example/Visuals
NA

### Time estimate
2min
