### PR TITLE
Fix storage conversion so pcm will be feasible

### DIFF
--- a/powersimdata/input/converter/pypsa_to_grid.py
+++ b/powersimdata/input/converter/pypsa_to_grid.py
@@ -52,7 +52,7 @@ def _get_storage_storagedata(df, storage_type):
         storage_storagedata["OutEff"] = 1
         storage_storagedata["InEff"] = 1
     else:
-        warnings.warn(
+        raise ValueError(
             "Inapplicable storage_type passed to function _get_storage_storagedata."
         )
 
@@ -66,10 +66,11 @@ def _get_storage_storagedata(df, storage_type):
 
     # fill with heuristic defaults if non-existent
     defaults = {
+        "InitialStorage": e_nom / 2,
         "MinStorageLevel": e_nom * storage_const["min_stor"],
         "MaxStorageLevel": e_nom * storage_const["max_stor"],
-        "ExpectedTerminalStorageMax": 1,
-        "ExpectedTerminalStorageMin": 0,
+        "ExpectedTerminalStorageMax": e_nom * storage_const["terminal_max"],
+        "ExpectedTerminalStorageMin": e_nom * storage_const["terminal_min"],
     }
     for k, v in defaults.items():
         if k not in storage_storagedata:
@@ -107,7 +108,9 @@ def _get_storage_gen(df, storage_type):
         pmax = np.inf
         pmin = -np.inf
     else:
-        warnings.warn("Inapplicable storage_type passed to function _get_storage_gen.")
+        raise ValueError(
+            "Inapplicable storage_type passed to function _get_storage_gen."
+        )
 
     storage_gen = _translate_df(df, "storage_gen")
     storage_gen["Pmax"] = pmax

--- a/powersimdata/input/converter/pypsa_to_grid.py
+++ b/powersimdata/input/converter/pypsa_to_grid.py
@@ -63,10 +63,10 @@ def _get_storage_storagedata(df, storage_type):
     storage_storagedata["InitialStorageCost"] = storage_const["energy_value"]
     storage_storagedata["TerminalStoragePrice"] = storage_const["energy_value"]
     storage_storagedata["rho"] = 1
+    storage_storagedata["InitialStorage"] = e_nom / 2
 
     # fill with heuristic defaults if non-existent
     defaults = {
-        "InitialStorage": e_nom / 2,
         "MinStorageLevel": e_nom * storage_const["min_stor"],
         "MaxStorageLevel": e_nom * storage_const["max_stor"],
         "ExpectedTerminalStorageMax": e_nom * storage_const["terminal_max"],

--- a/powersimdata/input/converter/tests/test_pypsa_to_grid.py
+++ b/powersimdata/input/converter/tests/test_pypsa_to_grid.py
@@ -79,9 +79,13 @@ def test_import_exported_network():
     test.branch.r = ref.branch.r
     test.bus.Va = ref.bus.Va
 
+    storage_data = test.storage["StorageData"]
     # storage specification is need in import but has to removed for testing
     test.storage["gencost"].drop(columns="pypsa_component", inplace=True)
     test.storage["gen"].drop(columns="pypsa_component", inplace=True)
-    test.storage["StorageData"].drop(columns="pypsa_component", inplace=True)
+    storage_data.drop(columns="pypsa_component", inplace=True)
+
+    # columns is overwritten in conversion to satisfy constraints set by engine
+    storage_data.InitialStorage = ref.storage["StorageData"].InitialStorage
 
     assert ref == test


### PR DESCRIPTION
### Purpose
Fix the infeasibility we encounter when adding storage.

### What the code is doing
Set the values during `pypsa_to_grid` conversion in a way that is consistent with `TransformGrid`. This fixes the underlying issue of initial storage (presumably) violating the JuMP constraint.

Also applied latest black formatting.

### Testing
Ran a 2 month pcm with the custom 128 node network, and got storage results files.

### Time estimate
10 min
