### PR TITLE
Generalize generator type in MockProfileInput

### DIFF
--- a/powersimdata/tests/mock_profile_input.py
+++ b/powersimdata/tests/mock_profile_input.py
@@ -22,12 +22,6 @@ class MockProfileInput:
     :return: (*powersimdata.tests.mock_profile_input.MockProfileInput*)
     """
 
-    _RESOURCES = {
-        "wind": {"wind", "wind_offshore"},
-        "solar": {"solar"},
-        "hydro": {"hydro"},
-    }
-
     def __init__(
         self,
         grid: Grid,
@@ -38,6 +32,7 @@ class MockProfileInput:
         random_seed=6669,
     ):
         self._grid = grid
+        self._resources = grid.model_immutables.plants["group_profile_resources"]
         self._start_time = start_time
         self._end_time = end_time
         self._periods = periods
@@ -48,7 +43,7 @@ class MockProfileInput:
             "demand": self._get_demand(),
             **{
                 resource: self._get_resource_profile(resource)
-                for resource in self._RESOURCES.keys()
+                for resource in sorted(self._resources.keys(), reverse=True)
             },
         }
         self._profiles.update(self._get_demand_flexibility())
@@ -109,7 +104,7 @@ class MockProfileInput:
         :param str resource_type: Can be any of *'hydro'*, *'solar'*, or *'wind'*.
         :return: (*list*) -- list of plant_ids
         """
-        resources = self._RESOURCES[resource_type]
+        resources = self._resources[resource_type]
         plant_ids = list(self._grid.plant[lambda ds: ds.type.isin(resources)].index)
         return plant_ids
 


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
Generalize generator type in the `MockProfileInput` class by using information from the `model_immutables` attribute of the `Grid` object

### What the code is doing
Replace hard coded generator type with a dictionary grouping profile to generator type that is available through an attribute of a `Grid` object for all grid model

### Testing
Existing unit tests. To get the tests in the `powersimdata.tests.test_mock` module pass, I had to sort the keys in the `grid.model_immutables.plants["group_profile_resources"]` dictionary to mirror what was hard coded before to get the random numbers in `_random` assigned to the same profile. 

### Where to look
The `powersimdata.tests.mock_profile_input` module

### Usage Example/Visuals
N/A

### Time estimate
5min
