### PR TITLE
chore: add pypsa to install_requires

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -32,6 +32,7 @@ install_requires =
     fs==2.4.14
     fs.sshfs
     fs-azureblob>=0.2.1
+    pypsa
 
 [options.package_data]
 powersimdata =


### PR DESCRIPTION
### Purpose
Currently pypsa isn't installed after doing `pip install powersimdata` or `pip install postreise` which causes import errors.

### What the code is doing
Add pypsa to list of packages installed via pip.

### Testing
n/a

### Time estimate
1 min
