### PR TITLE
Add Slack badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@
 ![GitHub last commit (branch)](https://img.shields.io/github/last-commit/Breakthrough-Energy/PowerSimData/develop?logo=GitHub)
 ![GitHub pull requests](https://img.shields.io/github/issues-pr/Breakthrough-Energy/PowerSimData?logo=GitHub)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Code of Conduct](https://img.shields.io/badge/code%20of-conduct-ff69b4.svg?style=flat)](https://breakthrough-energy.github.io/docs/communication/code_of_conduct.html)
+[![Code of Conduct](https://img.shields.io/badge/Code_of_conduct-ff69b4.svg)](https://breakthrough-energy.github.io/docs/communication/code_of_conduct.html)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4538590.svg)](https://doi.org/10.5281/zenodo.4538590)
-
+[![Slack](https://img.shields.io/badge/Community_Slack-sign_up-1f425f.svg?logo=slack)](https://science.breakthroughenergy.org/#get-updates)
 
 # PowerSimData
 **PowerSimData** is part of a Python software ecosystem developed by [Breakthrough


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
Add a Slack badge in README. Also modified the code of conduct one in order to highlight code of conduct with a single color and not two

### What the code is doing
N/A

### Testing
N/A

### Where to look
The header of the README

### Usage Example/Visuals
Before
<img width="824" alt="Screen Shot 2022-10-25 at 11 52 39 AM" src="https://user-images.githubusercontent.com/16549571/197857783-0daaf3fc-797f-488a-9a6b-6d5dc31a71ad.png">

After
<img width="824" alt="Screen Shot 2022-10-25 at 11 53 13 AM" src="https://user-images.githubusercontent.com/16549571/197857946-c2f668c5-7dd5-4fa6-b440-521957dd698f.png">

### Time estimate
2min
