### PR TITLE
Port linearize_gencost and pmin modifications from REISE.jl

### DIFF
--- a/powersimdata/design/generation/cost_curves.py
+++ b/powersimdata/design/generation/cost_curves.py
@@ -74,7 +74,7 @@ def _linearize_gencost(gencost_before, plant, num_segments=1):
         gencost_after.loc[nondispatchable_gens, ["c2", "c1"]] = 0
         gencost_after.loc[nondispatchable_gens, "c0"] = price_data[nondispatchable_gens]
 
-    return gencost_after
+    return gencost_after.fillna(0)
 
 
 def linearize_gencost(input_grid, num_segments=1):

--- a/powersimdata/design/generation/cost_curves.py
+++ b/powersimdata/design/generation/cost_curves.py
@@ -3,82 +3,9 @@ import copy
 import numpy as np
 import pandas as pd
 
+from powersimdata.input.configure import linearize_gencost
 from powersimdata.input.grid import Grid
 from powersimdata.utility.helpers import _check_import
-
-
-def linearize_gencost(gencost_before, plant, num_segments=1):
-    """Updates the generator cost information to include piecewise linear cost curve
-    information. Allows the user to specify the number of piecewise segments into which
-    the cost curve should be split.
-
-    :param pandas.DataFrame gencost_before: the original gencost
-    :param pandas.DataFrame plant: the generator information containing Pmin/Pmax
-    :param int num_segments: The number of segments into which the piecewise linear
-        cost curve will be split.
-    :return: (*pandas.DataFrame*) -- An updated DataFrame containing the piecewise
-        linear cost curve parameters.
-    :raises ValueError: if the generator cost curve is not of an acceptable form.
-    """
-    # Raise errors if the provided cost curves are not in a form that can be handled
-    if len(gencost_before[gencost_before.type != 2]):
-        raise ValueError("gencost currently limited to polynomial")
-    if len(gencost_before[gencost_before.n != 3]):
-        raise ValueError("gencost currently limited to quadratic")
-
-    gencost_before = gencost_before.copy()
-    # Access the quadratic cost curve information
-    quad_term = gencost_before.c2
-    lin_term = gencost_before.c1
-    const_term = gencost_before.c0
-
-    # Convert dispatchable generators to piecewise segments
-    dispatchable_gens = plant.Pmin != plant.Pmax
-    if sum(dispatchable_gens) > 0:
-        gencost_after = pd.DataFrame(
-            index=gencost_before.index,
-            columns=["type", "startup", "shutdown", "n", "c2", "c1", "c0"],
-        )
-        gencost_after.loc[dispatchable_gens, "type"] = 1
-        gencost_after[["startup", "shutdown", "c2", "c1", "c0"]] = gencost_before[
-            ["startup", "shutdown", "c2", "c1", "c0"]
-        ]
-        gencost_after.loc[dispatchable_gens, "n"] = num_segments + 1
-        power_step = (plant.Pmax - plant.Pmin) / num_segments
-        for i in range(num_segments + 1):
-            capacity_label = "p" + str(i + 1)
-            price_label = "f" + str(i + 1)
-            capacity_data = plant.Pmin + power_step * i
-            price_data = (
-                quad_term * capacity_data**2 + lin_term * capacity_data + const_term
-            )
-            gencost_after.loc[dispatchable_gens, capacity_label] = capacity_data[
-                dispatchable_gens
-            ]
-            gencost_after.loc[dispatchable_gens, price_label] = price_data[
-                dispatchable_gens
-            ]
-    else:
-        gencost_after = gencost_before.copy()
-
-    # Convert non-dispatchable gens to fixed values
-    nondispatchable_gens = ~dispatchable_gens
-    if sum(nondispatchable_gens) > 0:
-        gencost_after.loc[nondispatchable_gens, "type"] = gencost_before.loc[
-            nondispatchable_gens, "type"
-        ]
-        gencost_after.loc[nondispatchable_gens, "n"] = gencost_before.loc[
-            nondispatchable_gens, "n"
-        ]
-        power = plant.Pmax
-        price_data = quad_term * power**2 + lin_term * power + const_term
-        gencost_after.loc[nondispatchable_gens, ["c2", "c1"]] = 0
-        gencost_after.loc[nondispatchable_gens, "c0"] = price_data[nondispatchable_gens]
-
-    if "interconnect" in gencost_before.columns:
-        gencost_after["interconnect"] = gencost_before["interconnect"]
-
-    return gencost_after.fillna(0)
 
 
 def get_supply_data(grid, num_segments=1, save=None):

--- a/powersimdata/design/generation/cost_curves.py
+++ b/powersimdata/design/generation/cost_curves.py
@@ -63,7 +63,7 @@ def linearize_gencost(input_grid, num_segments=1):
                 dispatchable_gens
             ]
     else:
-        grid.gencost["after"] = gencost_before.copy()
+        gencost_after = gencost_before.copy()
 
     # Convert non-dispatchable gens to fixed values
     nondispatchable_gens = ~dispatchable_gens

--- a/powersimdata/design/generation/cost_curves.py
+++ b/powersimdata/design/generation/cost_curves.py
@@ -7,7 +7,7 @@ from powersimdata.input.grid import Grid
 from powersimdata.utility.helpers import _check_import
 
 
-def linearize_gencost(gencost_before, plant, num_segments=1):
+def _linearize_gencost(gencost_before, plant, num_segments=1):
     """Updates the generator cost information to include piecewise linear cost curve
     information. Allows the user to specify the number of piecewise segments into which
     the cost curve should be split.
@@ -77,7 +77,7 @@ def linearize_gencost(gencost_before, plant, num_segments=1):
     return gencost_after
 
 
-def _linearize_gencost(input_grid, num_segments=1):
+def linearize_gencost(input_grid, num_segments=1):
     """Updates the generator cost information to include piecewise linear cost curve
     information. Allows the user to specify the number of piecewise segments into which
     the cost curve should be split.
@@ -92,7 +92,7 @@ def _linearize_gencost(input_grid, num_segments=1):
     # Access the generator cost and plant information components
     grid = copy.deepcopy(input_grid)
     gencost_before = grid.gencost["before"]
-    gencost_after = linearize_gencost(gencost_before, grid.plant, num_segments)
+    gencost_after = _linearize_gencost(gencost_before, grid.plant, num_segments)
     gencost_after["interconnect"] = gencost_before["interconnect"]
     return gencost_after
 
@@ -120,7 +120,7 @@ def get_supply_data(grid, num_segments=1, save=None):
     grid = copy.deepcopy(grid)
 
     # Access the generator cost and plant information data
-    gencost_df = _linearize_gencost(grid, num_segments)
+    gencost_df = linearize_gencost(grid, num_segments)
     plant_df = grid.plant
 
     # Create a new DataFrame with the desired columns

--- a/powersimdata/design/generation/tests/test_cost_curves.py
+++ b/powersimdata/design/generation/tests/test_cost_curves.py
@@ -198,6 +198,11 @@ expected_two_segment.f2 = [
 ]
 expected_two_segment["interconnect"] = expected_two_segment.pop("interconnect")
 
+expected_all_equal = mock_grid_gc.gencost["before"].copy()
+expected_all_equal.c2 = 0
+expected_all_equal.c1 = 0
+expected_all_equal.c0 = [2707, 20508, 68409]
+
 
 def test_linearize_gencost():
     actual = linearize_gencost(mock_grid_gc)
@@ -207,6 +212,14 @@ def test_linearize_gencost():
 def test_linearize_gencost_two_segment():
     actual = linearize_gencost(mock_grid_gc, num_segments=2)
     assert_frame_equal(expected_two_segment, actual, check_dtype=False)
+
+
+def test_linearize_gencost_pmin_equal_pmax():
+    plant = mock_grid_gc.plant.copy()
+    plant.Pmin = plant.Pmax
+    grid = MockGrid({"plant": plant.reset_index().to_dict(), "gencost_before": mock_gc})
+    actual = linearize_gencost(grid, num_segments=3)
+    assert_frame_equal(expected_all_equal, actual, check_dtype=False)
 
 
 def test_get_supply_data():

--- a/powersimdata/design/generation/tests/test_cost_curves.py
+++ b/powersimdata/design/generation/tests/test_cost_curves.py
@@ -2,10 +2,10 @@ import pandas as pd
 from pandas.testing import assert_frame_equal, assert_series_equal
 
 from powersimdata.design.generation.cost_curves import (
+    _linearize_gencost,
     build_supply_curve,
     get_supply_data,
     ks_test,
-    linearize_gencost,
     lower_bound_index,
 )
 from powersimdata.tests.mock_grid import MockGrid
@@ -205,12 +205,12 @@ expected_all_equal.c0 = [2707, 20508, 68409]
 
 
 def test_linearize_gencost():
-    actual = linearize_gencost(mock_grid_gc)
+    actual = _linearize_gencost(mock_grid_gc)
     assert_frame_equal(expected_one_segment, actual, check_dtype=False)
 
 
 def test_linearize_gencost_two_segment():
-    actual = linearize_gencost(mock_grid_gc, num_segments=2)
+    actual = _linearize_gencost(mock_grid_gc, num_segments=2)
     assert_frame_equal(expected_two_segment, actual, check_dtype=False)
 
 
@@ -218,7 +218,7 @@ def test_linearize_gencost_pmin_equal_pmax():
     plant = mock_grid_gc.plant.copy()
     plant.Pmin = plant.Pmax
     grid = MockGrid({"plant": plant.reset_index().to_dict(), "gencost_before": mock_gc})
-    actual = linearize_gencost(grid, num_segments=3)
+    actual = _linearize_gencost(grid, num_segments=3)
     assert_frame_equal(expected_all_equal, actual, check_dtype=False)
 
 

--- a/powersimdata/design/generation/tests/test_cost_curves.py
+++ b/powersimdata/design/generation/tests/test_cost_curves.py
@@ -2,10 +2,10 @@ import pandas as pd
 from pandas.testing import assert_frame_equal, assert_series_equal
 
 from powersimdata.design.generation.cost_curves import (
-    _linearize_gencost,
     build_supply_curve,
     get_supply_data,
     ks_test,
+    linearize_gencost,
     lower_bound_index,
 )
 from powersimdata.tests.mock_grid import MockGrid
@@ -205,12 +205,12 @@ expected_all_equal.c0 = [2707, 20508, 68409]
 
 
 def test_linearize_gencost():
-    actual = _linearize_gencost(mock_grid_gc)
+    actual = linearize_gencost(mock_grid_gc)
     assert_frame_equal(expected_one_segment, actual, check_dtype=False)
 
 
 def test_linearize_gencost_two_segment():
-    actual = _linearize_gencost(mock_grid_gc, num_segments=2)
+    actual = linearize_gencost(mock_grid_gc, num_segments=2)
     assert_frame_equal(expected_two_segment, actual, check_dtype=False)
 
 
@@ -218,7 +218,7 @@ def test_linearize_gencost_pmin_equal_pmax():
     plant = mock_grid_gc.plant.copy()
     plant.Pmin = plant.Pmax
     grid = MockGrid({"plant": plant.reset_index().to_dict(), "gencost_before": mock_gc})
-    actual = _linearize_gencost(grid, num_segments=3)
+    actual = linearize_gencost(grid, num_segments=3)
     assert_frame_equal(expected_all_equal, actual, check_dtype=False)
 
 

--- a/powersimdata/design/generation/tests/test_cost_curves.py
+++ b/powersimdata/design/generation/tests/test_cost_curves.py
@@ -1,11 +1,10 @@
 import pandas as pd
-from pandas.testing import assert_frame_equal, assert_series_equal
+from pandas.testing import assert_series_equal
 
 from powersimdata.design.generation.cost_curves import (
     build_supply_curve,
     get_supply_data,
     ks_test,
-    linearize_gencost,
     lower_bound_index,
 )
 from powersimdata.tests.mock_grid import MockGrid
@@ -141,90 +140,6 @@ grid_attrs = {"plant": mock_plant, "gencost_before": mock_gencost}
 grid = MockGrid(grid_attrs)
 grid.interconnect = "Western"
 grid.zone2id = {"Utah": 210, "Colorado": 212, "Washington": 201}
-
-mock_gc = {
-    "plant_id": range(3),
-    "type": [2, 2, 2],
-    "startup": [0, 0, 0],
-    "shutdown": [0, 0, 0],
-    "n": [3, 3, 3],
-    "c2": [1, 2, 3],
-    "c1": [4, 5, 6],
-    "c0": [7, 8, 9],
-    "interconnect": ["Western"] * 3,
-}
-mock_plant_gc = {"plant_id": range(3), "Pmin": [20, 40, 60], "Pmax": [50, 100, 150]}
-grid_attrs_gc = {
-    "plant": mock_plant_gc,
-    "gencost_before": mock_gc,
-}
-mock_grid_gc = MockGrid(grid_attrs_gc)
-
-expected_one_segment = pd.DataFrame(
-    {
-        "plant_id": range(3),
-        "type": [1, 1, 1],
-        "startup": [0, 0, 0],
-        "shutdown": [0, 0, 0],
-        "n": [2, 2, 2],
-        "c2": [1, 2, 3],
-        "c1": [4, 5, 6],
-        "c0": [7, 8, 9],
-        "p1": [20, 40, 60],
-        "f1": [
-            (1 * 20**2 + 4 * 20 + 7),
-            (2 * 40**2 + 5 * 40 + 8),
-            (3 * 60**2 + 6 * 60 + 9),
-        ],
-        "p2": [50, 100, 150],
-        "f2": [
-            (1 * 50**2 + 4 * 50 + 7),
-            (2 * 100**2 + 5 * 100 + 8),
-            (3 * 150**2 + 6 * 150 + 9),
-        ],
-        "interconnect": ["Western"] * 3,
-    }
-).set_index("plant_id")
-
-expected_two_segment = expected_one_segment.copy()
-expected_two_segment.n = 3
-expected_two_segment["p3"] = expected_one_segment["p2"].copy()
-expected_two_segment["f3"] = expected_one_segment["f2"].copy()
-expected_two_segment.p2 = [35, 70, 105]
-expected_two_segment.f2 = [
-    1 * 35**2 + 4 * 35 + 7,
-    2 * 70**2 + 5 * 70 + 8,
-    3 * 105**2 + 6 * 105 + 9,
-]
-expected_two_segment["interconnect"] = expected_two_segment.pop("interconnect")
-
-expected_all_equal = mock_grid_gc.gencost["before"].copy()
-expected_all_equal.c2 = 0
-expected_all_equal.c1 = 0
-expected_all_equal.c0 = [2707, 20508, 68409]
-
-
-def _linearize_gencost(grid, num_segments=1):
-    before = grid.gencost["before"]
-    return linearize_gencost(before, grid.plant, num_segments)
-
-
-def test_linearize_gencost():
-    actual = _linearize_gencost(mock_grid_gc)
-    assert_frame_equal(expected_one_segment, actual, check_dtype=False)
-
-
-def test_linearize_gencost_two_segment():
-    actual = _linearize_gencost(mock_grid_gc, num_segments=2)
-    assert_frame_equal(expected_two_segment, actual, check_dtype=False)
-
-
-def test_linearize_gencost_pmin_equal_pmax():
-    plant = mock_grid_gc.plant.copy()
-    plant.Pmin = plant.Pmax
-    grid = MockGrid({"plant": plant.reset_index().to_dict(), "gencost_before": mock_gc})
-    actual = _linearize_gencost(grid, num_segments=3)
-    assert_frame_equal(expected_all_equal, actual, check_dtype=False)
 
 
 def test_get_supply_data():

--- a/powersimdata/design/generation/tests/test_cost_curves.py
+++ b/powersimdata/design/generation/tests/test_cost_curves.py
@@ -204,13 +204,18 @@ expected_all_equal.c1 = 0
 expected_all_equal.c0 = [2707, 20508, 68409]
 
 
+def _linearize_gencost(grid, num_segments=1):
+    before = grid.gencost["before"]
+    return linearize_gencost(before, grid.plant, num_segments)
+
+
 def test_linearize_gencost():
-    actual = linearize_gencost(mock_grid_gc)
+    actual = _linearize_gencost(mock_grid_gc)
     assert_frame_equal(expected_one_segment, actual, check_dtype=False)
 
 
 def test_linearize_gencost_two_segment():
-    actual = linearize_gencost(mock_grid_gc, num_segments=2)
+    actual = _linearize_gencost(mock_grid_gc, num_segments=2)
     assert_frame_equal(expected_two_segment, actual, check_dtype=False)
 
 
@@ -218,7 +223,7 @@ def test_linearize_gencost_pmin_equal_pmax():
     plant = mock_grid_gc.plant.copy()
     plant.Pmin = plant.Pmax
     grid = MockGrid({"plant": plant.reset_index().to_dict(), "gencost_before": mock_gc})
-    actual = linearize_gencost(grid, num_segments=3)
+    actual = _linearize_gencost(grid, num_segments=3)
     assert_frame_equal(expected_all_equal, actual, check_dtype=False)
 
 

--- a/powersimdata/input/configure.py
+++ b/powersimdata/input/configure.py
@@ -1,0 +1,124 @@
+import numpy as np
+import pandas as pd
+
+
+def adjust_pmin(grid):
+    """Adjust plant Pmin values inplace
+
+    :param powersimdata.input.grid.Grid grid: a grid object
+    """
+    mi = grid.model_immutables
+    plant = grid.plant
+    pmin_factor = mi.plants["pmin_as_share_of_pmax"]
+
+    def _scale(x):
+        factor = pmin_factor.get(x.type)
+        return x.Pmin if factor is None else factor * x.Pmax
+
+    plant.Pmin = plant.apply(_scale, axis=1)
+
+    # set Pmin to 0 for generators that are off or profile based
+    profile_resource = list(mi.plants["profile_resources"])
+    plant.loc[plant.type.isin(profile_resource), "Pmin"] = 0
+    plant.loc[plant.status == 0, "Pmin"] = 0
+
+
+def adjust_ramp30(plant):
+    """Adjust plant ramp_30 values inplace
+
+    :param pandas.DataDrame plant: a plant dataframe
+    """
+    plant.ramp_30 = np.inf
+    ramp30_points = {
+        "coal": {"xs": (200, 1400), "ys": (0.4, 0.15)},
+        "dfo": {"xs": (200, 1200), "ys": (0.5, 0.2)},
+        "ng": {"xs": (200, 600), "ys": (0.5, 0.2)},
+    }
+    for fuel, points in ramp30_points.items():
+        fuel_idx = plant.loc[plant.type == fuel, "Pmax"]
+        slope = (points["ys"][1] - points["ys"][0]) / (
+            points["xs"][1] - points["xs"][0]
+        )
+        intercept = points["ys"][0] - slope * points["xs"][0]
+        for idx in fuel_idx.index:
+            pmax = fuel_idx.at[idx]
+            norm_ramp = pmax * slope + intercept
+            if pmax < points["xs"][0]:
+                norm_ramp = points["ys"][0]
+            if pmax > points["xs"][1]:
+                norm_ramp = points["ys"][1]
+            plant.loc[idx, "ramp_30"] = norm_ramp * pmax
+
+
+def linearize_gencost(gencost_before, plant, num_segments=1):
+    """Updates the generator cost information to include piecewise linear cost curve
+    information. Allows the user to specify the number of piecewise segments into which
+    the cost curve should be split.
+
+    :param pandas.DataFrame gencost_before: the original gencost
+    :param pandas.DataFrame plant: the generator information containing Pmin/Pmax
+    :param int num_segments: The number of segments into which the piecewise linear
+        cost curve will be split.
+    :return: (*pandas.DataFrame*) -- An updated DataFrame containing the piecewise
+        linear cost curve parameters.
+    :raises ValueError: if the generator cost curve is not of an acceptable form.
+    """
+    # Raise errors if the provided cost curves are not in a form that can be handled
+    if len(gencost_before[gencost_before.type != 2]):
+        raise ValueError("gencost currently limited to polynomial")
+    if len(gencost_before[gencost_before.n != 3]):
+        raise ValueError("gencost currently limited to quadratic")
+
+    gencost_before = gencost_before.copy()
+    # Access the quadratic cost curve information
+    quad_term = gencost_before.c2
+    lin_term = gencost_before.c1
+    const_term = gencost_before.c0
+
+    # Convert dispatchable generators to piecewise segments
+    dispatchable_gens = plant.Pmin != plant.Pmax
+    if sum(dispatchable_gens) > 0:
+        gencost_after = pd.DataFrame(
+            index=gencost_before.index,
+            columns=["type", "startup", "shutdown", "n", "c2", "c1", "c0"],
+        )
+        gencost_after.loc[dispatchable_gens, "type"] = 1
+        gencost_after[["startup", "shutdown", "c2", "c1", "c0"]] = gencost_before[
+            ["startup", "shutdown", "c2", "c1", "c0"]
+        ]
+        gencost_after.loc[dispatchable_gens, "n"] = num_segments + 1
+        power_step = (plant.Pmax - plant.Pmin) / num_segments
+        for i in range(num_segments + 1):
+            capacity_label = "p" + str(i + 1)
+            price_label = "f" + str(i + 1)
+            capacity_data = plant.Pmin + power_step * i
+            price_data = (
+                quad_term * capacity_data**2 + lin_term * capacity_data + const_term
+            )
+            gencost_after.loc[dispatchable_gens, capacity_label] = capacity_data[
+                dispatchable_gens
+            ]
+            gencost_after.loc[dispatchable_gens, price_label] = price_data[
+                dispatchable_gens
+            ]
+    else:
+        gencost_after = gencost_before.copy()
+
+    # Convert non-dispatchable gens to fixed values
+    nondispatchable_gens = ~dispatchable_gens
+    if sum(nondispatchable_gens) > 0:
+        gencost_after.loc[nondispatchable_gens, "type"] = gencost_before.loc[
+            nondispatchable_gens, "type"
+        ]
+        gencost_after.loc[nondispatchable_gens, "n"] = gencost_before.loc[
+            nondispatchable_gens, "n"
+        ]
+        power = plant.Pmax
+        price_data = quad_term * power**2 + lin_term * power + const_term
+        gencost_after.loc[nondispatchable_gens, ["c2", "c1"]] = 0
+        gencost_after.loc[nondispatchable_gens, "c0"] = price_data[nondispatchable_gens]
+
+    if "interconnect" in gencost_before.columns:
+        gencost_after["interconnect"] = gencost_before["interconnect"]
+
+    return gencost_after.fillna(0)

--- a/powersimdata/input/input_data.py
+++ b/powersimdata/input/input_data.py
@@ -14,7 +14,7 @@ class InputData(InputBase):
 
     def __init__(self):
         super().__init__()
-        self._file_extension = {"ct": "pkl", "grid": "mat"}
+        self._file_extension = {"ct": "pkl", "grid": "pkl"}
         self.data_access = Context.get_data_access(get_scenario_fs)
 
     def _get_file_path(self, scenario_info, field_name):
@@ -40,9 +40,6 @@ class InputData(InputBase):
         ext = os.path.basename(path).split(".")[-1]
         if ext == "pkl":
             data = pd.read_pickle(f)
-        elif ext == "mat":
-            # get fully qualified local path to matfile
-            data = os.path.abspath(path)
         else:
             raise ValueError("Unknown extension! %s" % ext)
 

--- a/powersimdata/input/tests/test_configure.py
+++ b/powersimdata/input/tests/test_configure.py
@@ -1,0 +1,89 @@
+import pandas as pd
+from pandas.testing import assert_frame_equal
+
+from powersimdata.input.configure import linearize_gencost
+from powersimdata.tests.mock_grid import MockGrid
+
+mock_gc = {
+    "plant_id": range(3),
+    "type": [2, 2, 2],
+    "startup": [0, 0, 0],
+    "shutdown": [0, 0, 0],
+    "n": [3, 3, 3],
+    "c2": [1, 2, 3],
+    "c1": [4, 5, 6],
+    "c0": [7, 8, 9],
+    "interconnect": ["Western"] * 3,
+}
+mock_plant_gc = {"plant_id": range(3), "Pmin": [20, 40, 60], "Pmax": [50, 100, 150]}
+grid_attrs_gc = {
+    "plant": mock_plant_gc,
+    "gencost_before": mock_gc,
+}
+mock_grid_gc = MockGrid(grid_attrs_gc)
+
+expected_one_segment = pd.DataFrame(
+    {
+        "plant_id": range(3),
+        "type": [1, 1, 1],
+        "startup": [0, 0, 0],
+        "shutdown": [0, 0, 0],
+        "n": [2, 2, 2],
+        "c2": [1, 2, 3],
+        "c1": [4, 5, 6],
+        "c0": [7, 8, 9],
+        "p1": [20, 40, 60],
+        "f1": [
+            (1 * 20**2 + 4 * 20 + 7),
+            (2 * 40**2 + 5 * 40 + 8),
+            (3 * 60**2 + 6 * 60 + 9),
+        ],
+        "p2": [50, 100, 150],
+        "f2": [
+            (1 * 50**2 + 4 * 50 + 7),
+            (2 * 100**2 + 5 * 100 + 8),
+            (3 * 150**2 + 6 * 150 + 9),
+        ],
+        "interconnect": ["Western"] * 3,
+    }
+).set_index("plant_id")
+
+expected_two_segment = expected_one_segment.copy()
+expected_two_segment.n = 3
+expected_two_segment["p3"] = expected_one_segment["p2"].copy()
+expected_two_segment["f3"] = expected_one_segment["f2"].copy()
+expected_two_segment.p2 = [35, 70, 105]
+expected_two_segment.f2 = [
+    1 * 35**2 + 4 * 35 + 7,
+    2 * 70**2 + 5 * 70 + 8,
+    3 * 105**2 + 6 * 105 + 9,
+]
+expected_two_segment["interconnect"] = expected_two_segment.pop("interconnect")
+
+expected_all_equal = mock_grid_gc.gencost["before"].copy()
+expected_all_equal.c2 = 0
+expected_all_equal.c1 = 0
+expected_all_equal.c0 = [2707, 20508, 68409]
+
+
+def _linearize_gencost(grid, num_segments=1):
+    before = grid.gencost["before"]
+    return linearize_gencost(before, grid.plant, num_segments)
+
+
+def test_linearize_gencost():
+    actual = _linearize_gencost(mock_grid_gc)
+    assert_frame_equal(expected_one_segment, actual, check_dtype=False)
+
+
+def test_linearize_gencost_two_segment():
+    actual = _linearize_gencost(mock_grid_gc, num_segments=2)
+    assert_frame_equal(expected_two_segment, actual, check_dtype=False)
+
+
+def test_linearize_gencost_pmin_equal_pmax():
+    plant = mock_grid_gc.plant.copy()
+    plant.Pmin = plant.Pmax
+    grid = MockGrid({"plant": plant.reset_index().to_dict(), "gencost_before": mock_gc})
+    actual = _linearize_gencost(grid, num_segments=3)
+    assert_frame_equal(expected_all_equal, actual, check_dtype=False)

--- a/powersimdata/input/tests/test_input_data.py
+++ b/powersimdata/input/tests/test_input_data.py
@@ -10,7 +10,7 @@ def test_get_file_components():
     ct_file = _input_data._get_file_path(s_info, "ct")
     grid_file = _input_data._get_file_path(s_info, "grid")
     assert "data/input/123_ct.pkl" == ct_file
-    assert "data/input/123_grid.mat" == grid_file
+    assert "data/input/123_grid.pkl" == grid_file
 
 
 def test_check_field():

--- a/powersimdata/scenario/analyze.py
+++ b/powersimdata/scenario/analyze.py
@@ -58,9 +58,7 @@ class Analyze(Ready):
     def _set_ct_and_grid(self):
         """Sets change table and grid."""
         input_data = InputData()
-        grid_path = input_data.get_data(self._scenario_info, "grid")
-        with open(grid_path, "rb") as f:
-            self.grid = pickle.load(f)
+        self.grid = input_data.get_data(self._scenario_info, "grid")
 
         if self._scenario_info["change_table"] == "Yes":
             self.ct = input_data.get_data(self._scenario_info, "ct")

--- a/powersimdata/scenario/analyze.py
+++ b/powersimdata/scenario/analyze.py
@@ -3,7 +3,6 @@ import pickle
 
 import pandas as pd
 
-from powersimdata.input.grid import Grid
 from powersimdata.input.input_data import InputData
 from powersimdata.input.transform_profile import TransformProfile
 from powersimdata.output.output_data import OutputData, construct_load_shed
@@ -59,12 +58,9 @@ class Analyze(Ready):
     def _set_ct_and_grid(self):
         """Sets change table and grid."""
         input_data = InputData()
-        grid_mat_path = input_data.get_data(self._scenario_info, "grid")
-        self.grid = Grid(
-            interconnect=[None],
-            source=grid_mat_path,
-            engine=self._scenario_info["engine"],
-        )
+        grid_path = input_data.get_data(self._scenario_info, "grid")
+        with open(grid_path, "rb") as f:
+            self.grid = pickle.load(f)
 
         if self._scenario_info["change_table"] == "Yes":
             self.ct = input_data.get_data(self._scenario_info, "ct")

--- a/powersimdata/scenario/execute.py
+++ b/powersimdata/scenario/execute.py
@@ -3,10 +3,7 @@ import pickle
 import pandas as pd
 
 from powersimdata.data_access.context import Context
-from powersimdata.design.generation.cost_curves import (
-    _linearize_gencost,
-    linearize_gencost,
-)
+from powersimdata.design.generation.cost_curves import linearize_gencost
 from powersimdata.input.grid import Grid
 from powersimdata.input.input_data import InputData
 from powersimdata.input.transform_grid import TransformGrid
@@ -227,9 +224,10 @@ class SimulationInput:
         """Prepare grid for simulation."""
         print("--> Preparing grid data")
         self._adjust_pmin()
-        storage = self.grid.storage
-        self.grid.gencost["after"] = linearize_gencost(self.grid)
-        storage["gencost"] = _linearize_gencost(storage["gencost"], storage["gen"])
+        grid = self.grid
+        storage = grid.storage
+        grid.gencost["after"] = linearize_gencost(grid.gencost["before"], grid.plant)
+        storage["gencost"] = linearize_gencost(storage["gencost"], storage["gen"])
 
         dest_path = "/".join([self.REL_TMP_DIR, "grid.pkl"])
         with self._data_access.write(dest_path, save_local=False) as f:

--- a/powersimdata/scenario/execute.py
+++ b/powersimdata/scenario/execute.py
@@ -3,7 +3,10 @@ import pickle
 import pandas as pd
 
 from powersimdata.data_access.context import Context
-from powersimdata.design.generation.cost_curves import linearize_gencost
+from powersimdata.design.generation.cost_curves import (
+    _linearize_gencost,
+    linearize_gencost,
+)
 from powersimdata.input.grid import Grid
 from powersimdata.input.input_data import InputData
 from powersimdata.input.transform_grid import TransformGrid
@@ -221,10 +224,9 @@ class SimulationInput:
         """Prepare grid for simulation."""
         print("--> Preparing grid data")
         self._adjust_pmin()
-        grid = self.grid
-        storage = grid.storage
-        grid.gencost["after"] = linearize_gencost(grid.gencost["before"], grid.plant)
-        storage["gencost"] = linearize_gencost(storage["gencost"], storage["gen"])
+        storage = self.grid.storage
+        self.grid.gencost["after"] = linearize_gencost(self.grid)
+        storage["gencost"] = _linearize_gencost(storage["gencost"], storage["gen"])
 
         dest_path = "/".join([self.REL_TMP_DIR, "grid.pkl"])
         with self._data_access.write(dest_path, save_local=False) as f:

--- a/powersimdata/scenario/execute.py
+++ b/powersimdata/scenario/execute.py
@@ -221,7 +221,10 @@ class SimulationInput:
         """Prepare grid for simulation."""
         print("--> Preparing grid data")
         self._adjust_pmin()
-        self.grid.gencost["after"] = linearize_gencost(self.grid)
+        grid = self.grid
+        storage = grid.storage
+        grid.gencost["after"] = linearize_gencost(grid.gencost["before"], grid.plant)
+        storage["gencost"] = linearize_gencost(storage["gencost"], storage["gen"])
 
         dest_path = "/".join([self.REL_TMP_DIR, "grid.pkl"])
         with self._data_access.write(dest_path, save_local=False) as f:

--- a/powersimdata/scenario/execute.py
+++ b/powersimdata/scenario/execute.py
@@ -210,10 +210,13 @@ class SimulationInput:
     def _adjust_pmin(self):
         mi = self.grid.model_immutables
         plant = self.grid.plant
-        pmin_factor = {
-            k: v for k, v in mi.plants["pmin_as_share_of_pmax"].items() if v is not None
-        }
-        plant.Pmin = plant.apply(lambda x: pmin_factor.get(x.type, 1) * x.Pmax, axis=1)
+        pmin_factor = mi.plants["pmin_as_share_of_pmax"]
+
+        def _scale(x):
+            factor = pmin_factor.get(x.type)
+            return x.Pmin if factor is None else factor * x.Pmax
+
+        plant.Pmin = plant.apply(_scale, axis=1)
 
         # set Pmin to 0 for generators that are off or profile based
         profile_resource = list(mi.plants["profile_resources"])


### PR DESCRIPTION
### Purpose
To facilitate using a grid.pkl and remove the need for mapping between a case.mat/grid.mat/etc, we move grid modifications previously done in REISE.jl to the scenario preparation process. 

This PR should be merged at the same time as https://github.com/Breakthrough-Energy/REISE.jl/pull/187, after which we should update the existing grid.mat files. I believe we also need to update the ramp30 values in plant.csv as discussed in this issue https://github.com/Breakthrough-Energy/PowerSimData/issues/680 and release a new dataset on zenodo.

### What the code is doing
Scale plant Pmin values and linearize cost curves the same way we were doing in REISE.jl - after we apply the change table, and just before we upload the grid.pkl to the server (or, container, or wherever). I also ported the linearize_gencost tests from julia since those will be unused/deleted.

### Testing
Ran a scenario in a container and reloaded it after it finished for some cursory spot checking.

### Time estimate
20 min
