### PR TITLE
fix: preserve inflow suffix in pypsa to grid mapping

### DIFF
--- a/powersimdata/input/converter/pypsa_to_grid.py
+++ b/powersimdata/input/converter/pypsa_to_grid.py
@@ -338,7 +338,7 @@ class FromPyPSA(AbstractGrid):
             gencost_inflow = storage_gencost_storageunits[has_inflow].rename(
                 index=add_suffix
             )
-            gencost_inflow = storage_gencost_storageunits.assign(
+            gencost_inflow = gencost_inflow.assign(
                 c0=0, c1=0, c2=0, type=2, startup=0, shutdown=0, n=3
             )
 


### PR DESCRIPTION
### Purpose
Fix a typo which results in the `grid.gencost` data frames having a different size than `grid.plant`, which results in an error when trying to run `add_interconnect_to_grid_data_frames`. 

### What the code is doing
Use the same variable we started with instead of reassigning it. 

### Testing
Created a grid and observed the matching dimensions. Also checked that I could add the interconnect column as described above.


### Time estimate
5 min
