### PR TITLE
fix: include kwargs in cache key to prevent false collisions

### DIFF
--- a/powersimdata/input/grid.py
+++ b/powersimdata/input/grid.py
@@ -32,7 +32,7 @@ class Grid:
         if source not in supported:
             raise ValueError(f"Source must be one of {','.join(supported)} ")
 
-        key = cache_key(interconnect, source)
+        key = cache_key(interconnect, source, **kwargs)
         cached = _cache.get(key)
         if cached is not None:
             network = cached

--- a/powersimdata/utility/helpers.py
+++ b/powersimdata/utility/helpers.py
@@ -77,7 +77,8 @@ class CacheKeyBuilder:
             return arg
         if isinstance(arg, (list, set, tuple)):
             return tuple(self._build(a) for a in arg)
-        raise ValueError(f"unsupported type for cache key = {type(arg)}")
+        print(f"cache key of type = {type(arg)} may result in unexpected behavior")
+        return f"obj:{type(arg)}:{id(arg)}"
 
 
 class PrintManager:

--- a/powersimdata/utility/helpers.py
+++ b/powersimdata/utility/helpers.py
@@ -40,7 +40,7 @@ class MemoryCache:
         return keys
 
 
-def cache_key(*args):
+def cache_key(*args, **kwargs):
     """Creates a cache key from the given args. The user should ensure that the
     range of inputs will not result in key collisions.
 
@@ -48,7 +48,7 @@ def cache_key(*args):
     :return: (*tuple*) -- a tuple containing the input in heirarchical
         structure
     """
-    kb = CacheKeyBuilder(*args)
+    kb = CacheKeyBuilder(*args, **kwargs)
     return kb.build()
 
 
@@ -58,9 +58,10 @@ class CacheKeyBuilder:
     :param args: variable length arguments from which to build a key
     """
 
-    def __init__(self, *args):
+    def __init__(self, *args, **kwargs):
         """Constructor"""
-        self.args = args
+        self.args = list(args)
+        self.args.extend((k, v) for k, v in kwargs.items())
 
     def build(self):
         """Combine args into a tuple, preserving the structure of each element.

--- a/powersimdata/utility/tests/test_helpers.py
+++ b/powersimdata/utility/tests/test_helpers.py
@@ -1,5 +1,3 @@
-import pytest
-
 from powersimdata.utility.helpers import MemoryCache, PrintManager, cache_key
 
 
@@ -29,6 +27,9 @@ def test_cache_key_valid_types():
     key4 = cache_key(None)
     assert ("null",) == key4
 
+    key5 = cache_key(object())
+    assert "object" in key5[0]
+
 
 def test_no_collision():
     key1 = cache_key([["foo"], ["bar"]])
@@ -36,11 +37,6 @@ def test_no_collision():
     key3 = cache_key([["foo"], "bar"])
     keys = [key1, key2, key3]
     assert len(keys) == len(set(keys))
-
-
-def test_cache_key_unsupported_type():
-    with pytest.raises(ValueError):
-        cache_key(object())
 
 
 def test_cache_key_distinct_types():


### PR DESCRIPTION
### Purpose
When we cache the grid, the key should include reduction for europe_tub networks. Otherwise all reductions will be grouped together, and reloading the grid with a different reduction will result in the initial (wrong) grid.

### What the code is doing
Add kwargs to cache key  construction, encoded as a tuple to avoid changing/adding logic. 

### Testing
Loaded multiple grids with different reductions.


### Time estimate
5 min
