### PR TITLE
fix: set bus_id index name

### DIFF
--- a/powersimdata/input/transform_grid.py
+++ b/powersimdata/input/transform_grid.py
@@ -276,7 +276,7 @@ class TransformGrid:
             lat, lon = entry["lat"], entry["lon"]
             new_bus["lat"] = lat
             new_bus["lon"] = lon
-            new_bus_index = [self.grid.bus.index.max() + 1]
+            new_bus_index = pd.Index([self.grid.bus.index.max() + 1], name="bus_id")
             self.grid.bus = pd.concat(
                 [self.grid.bus, pd.DataFrame(new_bus, index=new_bus_index)]
             )


### PR DESCRIPTION
### Purpose
Fix error when we add buses, e.g. via the demo_western.py script in plug. Without the index name, the grid.pkl used in call.py cannot be exported to csv. This should address the issue from the community slack.

### What the code is doing
Add the index name for bus data frame. We already had this for the other ones but since it was tested with the demo_texas script, which doesn't transform buses, the error didn't occur.

### Testing
Ran a simulation using the western demo and didn't have the error anymore.

### Time estimate
2 min
