### PR TITLE
Change load zone definition

### DIFF
--- a/powersimdata/network/europe_tub/model.py
+++ b/powersimdata/network/europe_tub/model.py
@@ -32,7 +32,7 @@ class PyPSABase(FromPyPSA):
         )
 
     def build_eur(self):
-        self.id2zone = {i: l for i, l in enumerate(self.network.buses.index)}
+        self.id2zone = {i: l for i, l in enumerate(self.network.loads.index)}
         self.zone2id = {l: i for i, l in self.id2zone.items()}
 
         if self.interconnect != ["Europe"]:
@@ -45,11 +45,11 @@ class PyPSABase(FromPyPSA):
             self.network = self.network[
                 self.network.buses.query("country == @filter").index
             ]
-            self.zone2id = {l: self.zone2id[l] for l in self.network.buses.index}
+            self.zone2id = {l: self.zone2id[l] for l in self.network.loads.index}
             self.id2zone = {i: l for l, i in self.zone2id.items()}
 
         zone = (
-            self.network.buses["country"]
+            self.network.buses.loc[self.network.loads["bus"]]["country"]
             .reset_index()
             .set_axis(self.id2zone)
             .rename(columns={"Bus": "zone_name", "country": "abv"})


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
Use load buses instead of buses as load zone

### What the code is doing
N/A

### Testing
Existing unit tests

### Where to look
Load buses are used for geographical mappings.  The number of load buses now matches the number of nodes of the network as given by the reduction parameter (see below)

### Usage Example/Visuals
```
>>> from powersimdata import Grid
>>> entso = Grid("Europe", source="europe_tub", reduction=128)
Title: PyPSA-Eur: An Open Optimisation Model of the European Transmission System (Dataset)
Publication date: 2022-09-20
Version: v0.6.1
DOI: 10.5281/zenodo.7251657
networks.zip has been downloaded previously
WARNING:pypsa.io:Importing network from PyPSA version v0.20.0 while current version is v0.21.2. Read the release notes at https://pypsa.readthedocs.io/en/latest/release_notes.html to prepare your network for import.
INFO:pypsa.io:Imported network elec_s_128_ec.nc has buses, carriers, generators, lines, links, loads, storage_units, stores
>>> len(entso.model_immutables.zones["id2abv"])
128
>>> entso.model_immutables.zones["id2abv"]
{0: 'AL', 1: 'AT', 2: 'AT', 3: 'BA', 4: 'BE', 5: 'BE', 6: 'BE', 7: 'BG', 8: 'CH', 9: 'CZ', 10: 'CZ', 11: 'DE', 12: 'DE', 13: 'DE', 14: 'DE', 15: 'DE', 16: 'DE', 17: 'DE', 18: 'DE', 19: 'DE', 20: 'DE', 21: 'DE', 22: 'DE', 23: 'DE', 24: 'DE', 25: 'DE', 26: 'DE', 27: 'DE', 28: 'DE', 29: 'DE', 30: 'DE', 31: 'DK', 32: 'DK', 33: 'EE', 34: 'ES', 35: 'ES', 36: 'ES', 37: 'ES', 38: 'ES', 39: 'ES', 40: 'ES', 41: 'ES', 42: 'ES', 43: 'ES', 44: 'FI', 45: 'FI', 46: 'FI', 47: 'FR', 48: 'FR', 49: 'FR', 50: 'FR', 51: 'FR', 52: 'FR', 53: 'FR', 54: 'FR', 55: 'FR', 56: 'FR', 57: 'FR', 58: 'FR', 59: 'FR', 60: 'FR', 61: 'FR', 62: 'FR', 63: 'FR', 64: 'FR', 65: 'FR', 66: 'GB', 67: 'GB', 68: 'GB', 69: 'GB', 70: 'GB', 71: 'GB', 72: 'GB', 73: 'GB', 74: 'GB', 75: 'GB', 76: 'GB', 77: 'GB', 78: 'GB', 79: 'GB', 80: 'GR', 81: 'HR', 82: 'HU', 83: 'IE', 84: 'IT', 85: 'IT', 86: 'IT', 87: 'IT', 88: 'IT', 89: 'IT', 90: 'IT', 91: 'IT', 92: 'IT', 93: 'IT', 94: 'IT', 95: 'IT', 96: 'IT', 97: 'LT', 98: 'LU', 99: 'LV', 100: 'ME', 101: 'MK', 102: 'NL', 103: 'NL', 104: 'NL', 105: 'NL', 106: 'NO', 107: 'NO', 108: 'NO', 109: 'NO', 110: 'NO', 111: 'PL', 112: 'PL', 113: 'PL', 114: 'PL', 115: 'PL', 116: 'PT', 117: 'PT', 118: 'RO', 119: 'RO', 120: 'RS', 121: 'SE', 122: 'SE', 123: 'SE', 124: 'SE', 125: 'SE', 126: 'SI', 127: 'SK'}
>>> 
```

### Time estimate
2min
