### PR TITLE
Enable workflow for europe_tub grid model

### DIFF
--- a/powersimdata/data_access/tests/test_scenario_csv.py
+++ b/powersimdata/data_access/tests/test_scenario_csv.py
@@ -36,6 +36,7 @@ def test_get_scenario_file_from_server_header(data_access, scenario_table):
         "name",
         "state",
         "grid_model",
+        "grid_model_version",
         "interconnect",
         "base_demand",
         "base_hydro",
@@ -77,6 +78,7 @@ def mock_row():
             ("name", "dummy"),
             ("state", "create"),
             ("grid_model", ""),
+            ("grid_model_version", ""),
             ("interconnect", "Western"),
             ("base_demand", ""),
             ("base_hydro", ""),
@@ -95,7 +97,7 @@ def test_blank_csv_append(manager):
     entry = mock_row()
     table = manager.add_entry(entry)
     assert entry["id"] == "1"
-    assert table.shape == (1, 16)
+    assert table.shape == (1, 17)
 
 
 def test_get_scenario(manager):
@@ -113,4 +115,4 @@ def test_delete_entry(manager):
     manager.add_entry(mock_row())
     manager.add_entry(mock_row())
     table = manager.delete_entry(2)
-    assert table.shape == (2, 16)
+    assert table.shape == (2, 17)

--- a/powersimdata/input/converter/pypsa_to_grid.py
+++ b/powersimdata/input/converter/pypsa_to_grid.py
@@ -332,8 +332,8 @@ class FromPyPSA(AbstractGrid):
             gen_inflow["p_nom_extendable"] = False
             gen_inflow["committable"] = False
             gen_inflow["type"] = "inflow"
-            gen_inflow["lat"] = gen_inflow.bus_id.map(bus.lat)
-            gen_inflow["lon"] = gen_inflow.bus_id.map(bus.lon)
+            gen_inflow["lat"] = gen_inflow.bus_id.map(bus_inflow.lat)
+            gen_inflow["lon"] = gen_inflow.bus_id.map(bus_inflow.lon)
             gen_inflow = gen_inflow.reindex(columns=plant.columns)
             gencost_inflow = storage_gencost_storageunits[has_inflow].rename(
                 index=add_suffix

--- a/powersimdata/input/converter/pypsa_to_grid.py
+++ b/powersimdata/input/converter/pypsa_to_grid.py
@@ -147,6 +147,8 @@ class FromPyPSA(AbstractGrid):
             self.interconnect = self.network.name.split(", ")
 
     def _set_data_loc(self):
+        if self.data_loc is not None:
+            return
         if len(self.interconnect) > 1:
             self.data_loc = self.interconnect[0]
         else:

--- a/powersimdata/input/grid.py
+++ b/powersimdata/input/grid.py
@@ -63,6 +63,7 @@ class Grid:
         self.storage = network.storage
         self.grid_model = network.grid_model
         self.model_immutables = network.model_immutables
+        self.version = getattr(network, "version", None)
 
         _cache.put(key, network)
 
@@ -70,6 +71,7 @@ class Grid:
         result = self.__class__.__name__
         result += f"\ninterconnect: {self.interconnect}\n"
         result += f"model: {self.model_immutables.model}\n"
+        result += f"model version: {self.version}\n"
         result += f"data_loc: {self.data_loc}\n"
         df_name = ["sub", "plant", "dcline", "bus2sub", "bus", "branch"]
         for n in df_name:

--- a/powersimdata/network/europe_tub/model.py
+++ b/powersimdata/network/europe_tub/model.py
@@ -23,7 +23,7 @@ class PyPSABase(FromPyPSA):
         Grid object data frames.
     """
 
-    def __init__(self, interconnect, grid_model, network, add_pypsa_cols=True):
+    def __init__(self, interconnect, grid_model, network=None, add_pypsa_cols=True):
         """Constructor."""
         super().__init__(network, add_pypsa_cols)
         self.grid_model = grid_model
@@ -84,8 +84,8 @@ class TUB(PyPSABase):
     """
 
     def __init__(self, interconnect, zenodo_record_id=None, reduction=None):
-        network = self.from_zenodo(zenodo_record_id, reduction)
-        super().__init__(interconnect, "europe_tub", network)
+        super().__init__(interconnect, "europe_tub")
+        self.network = self.from_zenodo(zenodo_record_id, reduction)
 
     def from_zenodo(self, zenodo_record_id, reduction):
         """Create network from zenodo data

--- a/powersimdata/network/europe_tub/model.py
+++ b/powersimdata/network/europe_tub/model.py
@@ -105,6 +105,7 @@ class TUB(PyPSABase):
 
         z.load_data(os.path.dirname(__file__))
         self.data_loc = os.path.join(z.dir, "networks")
+        self.version = z.version
         return self._get_network(reduction)
 
     def _get_network(self, reduction):

--- a/powersimdata/network/zenodo.py
+++ b/powersimdata/network/zenodo.py
@@ -39,9 +39,10 @@ class Zenodo:
 
         content = json.loads(r.text)
         metadata = content["metadata"]
+        self.version = metadata["version"]
         print(f"Title: {metadata['title']}")
         print(f"Publication date: {metadata['publication_date']}")
-        print(f"Version: {metadata['version']}")
+        print(f"Version: {self.version}")
         print(f"DOI: {metadata['doi']}")
 
         return content

--- a/powersimdata/utility/templates/ScenarioList.csv
+++ b/powersimdata/utility/templates/ScenarioList.csv
@@ -1,1 +1,1 @@
-id,plan,name,state,grid_model,interconnect,base_demand,base_hydro,base_solar,base_wind,change_table,start_date,end_date,interval,engine,runtime,infeasibilities
+id,plan,name,state,grid_model,grid_model_version,interconnect,base_demand,base_hydro,base_solar,base_wind,change_table,start_date,end_date,interval,engine,runtime,infeasibilities


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
Add workflow to run scenario in PyPSA-Eur grid model.

### What the code is doing
* Modify schema of ScenarioList. A new `grid_model_version` field is added that will track the version of the files downloaded from Zenodo. Only applies to `europe_tub` grid model. New scenario for `usa_tamu` will have an empty entry. 
* Instantiate a European grid through `set_grid` (UI) as shown in the example below and set the version of the profiles based on the version of the network and the reduction parameter 

### Testing
Existing unit tests

### Where to look
Most of the code is in `powersimdata.scenario.create`. Some tweaks in other modules where necessary to be able to access the network version and correctly set the `data_loc` attribute of the `Grid` object

### Usage Example/Visuals
```
>>> from powersimdata import Scenario
>>> s = Scenario()
Could not connect to ssh server
Initialized remote filesystem with scenario_fs
>>> s.set_grid(grid_model="europe_tub", interconnect="ContinentalEurope", reduction=128, zenodo_record_id="3601881")
Transferring ScenarioList.csv.2 from scenario_fs
--> Begin: Existing Study
Nothing yet
<-- End: Existing Study
Title: PyPSA-Eur: An Open Optimisation Model of the European Transmission System (Dataset)
Publication date: 2022-09-20
Version: v0.6.1
DOI: 10.5281/zenodo.7251657
networks.zip has been downloaded previously
WARNING:pypsa.io:Importing network from PyPSA version v0.20.0 while current version is v0.21.2. Read the release notes at https://pypsa.readthedocs.io/en/latest/release_notes.html to prepare your network for import.
INFO:pypsa.io:Imported network elec_s_128_ec.nc has buses, carriers, generators, lines, links, loads, storage_units, stores
>>> grid = s.get_base_grid()
>>> grid.version
'v0.6.1'
>>> grid.data_loc
'/Users/brdo/CEM/PowerSimData/powersimdata/network/europe_tub/data_v0.6.1/networks'
>>> grid.plant.head()
                 bus_id  Pg  Qg  Qmax  ...  pypsa_ramp_limit_up  pypsa_ramp_limit_down  pypsa_ramp_limit_start_up  pypsa_ramp_limit_shut_down
plant_id                               ...                                                                                                   
AL1 0 offwind-ac  AL1 0 NaN NaN   NaN  ...                  NaN                    NaN                        1.0                         1.0
AL1 0 oil         AL1 0 NaN NaN   NaN  ...                  NaN                    NaN                        1.0                         1.0
AL1 0 onwind      AL1 0 NaN NaN   NaN  ...                  NaN                    NaN                        1.0                         1.0
AL1 0 ror         AL1 0 NaN NaN   NaN  ...                  NaN                    NaN                        1.0                         1.0
AL1 0 solar       AL1 0 NaN NaN   NaN  ...                  NaN                    NaN                        1.0                         1.0

[5 rows x 63 columns]
```

### Time estimate
20min
