### PR TITLE
ci: prevent duplicate workflows

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   formatting:
-    if: "!contains(github.event.head_commit.message, 'skip_ci')"
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -16,7 +16,7 @@ jobs:
       - run: python -m pip install --upgrade tox
       - run: tox -e checkformatting
   flake8:
-    if: "!contains(github.event.head_commit.message, 'skip_ci')"
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    if: "!contains(github.event.head_commit.message, 'skip_ci')"
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     runs-on: ubuntu-latest
     strategy:
         fail-fast: false


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
Prevent duplicate workflows after opening PRs. Currently we run one for `push` and `pull_request` events, which although technically different (since PRs use the pending merge commit vs branch head), that's not relevant as far as I know. We compare the base and head repo to ensure PRs from forks still run the checks (since those won't trigger a `push` event).

### What the code is doing
Add condition to jobs which should prevent duplicates. Copy pasted from https://github.com/zopefoundation/meta/issues/145

Also removed the `skip_ci` feature since this is kinda builtin now: see https://docs.github.com/en/actions/managing-workflow-runs/skipping-workflow-runs

### Testing
Some testing here, although that doesn't test the forked repo scenario: https://github.com/jenhagg/test-ci/pull/6

### Time estimate
5 min
