### PR TITLE
Fix index alignment of pypsa loads time series

### DIFF
--- a/powersimdata/input/converter/pypsa_to_profiles.py
+++ b/powersimdata/input/converter/pypsa_to_profiles.py
@@ -67,9 +67,9 @@ def get_pypsa_demand_profile(network):
         raise TypeError("network must be a Network object")
 
     if not network.loads_t.p.empty:
-        demand = network.loads_t.p.copy()
+        demand = network.get_switchable_as_dense("Load", "p_set")
     else:
-        demand = network.loads_t.p_set.copy()
+        demand = network.get_switchable_as_dense("Load", "p_set")
     if "zone_id" in network.buses:
         # Assume this is a PyPSA network originally created from powersimdata
         demand = demand.groupby(

--- a/powersimdata/input/converter/pypsa_to_profiles.py
+++ b/powersimdata/input/converter/pypsa_to_profiles.py
@@ -67,7 +67,7 @@ def get_pypsa_demand_profile(network):
         raise TypeError("network must be a Network object")
 
     if not network.loads_t.p.empty:
-        demand = network.get_switchable_as_dense("Load", "p_set")
+        demand = network.loads_t.p.copy()
     else:
         demand = network.get_switchable_as_dense("Load", "p_set")
     if "zone_id" in network.buses:


### PR DESCRIPTION
Use `get_switchable_as_dense` to align timeseries index with static index.

@jenhagg could you try this out?