### PR TITLE
Generalize area type in check function

### DIFF
--- a/powersimdata/input/check.py
+++ b/powersimdata/input/check.py
@@ -300,11 +300,11 @@ def _check_grid_type(grid):
 
 
 def _check_areas_and_format(areas, mi=None):
-    """Ensure that areas are valid. Duplicates are removed and state abbreviations are
-    converted to their actual name.
+    """Ensure that areas are valid. Duplicates are removed and state/country
+    abbreviations are converted to their actual name.
 
     :param str/list/tuple/set areas: areas(s) to check. Could be load zone name(s),
-        state name(s)/abbreviation(s) or interconnect(s).
+        state/country name(s)/abbreviation(s) or interconnect(s).
     :param powersimdata.network.model.ModelImmutables mi: immutables of a grid model.
     :raises TypeError: if ``areas`` is not a list/tuple/set of str.
     :raises ValueError: if ``areas`` is empty or not valid.
@@ -366,6 +366,7 @@ def _check_resources_and_format(resources, mi=None):
 def _check_resources_are_renewable_and_format(resources, mi=None):
     """Ensure that resources are valid renewable resources and convert variable to
     a set.
+
     :param powersimdata.network.model.ModelImmutables mi: immutables of a grid model.
     :param str/list/tuple/set resources: resource(s) to analyze.
     :raises ValueError: if resources are not renewables.
@@ -383,24 +384,25 @@ def _check_resources_are_renewable_and_format(resources, mi=None):
 def _check_areas_are_in_grid_and_format(areas, grid):
     """Ensure that list of areas are in grid.
 
-    :param dict areas: keys are area types: '*loadzone*', '*state*' or '*interconnect*'.
-        Values are str/list/tuple/set of areas.
+    :param dict areas: keys are area types: '*loadzone*', '*state*'/'*country*'' or
+        '*interconnect*'. Values are str/list/tuple/set of areas.
     :param powersimdata.input.grid.Grid grid: Grid instance.
     :return: (*dict*) -- modified areas dictionary. Keys are area types ('*loadzone*',
-        '*state*' or '*interconnect*'). State abbreviations, if present, are converted
-        to state names. Values are areas as a set.
+        '*state*'/'*country*' or '*interconnect*'). State abbreviations, if present,
+        are converted to state names. Values are areas as a set.
     :raises TypeError: if areas is not a dict or its keys are not str.
-    :raises ValueError: if area type is invalid, an area in not in grid or an
-        invalid loadzone/state/interconnect is passed.
+    :raises ValueError: if area type is invalid, an area in not in ``grid`` or an
+        invalid loadzone, state/country or interconnect is passed.
     """
     _check_grid_type(grid)
     if not isinstance(areas, dict):
         raise TypeError("areas must be a dict")
 
     mi = grid.model_immutables
+    division_type = mi.zones["division"]
     areas_formatted = {}
     for a in areas.keys():
-        if a in ["loadzone", "state", "interconnect"]:
+        if a in ["loadzone", division_type, "interconnect"]:
             areas_formatted[a] = set()
 
     all_loadzones = set()
@@ -415,14 +417,14 @@ def _check_areas_are_in_grid_and_format(areas, grid):
                 except KeyError:
                     raise ValueError("invalid interconnect: %s" % i)
             areas_formatted["interconnect"].update(interconnects)
-        elif k == "state":
-            states = _check_areas_and_format(v, mi)
-            for s in states:
+        elif k == division_type:
+            divisions = _check_areas_and_format(v, mi)
+            for s in divisions:
                 try:
-                    all_loadzones.update(mi.zones["state2loadzone"][s])
+                    all_loadzones.update(mi.zones[f"{division_type}2loadzone"][s])
                 except KeyError:
-                    raise ValueError("invalid state: %s" % s)
-            areas_formatted["state"].update(states)
+                    raise ValueError(f"invalid {division_type}: %s" % s)
+            areas_formatted[division_type].update(divisions)
         elif k == "loadzone":
             loadzones = _check_areas_and_format(v, mi)
             for l in loadzones:


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
Generalize area type type in check function so we can check for the european model that a given list of countries are in the grid.

### What the code is doing
Replace hard coded `state` by the `grid.model_immutables.zones["diivision"]` string that gives the division type (state or country so far) for a grid model

### Testing
Existing unit tests

### Where to look
Look at the `_check_areas_are_in_grid_and_format` functions. Other modifications are docstring improvements

### Usage Example/Visuals
N/A

### Time estimate
2min
