### PR TITLE
fix: use correct set of profile names for validation

### DIFF
--- a/powersimdata/input/transform_profile.py
+++ b/powersimdata/input/transform_profile.py
@@ -199,10 +199,12 @@ class TransformProfile:
             "demand_flexibility_dn",
             "demand_flexibility_cost_up",
             "demand_flexibility_cost_dn",
-        }.union(*self.scale_keys.values())
+        }.union(self.scale_keys.keys())
 
         if name not in possible:
-            raise ValueError("Choose from %s" % " | ".join(possible))
+            raise ValueError(
+                f"Invalid profile kind: {name}. Choose from %s" % " | ".join(possible)
+            )
         elif name == "demand":
             return self._slice_df(self._get_electrified_demand())
         elif "demand_flexibility" in name:


### PR DESCRIPTION
### Purpose
Fix the check we do on the profile name when we apply change table. Currently it will raise an error when we call, e.g. `tp.get_profile("wind")` for a scenario based on `europe_tub`, since the allowed values would be `{'offwind-ac', 'offwind-dc', 'onwind'}`. This is consistent with the usage of `self.scale_keys` in `TransformProfile._get_renewable_profile`. 

### What the code is doing
Update the set of allowed values and include the invalid argument in the error message so it's clear during a scenario workflow, where this method isn't called directly. 

### Testing
Ran a scenario for `usa_tamu` successfully. Similar for `europe_tub` except there are still subsequent errors, but not the one being fixed here.

### Time estimate
5 min
